### PR TITLE
Fix Props.Copy implementation

### DIFF
--- a/src/Proto.Actor/Actor.cs
+++ b/src/Proto.Actor/Actor.cs
@@ -32,7 +32,7 @@ namespace Proto
 
         public static Props FromProducer(Func<IActor> producer)
         {
-            return new Props().Copy(producer);
+            return new Props().WithProducer(producer);
         }
 
         public static Props FromFunc(Receive receive)
@@ -42,7 +42,7 @@ namespace Proto
 
         public static Props FromGroupRouter(IGroupRouterConfig routerConfig)
         {
-            return new Props().Copy(routerConfig: routerConfig);
+            return new Props().WithRouter(routerConfig);
         }
 
         public static PID Spawn(Props props)
@@ -59,7 +59,7 @@ namespace Proto
 
         private static PID SpawnRouter(string name, Props props, PID parent)
         {
-            var routeeProps = props.Copy(routerConfig: null);
+            var routeeProps = props.WithRouter(null);
             var config = props.RouterConfig;
             var routerState = config.CreateRouterState();
 


### PR DESCRIPTION
The usage of default parameters in Props.Copy does not quite work. The previous implementation basically did `_foo = foo ?? this._foo` which obviously won't work if you want to set the value to `null` (as in the case of RouterConfig - although perhaps the choice to use null as an indicator of a non-router Actor could be reconsidered).

This PR reimplements the Copy method to make a full copy first, then apply a mutator Action in order to change the desired property to it's new value.