### PR TITLE
Redesigning process

### DIFF
--- a/src/Proto.Actor/DeadLetter.cs
+++ b/src/Proto.Actor/DeadLetter.cs
@@ -26,14 +26,8 @@ namespace Proto
 
         public override void SendUserMessage(PID pid, object message)
         {
-            if (message is MessageEnvelope envelope)
-            {
-                EventStream.Instance.Publish(new DeadLetterEvent(pid, envelope.Message, envelope.Sender));
-            }
-            else
-            {
-                EventStream.Instance.Publish(new DeadLetterEvent(pid, message, null));
-            }
+            var (msg,sender, _) = MessageEnvelope.Unwrap(message);
+            EventStream.Instance.Publish(new DeadLetterEvent(pid, msg, sender));
         }
 
         public override void SendSystemMessage(PID pid, object message)

--- a/src/Proto.Actor/DeadLetter.cs
+++ b/src/Proto.Actor/DeadLetter.cs
@@ -24,9 +24,16 @@ namespace Proto
     {
         public static readonly DeadLetterProcess Instance = new DeadLetterProcess();
 
-        public override void SendUserMessage(PID pid, object message, PID sender)
+        public override void SendUserMessage(PID pid, object message)
         {
-            EventStream.Instance.Publish(new DeadLetterEvent(pid, message, sender));
+            if (message is MessageEnvelope envelope)
+            {
+                EventStream.Instance.Publish(new DeadLetterEvent(pid, envelope.Message, envelope.Sender));
+            }
+            else
+            {
+                EventStream.Instance.Publish(new DeadLetterEvent(pid, message, null));
+            }
         }
 
         public override void SendSystemMessage(PID pid, object message)

--- a/src/Proto.Actor/Futures.cs
+++ b/src/Proto.Actor/Futures.cs
@@ -51,8 +51,13 @@ namespace Proto
         public PID Pid { get; }
         public Task<T> Task { get; }
 
-        public override void SendUserMessage(PID pid, object message, PID sender)
+        public override void SendUserMessage(PID pid, object message)
         {
+            if (message is MessageEnvelope messageEnvelope)
+            {
+                message = messageEnvelope.Message;
+            }
+
             if (message is T || message == null)
             {
                 if (_cts != null && _cts.IsCancellationRequested) return;

--- a/src/Proto.Actor/Futures.cs
+++ b/src/Proto.Actor/Futures.cs
@@ -53,21 +53,19 @@ namespace Proto
 
         public override void SendUserMessage(PID pid, object message)
         {
-            if (message is MessageEnvelope messageEnvelope)
-            {
-                message = messageEnvelope.Message;
-            }
+            var env = MessageEnvelope.Unwrap(message);
+            
 
-            if (message is T || message == null)
+            if (env.message is T || message == null)
             {
                 if (_cts != null && _cts.IsCancellationRequested) return;
 
-                _tcs.TrySetResult((T)message);
+                _tcs.TrySetResult((T)env.message);
                 pid.Stop();
             }            
             else
             {
-                throw new InvalidOperationException($"Unexpected message.  Was type {message.GetType()} but expected {typeof(T)}");
+                throw new InvalidOperationException($"Unexpected message.  Was type {env.message.GetType()} but expected {typeof(T)}");
             }
 
         }

--- a/src/Proto.Actor/MessageEnvelope.cs
+++ b/src/Proto.Actor/MessageEnvelope.cs
@@ -14,6 +14,17 @@ namespace Proto
         public PID Sender { get; }
         public object Message { get; }
         public MessageHeader Header { get; }
+
+
+        public static (object message, PID sender, MessageHeader headers) Unwrap(object message)
+        {
+            if (message is MessageEnvelope envelope)
+            {
+                return (envelope.Message, envelope.Sender, envelope.Header);
+            }
+
+            return (message, null, null);
+        }
     }
 
     public class MessageHeader : Dictionary<string, string>

--- a/src/Proto.Actor/PID.cs
+++ b/src/Proto.Actor/PID.cs
@@ -47,7 +47,7 @@ namespace Proto
         public void Tell(object message)
         {
             var reff = Ref ?? ProcessRegistry.Instance.Get(this);
-            reff.SendUserMessage(this, message, null);
+            reff.SendUserMessage(this, message);
         }
 
         public void SendSystemMessage(object sys)
@@ -59,7 +59,8 @@ namespace Proto
         public void Request(object message, PID sender)
         {
             var reff = Ref ?? ProcessRegistry.Instance.Get(this);
-            reff.SendUserMessage(this, message, sender);
+            var messageEnvelope = new MessageEnvelope(message,sender,null);
+            reff.SendUserMessage(this, messageEnvelope);
         }
         
         public Task<T> RequestAsync<T>(object message, TimeSpan timeout)

--- a/src/Proto.Actor/Process.cs
+++ b/src/Proto.Actor/Process.cs
@@ -11,7 +11,7 @@ namespace Proto
 {
     public abstract class Process
     {
-        public abstract void SendUserMessage(PID pid, object message, PID sender);
+        public abstract void SendUserMessage(PID pid, object message);
 
         public virtual void Stop(PID pid)
         {
@@ -38,14 +38,8 @@ namespace Proto
         }
 
 
-        public override void SendUserMessage(PID pid, object message, PID sender)
+        public override void SendUserMessage(PID pid, object message)
         {
-            if (sender != null)
-            {
-                Mailbox.PostUserMessage(new MessageEnvelope(message, sender, null));
-                return;
-            }
-
             Mailbox.PostUserMessage(message);
         }
 

--- a/src/Proto.Actor/RootContext.cs
+++ b/src/Proto.Actor/RootContext.cs
@@ -1,0 +1,55 @@
+﻿// -----------------------------------------------------------------------
+//   <copyright file="RootContext.cs" company="Asynkron HB">
+//       Copyright (C) 2015-2017 Asynkron HB All rights reserved
+//   </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Proto
+{
+    public interface IOutboundContext
+    {
+        void Tell(PID target, object message);
+        void Request(PID target, object message);
+        Task<T> RequestAsync<T>(PID target, object message, TimeSpan timeout);
+        Task<T> RequestAsync<T>(PID target, object message, CancellationToken cancellationToken);
+        Task<T> RequestAsync<T>(PID target, object message);
+    }
+    public class RootContext : IOutboundContext
+    {
+        private readonly Sender _senderMiddleware;
+
+        public RootContext(Sender senderMiddleware)
+        {
+            _senderMiddleware = senderMiddleware;
+        }
+
+        public void Tell(PID pid, object message)
+        {
+            
+        }
+
+        public void Request(PID target, object message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<T> RequestAsync<T>(PID target, object message, TimeSpan timeout)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<T> RequestAsync<T>(PID target, object message, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<T> RequestAsync<T>(PID target, object message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Proto.Remote/RemoteProcess.cs
+++ b/src/Proto.Remote/RemoteProcess.cs
@@ -18,17 +18,17 @@ namespace Proto.Remote
             _pid = pid;
         }
 
-        public override void SendUserMessage(PID pid, object message, PID sender)
+        public override void SendUserMessage(PID pid, object message)
         {
-            Send(pid, message, sender);
+            Send(pid, message);
         }
 
         public override void SendSystemMessage(PID pid, object message)
         {
-            Send(pid, message, null);
+            Send(pid, message);
         }
 
-        private void Send(PID pid, object msg, PID sender)
+        private void Send(PID _, object msg)
         {
             if (msg is Watch w)
             {
@@ -42,26 +42,30 @@ namespace Proto.Remote
             }
             else
             {
-                SendRemoteMessage(_pid, msg, sender);
+                SendRemoteMessage(_pid, msg);
             }
         }
 
-        public static void SendRemoteMessage(PID pid, object msg, PID sender)
+        public static void SendRemoteMessage(PID pid, object msg)
         {
-            if (msg is IMessage)
-            {
-                var imsg = (IMessage) msg;
-                var env = new RemoteDeliver(imsg, pid, sender);
+            object message;
+            PID sender;
 
-                /*
-                 *
-                {
-                    Target = pid,
-                    Sender = sender,
-                    MessageData = Serialization.Serialize(imsg),
-                    TypeName = imsg.Descriptor.File.Package + "." + imsg.Descriptor.Name
-                }; 
-                 */
+            if (msg is Proto.MessageEnvelope messageEnvelope)
+            {
+                message = messageEnvelope.Message;
+                sender = messageEnvelope.Sender;
+            }
+            else
+            {
+                message = msg;
+                sender = null;
+            }
+
+            if (message is IMessage protoMessage)
+            {
+                var env = new RemoteDeliver(protoMessage, pid, sender);
+
                 Remote.EndpointManagerPid.Tell(env);
             }
             else

--- a/src/Proto.Remote/RemoteProcess.cs
+++ b/src/Proto.Remote/RemoteProcess.cs
@@ -48,19 +48,7 @@ namespace Proto.Remote
 
         public static void SendRemoteMessage(PID pid, object msg)
         {
-            object message;
-            PID sender;
-
-            if (msg is Proto.MessageEnvelope messageEnvelope)
-            {
-                message = messageEnvelope.Message;
-                sender = messageEnvelope.Sender;
-            }
-            else
-            {
-                message = msg;
-                sender = null;
-            }
+            var (message, sender, _) = Proto.MessageEnvelope.Unwrap(msg);
 
             if (message is IMessage protoMessage)
             {

--- a/src/Proto.Router/RouterProcess.cs
+++ b/src/Proto.Router/RouterProcess.cs
@@ -22,9 +22,9 @@ namespace Proto.Router
 
         public override void SendUserMessage(PID pid, object message)
         {
-            switch (message)
+            var env = MessageEnvelope.Unwrap(message);
+            switch (env.message)
             {
-                case MessageEnvelope msg when msg.Message is RouterManagementMessage:
                 case RouterManagementMessage _:
                     var router = ProcessRegistry.Instance.Get(_router);
                     router.SendUserMessage(pid, message);

--- a/src/Proto.Router/RouterProcess.cs
+++ b/src/Proto.Router/RouterProcess.cs
@@ -20,16 +20,16 @@ namespace Proto.Router
             _state = state;
         }
 
-        public override void SendUserMessage(PID pid, object message, PID sender)
+        public override void SendUserMessage(PID pid, object message)
         {
             if (message is RouterManagementMessage)
             {
                 var router = ProcessRegistry.Instance.Get(_router);
-                router.SendUserMessage(pid, message, sender);
+                router.SendUserMessage(pid, message);
             }
             else
             {
-                _state.RouteMessage(message, sender);
+                _state.RouteMessage(message);
             }
         }
 

--- a/src/Proto.Router/RouterProcess.cs
+++ b/src/Proto.Router/RouterProcess.cs
@@ -22,14 +22,16 @@ namespace Proto.Router
 
         public override void SendUserMessage(PID pid, object message)
         {
-            if (message is RouterManagementMessage)
+            switch (message)
             {
-                var router = ProcessRegistry.Instance.Get(_router);
-                router.SendUserMessage(pid, message);
-            }
-            else
-            {
-                _state.RouteMessage(message);
+                case MessageEnvelope msg when msg.Message is RouterManagementMessage:
+                case RouterManagementMessage _:
+                    var router = ProcessRegistry.Instance.Get(_router);
+                    router.SendUserMessage(pid, message);
+                    break;
+                default:
+                    _state.RouteMessage(message);
+                    break;
             }
         }
 

--- a/src/Proto.Router/Routers/BroadcastRouterState.cs
+++ b/src/Proto.Router/Routers/BroadcastRouterState.cs
@@ -22,11 +22,11 @@ namespace Proto.Router.Routers
             _routees = routees;
         }
 
-        public override void RouteMessage(object message, PID sender)
+        public override void RouteMessage(object message)
         {
             foreach (var pid in _routees)
             {
-                pid.Request(message, sender);
+                pid.Tell(message);
             }
         }
     }

--- a/src/Proto.Router/Routers/ConsistentHashRouterState.cs
+++ b/src/Proto.Router/Routers/ConsistentHashRouterState.cs
@@ -40,14 +40,14 @@ namespace Proto.Router.Routers
             _hashRing = new HashRing(nodes, _hash, _replicaCount);
         }
 
-        public override void RouteMessage(object message, PID sender)
+        public override void RouteMessage(object message)
         {
             if (message is IHashable hashable)
             {
                 var key = hashable.HashBy();
                 var node = _hashRing.GetNode(key);
                 var routee = _routeeMap[node];
-                routee.Request(message, sender);
+                routee.Tell(message);
             }
         }
     }

--- a/src/Proto.Router/Routers/ConsistentHashRouterState.cs
+++ b/src/Proto.Router/Routers/ConsistentHashRouterState.cs
@@ -42,13 +42,19 @@ namespace Proto.Router.Routers
 
         public override void RouteMessage(object message)
         {
-            if (message is IHashable hashable)
+            var env = MessageEnvelope.Unwrap(message);
+            if (env.message is IHashable hashable)
             {
                 var key = hashable.HashBy();
                 var node = _hashRing.GetNode(key);
                 var routee = _routeeMap[node];
                 routee.Tell(message);
             }
+            else
+            {
+                throw new NotSupportedException($"Message of type '{message.GetType().Name}' does not implement IHashable");
+            }
+
         }
     }
 }

--- a/src/Proto.Router/Routers/RandomRouterState.cs
+++ b/src/Proto.Router/Routers/RandomRouterState.cs
@@ -27,11 +27,11 @@ namespace Proto.Router.Routers
             _values = routees.ToArray();
         }
 
-        public override void RouteMessage(object message, PID sender)
+        public override void RouteMessage(object message)
         {
             var i = _random.Next(_values.Length);
             var pid = _values[i];
-            pid.Request(message, sender);
+            pid.Tell(message);
         }
     }
 }

--- a/src/Proto.Router/Routers/RoundRobinRouterState.cs
+++ b/src/Proto.Router/Routers/RoundRobinRouterState.cs
@@ -27,12 +27,12 @@ namespace Proto.Router.Routers
             _values = routees.ToList();
         }
 
-        public override void RouteMessage(object message, PID sender)
+        public override void RouteMessage(object message)
         {
             var i = _currentIndex % _values.Count;
             var pid = _values[i];
             Interlocked.Add(ref _currentIndex, 1);
-            pid.Request(message, sender);
+            pid.Tell(message);
         }
     }
 }

--- a/src/Proto.Router/Routers/RouterState.cs
+++ b/src/Proto.Router/Routers/RouterState.cs
@@ -12,6 +12,6 @@ namespace Proto.Router.Routers
     {
         public abstract HashSet<PID> GetRoutees();
         public abstract void SetRoutees(HashSet<PID> routees);
-        public abstract void RouteMessage(object message, PID sender);
+        public abstract void RouteMessage(object message);
     }
 }

--- a/tests/Proto.TestFixtures/TestProcess.cs
+++ b/tests/Proto.TestFixtures/TestProcess.cs
@@ -2,7 +2,7 @@
 {
     public class TestProcess : Process
     {
-        public override void SendUserMessage(PID pid, object message, PID sender)
+        public override void SendUserMessage(PID pid, object message)
         {
         }
 


### PR DESCRIPTION
Redesigning `Process`, removed Sender from API.
We already have `MessageEnvelope` which carries sender information,
previously the message envelope was created inside the local process.
Now it is created at the call site.
This is done to enable passing message headers together with the message and to eventually complete the outbound middleware.

In my machine the Router tests break now, I cant fint out why. 
Any router based example works fine, so I need to locate the issue before merging.

