### PR TITLE
added Scheduler api for IContext and added example application

### DIFF
--- a/ProtoActor.sln
+++ b/ProtoActor.sln
@@ -94,7 +94,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Proto.TestFixtures", "tests
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Proto.Cluster", "src\Proto.Cluster\Proto.Cluster.csproj", "{31517A92-5B06-434B-8BA2-597ECD3DEBA5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Proto.Persistence.RavenDB", "src\PersistenceProviders\Proto.Persistence.RavenDB\Proto.Persistence.RavenDB.csproj", "{3ACE539B-0BE6-4CC3-9016-52F902BF25EC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Proto.Persistence.RavenDB", "src\PersistenceProviders\Proto.Persistence.RavenDB\Proto.Persistence.RavenDB.csproj", "{3ACE539B-0BE6-4CC3-9016-52F902BF25EC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scheduler", "Scheduler", "{11DDAD1F-AF0B-4511-B0DE-29DF1DAC46BB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scheduler", "examples\Scheduler\Scheduler\Scheduler.csproj", "{3F20C66C-C964-4664-B85D-77E199FCC45F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -465,6 +469,18 @@ Global
 		{3ACE539B-0BE6-4CC3-9016-52F902BF25EC}.Release|x64.Build.0 = Release|Any CPU
 		{3ACE539B-0BE6-4CC3-9016-52F902BF25EC}.Release|x86.ActiveCfg = Release|Any CPU
 		{3ACE539B-0BE6-4CC3-9016-52F902BF25EC}.Release|x86.Build.0 = Release|Any CPU
+		{3F20C66C-C964-4664-B85D-77E199FCC45F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F20C66C-C964-4664-B85D-77E199FCC45F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F20C66C-C964-4664-B85D-77E199FCC45F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3F20C66C-C964-4664-B85D-77E199FCC45F}.Debug|x64.Build.0 = Debug|Any CPU
+		{3F20C66C-C964-4664-B85D-77E199FCC45F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3F20C66C-C964-4664-B85D-77E199FCC45F}.Debug|x86.Build.0 = Debug|Any CPU
+		{3F20C66C-C964-4664-B85D-77E199FCC45F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F20C66C-C964-4664-B85D-77E199FCC45F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F20C66C-C964-4664-B85D-77E199FCC45F}.Release|x64.ActiveCfg = Release|Any CPU
+		{3F20C66C-C964-4664-B85D-77E199FCC45F}.Release|x64.Build.0 = Release|Any CPU
+		{3F20C66C-C964-4664-B85D-77E199FCC45F}.Release|x86.ActiveCfg = Release|Any CPU
+		{3F20C66C-C964-4664-B85D-77E199FCC45F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -514,5 +530,7 @@ Global
 		{BEAC63DD-5701-4B33-8155-5218B9761A70} = {9AA2BCF0-19AB-4DD9-8D91-7D188E463806}
 		{31517A92-5B06-434B-8BA2-597ECD3DEBA5} = {771514F1-12AE-4A26-89CB-2646D3EF7034}
 		{3ACE539B-0BE6-4CC3-9016-52F902BF25EC} = {7AF64900-EA34-4A93-9514-FEBC4648E39E}
+		{11DDAD1F-AF0B-4511-B0DE-29DF1DAC46BB} = {59DCCC96-DDAF-469F-9E8E-9BC733285082}
+		{3F20C66C-C964-4664-B85D-77E199FCC45F} = {11DDAD1F-AF0B-4511-B0DE-29DF1DAC46BB}
 	EndGlobalSection
 EndGlobal

--- a/examples/Scheduler/Scheduler/Program.cs
+++ b/examples/Scheduler/Scheduler/Program.cs
@@ -1,0 +1,72 @@
+﻿using Proto;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Scheduler
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var props = Actor.FromProducer(() => new ScheduleActor());
+
+            var pid = Actor.Spawn(props);
+
+            Console.ReadLine();
+        }
+    }
+
+    public class Hello { }
+    public class HickUp { }
+    public class AbortHickUp { }
+
+    public class ScheduleActor : IActor
+    {
+        private CancellationTokenSource timer;
+        private int counter = 0;
+
+        public Task ReceiveAsync(IContext context)
+        {
+            switch(context.Message)
+            {
+                case Started _:
+
+                    context.ScheduleTellOnce(TimeSpan.FromSeconds(1), context.Self, new Hello());
+
+                    timer = context.ScheduleTellRepeatedly(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(250), context.Self, new HickUp());
+
+                    break;
+
+                case Hello hl:
+
+                    Console.WriteLine($"Hello Once, let's give you a 5 times hickup!");
+
+                    break;
+
+                case HickUp hu:
+
+                    counter++;
+
+                    Console.WriteLine($"Hello!");
+
+                    if (counter == 5)
+                    {
+                        timer.Cancel();
+
+                        context.Self.Tell(new AbortHickUp());
+                    }
+
+                    break;
+
+                case AbortHickUp ahu:
+
+                    Console.WriteLine($"Aborted hickup after {counter} times");
+
+                    break;
+            }
+
+            return Actor.Done;
+        }
+    }
+}

--- a/examples/Scheduler/Scheduler/Scheduler.csproj
+++ b/examples/Scheduler/Scheduler/Scheduler.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Proto.Actor/Scheduler.cs
+++ b/src/Proto.Actor/Scheduler.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Proto
+{
+    public static class Scheduler
+    {
+        public static void ScheduleTellOnce(this IContext context, TimeSpan delay, PID target, object message)
+        {
+            Task.Run(async () =>
+            {
+                await Task.Delay(delay);
+
+                context.Tell(target, message);
+            });
+        }
+
+        public static CancellationTokenSource ScheduleTellRepeatedly(this IContext context, TimeSpan delay, TimeSpan interval, PID target, object message)
+        {
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            var task = Task.Run(async () =>
+            {
+                await Task.Delay(delay);
+
+                async void Trigger(object _message)
+                {
+                    if (cts.IsCancellationRequested)
+                        return;
+
+                    context.Tell(target, message);
+
+                    await Task.Delay(interval);
+
+                    Trigger(_message);
+                }
+
+                Trigger(message);
+
+            }, cts.Token);
+
+            return cts;
+        }
+    }
+}


### PR DESCRIPTION
Implemented Scheduler api as an extension for IContext on the actor.

It can be used in two ways.

**ScheduleTellOnce - fire and forget with delay**
```
context.ScheduleTellOnce(TimeSpan.FromSeconds(1), context.Self, new Hello());
```

**ScheduleTellRepeatedly - fire with delay, interval and cancellation**
```
var timer = context.ScheduleTellRepeatedly(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(250), context.Self, new Hello());

timer.Cancel();
```