### PR TITLE
substitute Dictionary with ConcurrentDictionary

### DIFF
--- a/src/Proto.Remote/EndpointManager.cs
+++ b/src/Proto.Remote/EndpointManager.cs
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Threading.Tasks;
 
 namespace Proto.Remote
@@ -25,7 +25,7 @@ namespace Proto.Remote
     public class EndpointManager : IActor
     {
         private readonly RemoteConfig _config;
-        private readonly Dictionary<string, Endpoint> _connections = new Dictionary<string, Endpoint>();
+        private readonly ConcurrentDictionary<string, Endpoint> _connections = new ConcurrentDictionary<string, Endpoint>();
 
         public EndpointManager(RemoteConfig config)
         {
@@ -87,7 +87,10 @@ namespace Proto.Remote
                 var watcher = SpawnWatcher(address, context);
 
                 endpoint = new Endpoint(writer, watcher);
-                _connections.Add(address, endpoint);
+                
+                if (!_connections.TryAdd(address, endpoint)){
+                    _connections.TryGetValue(address, out endpoint);
+                }
             }
 
             return endpoint;


### PR DESCRIPTION
I believe it should be like this. If it could called with the same `address` 2 times concurent it will raise an exception. This variant is more concurent stable I think.