### PR TITLE
Throw exception if Proto.Remote.Tests.Node dll path incorrect

### DIFF
--- a/tests/Proto.Remote.Tests/RemoteActorSystem.cs
+++ b/tests/Proto.Remote.Tests/RemoteActorSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Threading;
 using Xunit;
 
@@ -18,6 +19,10 @@ namespace Proto.Remote.Tests
             var testsDirectory = System.IO.Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent;
             var nodeDllPath = $@"{testsDirectory.FullName}/{nodeAppPath}";
             Console.WriteLine($"NodeDLL path: {nodeDllPath}");
+            if (!File.Exists(nodeDllPath))
+            {
+                throw new FileNotFoundException(nodeDllPath);
+            }
             _process = new System.Diagnostics.Process
             {
                 StartInfo =


### PR DESCRIPTION
Fails the tests early if the remote dll isn't found and makes it obvious what went wrong