### PR TITLE
tests for ConsistentHashGroupRouter

### DIFF
--- a/src/Proto.Router/HashRing.cs
+++ b/src/Proto.Router/HashRing.cs
@@ -12,21 +12,33 @@ using System.Text;
 
 namespace Proto.Router
 {
+    public static class MD5Hasher
+    {
+        private static readonly HashAlgorithm HashAlgorithm = MD5.Create();
+
+        public static uint Hash(string hashKey)
+        {
+            var digest = HashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(hashKey));
+            var hash = BitConverter.ToUInt32(digest, 0);
+            return hash;
+        }
+    }
+
     public class HashRing
     {
-        private const int ReplicaCount = 100;
-        private static readonly HashAlgorithm HashAlgorithm = MD5.Create();
+        private readonly Func<string, uint> _hash;
         private readonly List<Tuple<uint, string>> _ring;
 
-        public HashRing(IEnumerable<string> nodes)
+        public HashRing(IEnumerable<string> nodes, Func<string, uint> hash, int replicaCount)
         {
+            _hash = hash;
             _ring = nodes
-                .SelectMany(n => Enumerable.Range(0, ReplicaCount).Select(i => new
+                .SelectMany(n => Enumerable.Range(0, replicaCount).Select(i => new
                 {
                     hashKey = i + n,
                     node = n
                 }))
-                .Select(a => Tuple.Create(Hash(a.hashKey), a.node))
+                .Select(a => Tuple.Create(_hash(a.hashKey), a.node))
                 .OrderBy(t => t.Item1)
                 .ToList();
         }
@@ -34,16 +46,9 @@ namespace Proto.Router
         public string GetNode(string key)
         {
             return (
-                _ring.FirstOrDefault(t => t.Item1 > Hash(key))
+                _ring.FirstOrDefault(t => t.Item1 > _hash(key))
                 ?? _ring.First()
             ).Item2;
-        }
-
-        private static uint Hash(string s)
-        {
-            var digest = HashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(s));
-            var hash = BitConverter.ToUInt32(digest, 0);
-            return hash;
         }
     }
 }

--- a/src/Proto.Router/Router.cs
+++ b/src/Proto.Router/Router.cs
@@ -4,6 +4,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Threading;
 using Proto.Router.Routers;
 
@@ -18,7 +19,12 @@ namespace Proto.Router
 
         public static Props NewConsistentHashGroup(Props props, params PID[] routees)
         {
-            return props.WithSpawner(Spawner(new ConsistentHashGroupRouterConfig(routees)));
+            return props.WithSpawner(Spawner(new ConsistentHashGroupRouterConfig(MD5Hasher.Hash, 100, routees)));
+        }
+
+        public static Props NewConsistentHashGroup(Props props, Func<string, uint> hash, int replicaCount, params PID[] routees)
+        {
+            return props.WithSpawner(Spawner(new ConsistentHashGroupRouterConfig(hash, replicaCount, routees)));
         }
 
         public static Props NewRandomGroup(Props props, params PID[] routees)
@@ -36,9 +42,9 @@ namespace Proto.Router
             return props.WithSpawner(Spawner(new BroadcastPoolRouterConfig(poolSize)));
         }
 
-        public static Props NewConsistentHashPool(Props props, int poolSize)
+        public static Props NewConsistentHashPool(Props props, int poolSize, Func<string, uint> hash = null, int replicaCount = 100)
         {
-            return props.WithSpawner(Spawner(new ConsistentHashPoolRouterConfig(poolSize)));
+            return props.WithSpawner(Spawner(new ConsistentHashPoolRouterConfig(poolSize, hash ?? MD5Hasher.Hash, replicaCount)));
         }
 
         public static Props NewRandomPool(Props props, int poolSize)

