### PR TITLE
Tests for EventStream

### DIFF
--- a/src/Proto.Actor/EventStream.cs
+++ b/src/Proto.Actor/EventStream.cs
@@ -28,6 +28,7 @@ namespace Proto
             });
         }
     }
+
     public class EventStream<T>
     {
         private readonly ConcurrentDictionary<Guid, Action<T>> _subscriptions =

--- a/tests/Proto.Actor.Tests/EventStreamTests.cs
+++ b/tests/Proto.Actor.Tests/EventStreamTests.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace Proto.Tests
+{
+    public class EventStreamTests
+    {
+        [Fact]
+        public void EventStream_CanSubscribeToSpecificEventTypes()
+        {
+            var received = "";
+            var eventStream = new EventStream();
+            eventStream.Subscribe<string>(theString => received = theString);
+            eventStream.Publish("hello");
+            Assert.Equal("hello", received);
+        }
+
+        [Fact]
+        public void EventStream_CanSubscribeToAllEventTypes()
+        { 
+            var receivedEvents = new List<object>();
+            var eventStream = new EventStream();
+            eventStream.Subscribe(@event => receivedEvents.Add(@event));
+            eventStream.Publish("hello");
+            eventStream.Publish(1);
+            eventStream.Publish(true);
+            Assert.Equal(3, receivedEvents.Count);
+        }
+
+        [Fact]
+        public void EventStream_CanUnsubscribeFromEvents()
+        {
+            var receivedEvents = new List<object>();
+            var eventStream = new EventStream();
+            var subscription = eventStream.Subscribe<string>(@event => receivedEvents.Add(@event));
+            eventStream.Publish("first message");
+            subscription.Unsubscribe();
+            eventStream.Publish("second message");
+            Assert.Equal(1, receivedEvents.Count);
+        }
+
+        [Fact]
+        public void EventStream_OnlyReceiveSubscribedToEventTypes()
+        {
+            var eventsReceived = new List<object>();
+            var eventStream = new EventStream();
+            eventStream.Subscribe<int>(@event => eventsReceived.Add(@event));
+            eventStream.Publish("not an int");
+            Assert.Equal(0, eventsReceived.Count);
+        }
+    }
+}


### PR DESCRIPTION
- made EventStream ctor public. We do not want to use the static EventStream.Instance for tests as they would all interfere with each other anytime a message type was sent that another test subscribed to.