### PR TITLE
tests for RandomGroupRouter and Pool routers

### DIFF
--- a/src/Proto.Router/Router.cs
+++ b/src/Proto.Router/Router.cs
@@ -32,6 +32,11 @@ namespace Proto.Router
             return props.WithSpawner(Spawner(new RandomGroupRouterConfig(routees)));
         }
 
+        public static Props NewRandomGroup(Props props, int seed, params PID[] routees)
+        {
+            return props.WithSpawner(Spawner(new RandomGroupRouterConfig(seed, routees)));
+        }
+
         public static Props NewRoundRobinGroup(Props props, params PID[] routees)
         {
             return props.WithSpawner(Spawner(new RoundRobinGroupRouterConfig(routees)));
@@ -47,9 +52,9 @@ namespace Proto.Router
             return props.WithSpawner(Spawner(new ConsistentHashPoolRouterConfig(poolSize, hash ?? MD5Hasher.Hash, replicaCount)));
         }
 
-        public static Props NewRandomPool(Props props, int poolSize)
+        public static Props NewRandomPool(Props props, int poolSize, int? seed = null)
         {
-            return props.WithSpawner(Spawner(new RandomPoolRouterConfig(poolSize)));
+            return props.WithSpawner(Spawner(new RandomPoolRouterConfig(poolSize, seed)));
         }
 
         public static Props NewRoundRobinPool(Props props, int poolSize)

