### PR TITLE
As we’ve stopped children, forget them.

### DIFF
--- a/src/Proto.Actor/LocalContext.cs
+++ b/src/Proto.Actor/LocalContext.cs
@@ -451,6 +451,7 @@ namespace Proto
                 {
                     child.Stop();
                 }
+                _children = null;
             }
             await TryRestartOrTerminateAsync();
         }


### PR DESCRIPTION
This is needed because of the `if (_children?.Count > 0)` check in `TryRestartOrTerminateAsync`