### PR TITLE
Fast set for PID's.

### DIFF
--- a/src/Proto.Actor/FastSet.cs
+++ b/src/Proto.Actor/FastSet.cs
@@ -1,0 +1,71 @@
+﻿// -----------------------------------------------------------------------
+//   <copyright file="FastSet.cs" company="Asynkron HB">
+//       Copyright (C) 2015-2017 Asynkron HB All rights reserved
+//   </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Proto
+{
+    internal class FastSet<T> : IEnumerable<T>
+    {
+        private T _first;
+        private HashSet<T> _set;
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            if (_first == null)
+            {
+                yield break;
+            }
+            if (_set == null)
+            {
+                yield return _first;
+                yield break;
+            }
+            foreach (var item in _set)
+            {
+                yield return item;
+            }
+        }
+
+        public void Add(T item)
+        {
+            if (_first == null)
+            {
+                _first = item;
+                return;
+            }
+            if (_set == null)
+            {
+                _set = new HashSet<T> {_first};
+            }
+            _set.Add(item);
+        }
+
+        public void Remove(T item)
+        {
+            if (_first == null)
+            {
+                return;
+            }
+            if (_set == null  )
+            {
+                if (_first.Equals(item))
+                {
+                    _first = default(T);
+                 
+                }
+                return;
+            }
+            _set.Remove(item);
+        }
+    }
+}

--- a/src/Proto.Actor/FastSet.cs
+++ b/src/Proto.Actor/FastSet.cs
@@ -14,6 +14,18 @@ namespace Proto
         private T _first;
         private HashSet<T> _set;
 
+        public int Count
+        {
+            get
+            {
+                if (_set == null && _first == null)
+                {
+                    return 0;
+                }
+                return _set?.Count ?? 1;
+            }
+        }
+
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();

--- a/src/Proto.Actor/LocalContext.cs
+++ b/src/Proto.Actor/LocalContext.cs
@@ -23,7 +23,7 @@ namespace Proto
         private readonly Sender _senderMiddleware;
         private readonly Func<IActor> _producer;
         private readonly ISupervisorStrategy _supervisorStrategy;
-        private HashSet<PID> _children;
+        private FastSet<PID> _children;
         private object _message;
         private Receive _receive;
         private Timer _receiveTimeoutTimer;
@@ -117,7 +117,7 @@ namespace Proto
             var pid = props.Spawn($"{Self.Id}/{name}", Self);
             if (_children == null)
             {
-                _children = new HashSet<PID>();
+                _children = new FastSet<PID>();
             }
             _children.Add(pid);
 

--- a/src/Proto.Actor/LocalContext.cs
+++ b/src/Proto.Actor/LocalContext.cs
@@ -31,8 +31,8 @@ namespace Proto
         private RestartStatistics _restartStatistics;
         private Stack<object> _stash;
         private bool _stopping;
-        private HashSet<PID> _watchers;
-        private HashSet<PID> _watching;
+        private FastSet<PID> _watchers;
+        private FastSet<PID> _watching;
         private ILogger _logger;
 
 
@@ -49,10 +49,8 @@ namespace Proto
             //fast path
             if (parent != null)
             {
-                _watchers = new HashSet<PID>
-                {
-                    parent
-                };
+                _watchers = new FastSet<PID>();
+                _watchers.Add(parent);
             }
         }
 
@@ -126,7 +124,7 @@ namespace Proto
             //fast path add watched
             if (_watching == null)
             {
-                _watching = new HashSet<PID>();
+                _watching = new FastSet<PID>();
             }
             _watching.Add(pid);
             return pid;
@@ -162,7 +160,7 @@ namespace Proto
             pid.SendSystemMessage(new Watch(Self));
             if (_watching == null)
             {
-                _watching = new HashSet<PID>();
+                _watching = new FastSet<PID>();
             }
             _watching.Add(pid);
         }
@@ -172,7 +170,7 @@ namespace Proto
             pid.SendSystemMessage(new Unwatch(Self));
             if (_watching == null)
             {
-                _watching = new HashSet<PID>();
+                _watching = new FastSet<PID>();
             }
             _watching.Remove(pid);
         }
@@ -435,7 +433,7 @@ namespace Proto
             {
                 if (_watchers == null)
                 {
-                    _watchers = new HashSet<PID>();
+                    _watchers = new FastSet<PID>();
                 }
                 _watchers.Add(w.Watcher);
             }


### PR DESCRIPTION
Performance optimization for watchers and watchees.
Only allocate a full hashset when there are more than one PID in the set.
Leads to less allocations for actors with no or one children.