--- a/src/Proto.Router/Routers/RandomGroupRouterConfig.cs
+++ b/src/Proto.Router/Routers/RandomGroupRouterConfig.cs
@@ -10,6 +10,14 @@ namespace Proto.Router.Routers
 {
     internal class RandomGroupRouterConfig : GroupRouterConfig
     {
+        private readonly int? _seed;
+
+        public RandomGroupRouterConfig(int seed, params PID[] routees)
+        {
+            _seed = seed;
+            Routees = new HashSet<PID>(routees);
+        }
+
         public RandomGroupRouterConfig(params PID[] routees)
         {
             Routees = new HashSet<PID>(routees);
@@ -17,7 +25,7 @@ namespace Proto.Router.Routers
 
         public override RouterState CreateRouterState()
         {
-            return new RandomRouterState();
+            return new RandomRouterState(_seed);
         }
     }
 }

--- a/src/Proto.Router/Routers/RandomPoolRouterConfig.cs
+++ b/src/Proto.Router/Routers/RandomPoolRouterConfig.cs
@@ -8,14 +8,17 @@ namespace Proto.Router.Routers
 {
     internal class RandomPoolRouterConfig : PoolRouterConfig
     {
-        public RandomPoolRouterConfig(int poolSize)
+        private readonly int? _seed;
+
+        public RandomPoolRouterConfig(int poolSize, int? seed)
             : base(poolSize)
         {
+            _seed = seed;
         }
 
         public override RouterState CreateRouterState()
         {
-            return new RandomRouterState();
+            return new RandomRouterState(_seed);
         }
     }
 }

--- a/src/Proto.Router/Routers/RandomRouterState.cs
+++ b/src/Proto.Router/Routers/RandomRouterState.cs
@@ -12,9 +12,14 @@ namespace Proto.Router.Routers
 {
     internal class RandomRouterState : RouterState
     {
-        private readonly Random _random = new Random();
+        private readonly Random _random;
         private HashSet<PID> _routees;
         private PID[] _values;
+
+        public RandomRouterState(int? seed)
+        {
+            _random = seed.HasValue ? new Random(seed.Value) : new Random();
+        }
 
         public override HashSet<PID> GetRoutees()
         {

--- a/tests/Proto.Router.Tests/PoolRouterTests.cs
+++ b/tests/Proto.Router.Tests/PoolRouterTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Proto.Router.Messages;
+using Proto.TestFixtures;
+using Xunit;
+
+namespace Proto.Router.Tests
+{
+    public class PoolRouterTests
+    {
+        private static readonly Props MyActorProps = Actor.FromProducer(() => new DoNothingActor());
+        private readonly TimeSpan _timeout = TimeSpan.FromMilliseconds(250);
+
+        [Fact]
+        public async void BroadcastGroupPool_CreatesRoutees()
+        {
+            var props = Router.NewBroadcastPool(MyActorProps, 3)
+                .WithMailbox(() => new TestMailbox());
+            var router = Actor.Spawn(props);
+            var routees = await router.RequestAsync<Routees>(new RouterGetRoutees(), _timeout);
+            Assert.Equal(3, routees.PIDs.Count);
+        }
+
+        [Fact]
+        public async void RoundRobinPool_CreatesRoutees()
+        {
+            var props = Router.NewRoundRobinPool(MyActorProps, 3)
+                .WithMailbox(() => new TestMailbox());
+            var router = Actor.Spawn(props);
+            var routees = await router.RequestAsync<Routees>(new RouterGetRoutees(), _timeout);
+            Assert.Equal(3, routees.PIDs.Count);
+        }
+
+        [Fact]
+        public async void ConsistentHashPool_CreatesRoutees()
+        {
+            var props = Router.NewConsistentHashPool(MyActorProps, 3)
+                .WithMailbox(() => new TestMailbox());
+            var router = Actor.Spawn(props);
+            var routees = await router.RequestAsync<Routees>(new RouterGetRoutees(), _timeout);
+            Assert.Equal(3, routees.PIDs.Count);
+        }
+
+        [Fact]
+        public async void RandomPool_CreatesRoutees()
+        {
+            var props = Router.NewRandomPool(MyActorProps, 3)
+                .WithMailbox(() => new TestMailbox());
+            var router = Actor.Spawn(props);
+            var routees = await router.RequestAsync<Routees>(new RouterGetRoutees(), _timeout);
+            Assert.Equal(3, routees.PIDs.Count);
+        }
+    }
+}

--- a/tests/Proto.Router.Tests/RandomGroupRouterTests.cs
+++ b/tests/Proto.Router.Tests/RandomGroupRouterTests.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Proto.Router.Messages;
+using Proto.TestFixtures;
+using Xunit;
+
+namespace Proto.Router.Tests
+{
+    public class RandomGroupRouterTests
+    {
+        private static readonly Props MyActorProps = Actor.FromProducer(() => new MyTestActor());
+        private readonly TimeSpan _timeout = TimeSpan.FromMilliseconds(250);
+
+        [Fact]
+        public async void RandomGroupRouter_RouteesReceiveMessagesInRandomOrder()
+        {
+            var (router, routee1, routee2, routee3) = CreateRouterWith3Routees();
+
+            router.Tell("1");
+            router.Tell("2");
+            router.Tell("3");
+
+            Assert.Equal("2", await routee1.RequestAsync<string>("received?", _timeout));
+            Assert.Equal("3", await routee2.RequestAsync<string>("received?", _timeout));
+            Assert.Equal("1", await routee3.RequestAsync<string>("received?", _timeout));
+        }
+
+        [Fact]
+        public async void RandomGroupRouter_NewlyAddedRouteesReceiveMessages()
+        {
+            var (router, routee1, routee2, routee3) = CreateRouterWith3Routees();
+            var routee4 = Actor.Spawn(MyActorProps);
+            router.Tell(new RouterAddRoutee
+            {
+                PID = routee4
+            });
+            router.Tell("1");
+            router.Tell("2");
+            router.Tell("3");
+            router.Tell("4");
+
+            // results are random! (but consistent due to seeding) As MyTestActor only stores the most
+            // recent message, "1" is overwritten by a subsequent message. 
+            Assert.Equal("2", await routee1.RequestAsync<string>("received?", _timeout));
+            Assert.Equal(null, await routee2.RequestAsync<string>("received?", _timeout));
+            Assert.Equal("3", await routee3.RequestAsync<string>("received?", _timeout));
+            Assert.Equal("4", await routee4.RequestAsync<string>("received?", _timeout));
+        }
+
+        [Fact]
+        public async void RandomGroupRouter_RemovedRouteesDoNotReceiveMessages()
+        {
+            var (router, routee1, _, _) = CreateRouterWith3Routees();
+            router.Tell(new RouterRemoveRoutee
+            {
+                PID = routee1
+            });
+            for (int i = 0; i < 100; i++)
+            {
+                router.Tell(i.ToString());
+            }
+            
+            Assert.Equal(null, await routee1.RequestAsync<string>("received?", _timeout));
+        }
+
+        [Fact]
+        public async void RandomGroupRouter_RouteesCanBeRemoved()
+        {
+            var (router, routee1, routee2, routee3) = CreateRouterWith3Routees();
+
+            router.Tell(new RouterRemoveRoutee { PID = routee1 });
+
+            var routees = await router.RequestAsync<Routees>(new RouterGetRoutees(), _timeout);
+            Assert.DoesNotContain(routee1, routees.PIDs);
+            Assert.Contains(routee2, routees.PIDs);
+            Assert.Contains(routee3, routees.PIDs);
+        }
+
+        [Fact]
+        public async void RandomGroupRouter_RouteesCanBeAdded()
+        {
+            var (router, routee1, routee2, routee3) = CreateRouterWith3Routees();
+            var routee4 = Actor.Spawn(MyActorProps);
+            router.Tell(new RouterAddRoutee { PID = routee4 });
+
+            var routees = await router.RequestAsync<Routees>(new RouterGetRoutees(), _timeout);
+            Assert.Contains(routee1, routees.PIDs);
+            Assert.Contains(routee2, routees.PIDs);
+            Assert.Contains(routee3, routees.PIDs);
+            Assert.Contains(routee4, routees.PIDs);
+        }
+
+        [Fact]
+        public async void RandomGroupRouter_AllRouteesReceiveRouterBroadcastMessages()
+        {
+            var (router, routee1, routee2, routee3) = CreateRouterWith3Routees();
+
+            router.Tell(new RouterBroadcastMessage { Message = "hello" });
+
+            Assert.Equal("hello", await routee1.RequestAsync<string>("received?", _timeout));
+            Assert.Equal("hello", await routee2.RequestAsync<string>("received?", _timeout));
+            Assert.Equal("hello", await routee3.RequestAsync<string>("received?", _timeout));
+        }
+
+        private (PID router, PID routee1, PID routee2, PID routee3) CreateRouterWith3Routees()
+        {
+            var routee1 = Actor.Spawn(MyActorProps);
+            var routee2 = Actor.Spawn(MyActorProps);
+            var routee3 = Actor.Spawn(MyActorProps);
+
+            var props = Router.NewRandomGroup(MyActorProps, 10000, routee1, routee2, routee3)
+                .WithMailbox(() => new TestMailbox());
+            var router = Actor.Spawn(props);
+            return (router, routee1, routee2, routee3);
+        }
+
+        internal class MyTestActor : IActor
+        {
+            private string _received;
+            public Task ReceiveAsync(IContext context)
+            {
+                switch (context.Message)
+                {
+                    case string msg when msg == "received?":
+                        context.Sender.Tell(_received);
+                        break;
+                    case string msg:
+                        _received = msg;
+                        break;
+                }
+                return Actor.Done;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added ability to pass in a seed to the random function so that tests can be deterministic. 

Not sure if there is anything else to test for the pool routers - I'm just testing that they create a pool of routees. 