--- a/src/Proto.Router/Routers/ConsistentHashGroupRouterConfig.cs
+++ b/src/Proto.Router/Routers/ConsistentHashGroupRouterConfig.cs
@@ -4,20 +4,30 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 
 namespace Proto.Router.Routers
 {
     internal class ConsistentHashGroupRouterConfig : GroupRouterConfig
     {
-        public ConsistentHashGroupRouterConfig(params PID[] routees)
+        private readonly Func<string, uint> _hash;
+        private readonly int _replicaCount;
+
+        public ConsistentHashGroupRouterConfig(Func<string, uint> hash, int replicaCount, params PID[] routees)
         {
+            if (replicaCount <= 0)
+            {
+                throw new ArgumentException("ReplicaCount must be greater than 0");
+            }
+            _hash = hash;
+            _replicaCount = replicaCount;
             Routees = new HashSet<PID>(routees);
         }
 
         public override RouterState CreateRouterState()
         {
-            return new ConsistentHashRouterState();
+            return new ConsistentHashRouterState(_hash, _replicaCount);
         }
     }
 }

--- a/src/Proto.Router/Routers/ConsistentHashPoolRouterConfig.cs
+++ b/src/Proto.Router/Routers/ConsistentHashPoolRouterConfig.cs
@@ -4,18 +4,29 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
+
 namespace Proto.Router.Routers
 {
     internal class ConsistentHashPoolRouterConfig : PoolRouterConfig
     {
-        public ConsistentHashPoolRouterConfig(int poolSize)
+        private readonly Func<string, uint> _hash;
+        private readonly int _replicaCount;
+
+        public ConsistentHashPoolRouterConfig(int poolSize, Func<string, uint> hash, int replicaCount)
             : base(poolSize)
         {
+            if (replicaCount <= 0)
+            {
+                throw new ArgumentException("ReplicaCount must be greater than 0");
+            }
+            _hash = hash;
+            _replicaCount = replicaCount;
         }
 
         public override RouterState CreateRouterState()
         {
-            return new ConsistentHashRouterState();
+            return new ConsistentHashRouterState(_hash, _replicaCount);
         }
     }
 }

