### PR TITLE
remove not used dictionary

### DIFF
--- a/src/Proto.Remote/EndpointWatcher.cs
+++ b/src/Proto.Remote/EndpointWatcher.cs
@@ -12,7 +12,6 @@ namespace Proto.Remote
     public class EndpointWatcher : IActor
     {
         private readonly Dictionary<string, PID> _watched = new Dictionary<string, PID>();
-        private readonly Dictionary<string, PID> _watcher = new Dictionary<string, PID>();
         private string _address; //for logging
 
         public EndpointWatcher(string address)
@@ -27,7 +26,6 @@ namespace Proto.Remote
                 case RemoteTerminate msg:
                 {
                     _watched.Remove(msg.Watcher.Id);
-                    _watcher.Remove(msg.Watchee.Id);
                     //create a terminated event for the Watched actor
                     var t = new Terminated
                     {
@@ -57,7 +55,6 @@ namespace Proto.Remote
                 case RemoteUnwatch msg:
                 {
                     _watched[msg.Watcher.Id] = null;
-                    _watcher[msg.Watchee.Id] = null;
 
                     var w = new Unwatch(msg.Watcher);
                     msg.Watchee.SendSystemMessage(w);
@@ -67,7 +64,6 @@ namespace Proto.Remote
                 case RemoteWatch msg:
                 {
                     _watched[msg.Watcher.Id] = msg.Watchee;
-                    _watcher[msg.Watchee.Id] = msg.Watcher;
 
                     var w = new Watch(msg.Watcher);
                     msg.Watchee.SendSystemMessage(w);


### PR DESCRIPTION
It seems that this dictionary is used just for add and remove elements. I don't see reason to support it.