--- a/src/Proto.Router/Routers/ConsistentHashRouterState.cs
+++ b/src/Proto.Router/Routers/ConsistentHashRouterState.cs
@@ -4,15 +4,23 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 
 namespace Proto.Router.Routers
 {
     internal class ConsistentHashRouterState : RouterState
     {
+        private readonly Func<string, uint> _hash;
+        private readonly int _replicaCount;
         private HashRing _hashRing;
         private Dictionary<string, PID> _routeeMap;
 
+        public ConsistentHashRouterState(Func<string, uint> hash, int replicaCount)
+        {
+            _hash = hash;
+            _replicaCount = replicaCount;
+        }
 
         public override HashSet<PID> GetRoutees()
         {
@@ -29,7 +37,7 @@ namespace Proto.Router.Routers
                 nodes.Add(nodeName);
                 _routeeMap[nodeName] = pid;
             }
-            _hashRing = new HashRing(nodes);
+            _hashRing = new HashRing(nodes, _hash, _replicaCount);
         }
 
         public override void RouteMessage(object message, PID sender)

--- a/tests/Proto.Router.Tests/ConsistentHashGroupTests.cs
+++ b/tests/Proto.Router.Tests/ConsistentHashGroupTests.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Proto.Router.Messages;
+using Proto.TestFixtures;
+using Xunit;
+
+namespace Proto.Router.Tests
+{
+    public class ConsistentHashGroupTests
+    {
+        private static readonly Props MyActorProps = Actor.FromProducer(() => new MyTestActor())
+            .WithMailbox(() => new TestMailbox());
+        private readonly TimeSpan _timeout = TimeSpan.FromMilliseconds(250);
+
+        [Fact]
+        public async void ConsistentHashGroupRouter_MessageWithSameHashAlwaysGoesToSameRoutee()
+        {
+            var (router, routee1, routee2, routee3) = CreateRouterWith3Routees();
+
+            router.Tell(new Message("message1"));
+            router.Tell(new Message("message1"));
+            router.Tell(new Message("message1"));
+
+            Assert.Equal(3, await routee1.RequestAsync<int>("received?", _timeout));
+            Assert.Equal(0, await routee2.RequestAsync<int>("received?", _timeout));
+            Assert.Equal(0, await routee3.RequestAsync<int>("received?", _timeout));
+        }
+
+        [Fact]
+        public async void ConsistentHashGroupRouter_MessagesWithDifferentHashesGoToDifferentRoutees()
+        {
+            var (router, routee1, routee2, routee3) = CreateRouterWith3Routees();
+
+            router.Tell(new Message("message1"));
+            router.Tell(new Message("message2"));
+            router.Tell(new Message("message3"));
+
+            Assert.Equal(1, await routee1.RequestAsync<int>("received?", _timeout));
+            Assert.Equal(1, await routee2.RequestAsync<int>("received?", _timeout));
+            Assert.Equal(1, await routee3.RequestAsync<int>("received?", _timeout));
+        }
+
+        [Fact]
+        public async void ConsistentHashGroupRouter_MessageWithSameHashAlwaysGoesToSameRoutee_EvenWhenNewRouteeAdded()
+        {
+            var (router, routee1, routee2, routee3) = CreateRouterWith3Routees();
+
+            router.Tell(new Message("message1"));
+            var routee4 = Actor.Spawn(MyActorProps);
+            router.Tell(new RouterAddRoutee{PID = routee4});
+            router.Tell(new Message("message1"));
+
+            Assert.Equal(2, await routee1.RequestAsync<int>("received?", _timeout));
+            Assert.Equal(0, await routee2.RequestAsync<int>("received?", _timeout));
+            Assert.Equal(0, await routee3.RequestAsync<int>("received?", _timeout));
+        }
+
+        [Fact]
+        public async void ConsistentHashGroupRouter_RouteesCanBeRemoved()
+        {
+            var (router, routee1, routee2, routee3) = CreateRouterWith3Routees();
+
+            router.Tell(new RouterRemoveRoutee { PID = routee1 });
+
+            var routees = await router.RequestAsync<Routees>(new RouterGetRoutees());
+            Assert.DoesNotContain(routee1, routees.PIDs);
+            Assert.Contains(routee2, routees.PIDs);
+            Assert.Contains(routee3, routees.PIDs);
+        }
+
+        [Fact]
+        public async void ConsistentHashGroupRouter_RouteesCanBeAdded()
+        {
+            var (router, routee1, routee2, routee3) = CreateRouterWith3Routees();
+            var routee4 = Actor.Spawn(MyActorProps);
+            router.Tell(new RouterAddRoutee { PID = routee4 });
+
+            var routees = await router.RequestAsync<Routees>(new RouterGetRoutees());
+            Assert.Contains(routee1, routees.PIDs);
+            Assert.Contains(routee2, routees.PIDs);
+            Assert.Contains(routee3, routees.PIDs);
+            Assert.Contains(routee4, routees.PIDs);
+        }
+
+        [Fact]
+        public async void ConsistentHashGroupRouter_RemovedRouteesNoLongerReceiveMessages()
+        {
+            var (router, routee1, _, _) = CreateRouterWith3Routees();
+            
+            router.Tell(new RouterRemoveRoutee { PID = routee1 });
+            router.Tell(new Message("message1"));
+            Assert.Equal(0, await routee1.RequestAsync<int>("received?", _timeout));
+        }
+
+        [Fact]
+        public async void ConsistentHashGroupRouter_AddedRouteesReceiveMessages()
+        {
+            var (router, _, _, _) = CreateRouterWith3Routees();
+            var routee4 = Actor.Spawn(MyActorProps);
+            router.Tell(new RouterAddRoutee { PID = routee4 });
+            router.Tell(new Message("message4"));
+            Assert.Equal(1, await routee4.RequestAsync<int>("received?", _timeout));
+        }
+
+        [Fact]
+        public async void ConsistentHashGroupRouter_MessageIsReassignedWhenRouteeRemoved()
+        {
+            var (router, routee1, routee2, _) = CreateRouterWith3Routees();
+
+            router.Tell(new Message("message1"));
+            // routee1 handles "message1"
+            Assert.Equal(1, await routee1.RequestAsync<int>("received?", _timeout));
+            // remove receiver
+            router.Tell(new RouterRemoveRoutee { PID = routee1 });
+            // routee2 should now handle "message1"
+            router.Tell(new Message("message1"));
+
+            Assert.Equal(1, await routee2.RequestAsync<int>("received?", _timeout));
+        }
+
+        [Fact]
+        public async void ConsistentHashGroupRouter_AllRouteesReceiveRouterBroadcastMessages()
+        {
+            var (router, routee1, routee2, routee3) = CreateRouterWith3Routees();
+
+            router.Tell(new RouterBroadcastMessage { Message = new Message("hello") });
+
+            Assert.Equal(1, await routee1.RequestAsync<int>("received?", _timeout));
+            Assert.Equal(1, await routee2.RequestAsync<int>("received?", _timeout));
+            Assert.Equal(1, await routee3.RequestAsync<int>("received?", _timeout));
+        }
+
+        private (PID router, PID routee1, PID routee2, PID routee3) CreateRouterWith3Routees()
+        {
+            // assign unique names for when tests run in parallel
+            var routee1 = Actor.SpawnNamed(MyActorProps, Guid.NewGuid() + "routee1");
+            var routee2 = Actor.SpawnNamed(MyActorProps, Guid.NewGuid() + "routee2");
+            var routee3 = Actor.SpawnNamed(MyActorProps, Guid.NewGuid() + "routee3");
+
+            var props = Router.NewConsistentHashGroup(MyActorProps, SuperIntelligentDeterministicHash.Hash, 1, routee1, routee2, routee3)
+                .WithMailbox(() => new TestMailbox());
+            var router = Actor.Spawn(props);
+            return (router, routee1, routee2, routee3);
+        }
+        
+        private static class SuperIntelligentDeterministicHash
+        {
+            public static uint Hash(string hashKey)
+            {
+                if (hashKey.EndsWith("routee1")) return 10;
+                if (hashKey.EndsWith("routee2")) return 20;
+                if (hashKey.EndsWith("routee3")) return 30;
+                if (hashKey.EndsWith("routee4")) return 40;
+                if (hashKey.EndsWith("message1")) return 9;
+                if (hashKey.EndsWith("message2")) return 19;
+                if (hashKey.EndsWith("message3")) return 29;
+                if (hashKey.EndsWith("message4")) return 39;
+                return 0;
+            }
+        }
+
+        internal class Message : IHashable
+        {
+            private readonly string _value;
+
+            public Message(string value)
+            {
+                _value = value;
+            }
+            public string HashBy()
+            {
+                return _value;
+            }
+
+            public override string ToString()
+            {
+                return _value;
+            }
+        }
+
+        internal class MyTestActor : IActor
+        {
+            private readonly List<string> _receivedMessages = new List<string>();
+            public Task ReceiveAsync(IContext context)
+            {
+                switch (context.Message)
+                {
+                    case string msg when msg == "received?":
+                        context.Sender.Tell(_receivedMessages.Count);
+                        break;
+                    case Message msg:
+                        _receivedMessages.Add(msg.ToString());
+                        break;
+                }
+                return Actor.Done;
+            }
+        }
+    }
+}


### PR DESCRIPTION
To allow deterministic testing, you can now pass in a function to compute the hash in the HashRing

Tests use a super-simple deterministic hashing function to determine which messages go to which routee. 

