### PR TITLE
simplifying remote tests

### DIFF
--- a/tests/Proto.Remote.Tests.Messages/Protos.g.cs
+++ b/tests/Proto.Remote.Tests.Messages/Protos.g.cs
@@ -24,15 +24,16 @@ namespace Proto.Remote.Tests.Messages {
           string.Concat(
             "CgxQcm90b3MucHJvdG8SFHJlbW90ZV90ZXN0X21lc3NhZ2VzGhhQcm90by5B",
             "Y3Rvci9Qcm90b3MucHJvdG8iBwoFU3RhcnQiKQoLU3RhcnRSZW1vdGUSGgoG",
-            "U2VuZGVyGAEgASgLMgouYWN0b3IuUElEIgYKBFBpbmciBgoEUG9uZ0IeqgIb",
-            "UHJvdG8uUmVtb3RlLlRlc3RzLk1lc3NhZ2VzYgZwcm90bzM="));
+            "U2VuZGVyGAEgASgLMgouYWN0b3IuUElEIhcKBFBpbmcSDwoHbWVzc2FnZRgB",
+            "IAEoCSIXCgRQb25nEg8KB21lc3NhZ2UYASABKAlCHqoCG1Byb3RvLlJlbW90",
+            "ZS5UZXN0cy5NZXNzYWdlc2IGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Proto.ProtosReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Proto.Remote.Tests.Messages.Start), global::Proto.Remote.Tests.Messages.Start.Parser, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Proto.Remote.Tests.Messages.StartRemote), global::Proto.Remote.Tests.Messages.StartRemote.Parser, new[]{ "Sender" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Proto.Remote.Tests.Messages.Ping), global::Proto.Remote.Tests.Messages.Ping.Parser, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Proto.Remote.Tests.Messages.Pong), global::Proto.Remote.Tests.Messages.Pong.Parser, null, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Proto.Remote.Tests.Messages.Ping), global::Proto.Remote.Tests.Messages.Ping.Parser, new[]{ "Message" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Proto.Remote.Tests.Messages.Pong), global::Proto.Remote.Tests.Messages.Pong.Parser, new[]{ "Message" }, null, null, null)
           }));
     }
     #endregion
@@ -275,11 +276,23 @@ namespace Proto.Remote.Tests.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public Ping(Ping other) : this() {
+      message_ = other.message_;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public Ping Clone() {
       return new Ping(this);
+    }
+
+    /// <summary>Field number for the "message" field.</summary>
+    public const int MessageFieldNumber = 1;
+    private string message_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string Message {
+      get { return message_; }
+      set {
+        message_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -295,12 +308,14 @@ namespace Proto.Remote.Tests.Messages {
       if (ReferenceEquals(other, this)) {
         return true;
       }
+      if (Message != other.Message) return false;
       return true;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
+      if (Message.Length != 0) hash ^= Message.GetHashCode();
       return hash;
     }
 
@@ -311,11 +326,18 @@ namespace Proto.Remote.Tests.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      if (Message.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Message);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
+      if (Message.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Message);
+      }
       return size;
     }
 
@@ -323,6 +345,9 @@ namespace Proto.Remote.Tests.Messages {
     public void MergeFrom(Ping other) {
       if (other == null) {
         return;
+      }
+      if (other.Message.Length != 0) {
+        Message = other.Message;
       }
     }
 
@@ -334,6 +359,10 @@ namespace Proto.Remote.Tests.Messages {
           default:
             input.SkipLastField();
             break;
+          case 10: {
+            Message = input.ReadString();
+            break;
+          }
         }
       }
     }
@@ -364,11 +393,23 @@ namespace Proto.Remote.Tests.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public Pong(Pong other) : this() {
+      message_ = other.message_;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public Pong Clone() {
       return new Pong(this);
+    }
+
+    /// <summary>Field number for the "message" field.</summary>
+    public const int MessageFieldNumber = 1;
+    private string message_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string Message {
+      get { return message_; }
+      set {
+        message_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -384,12 +425,14 @@ namespace Proto.Remote.Tests.Messages {
       if (ReferenceEquals(other, this)) {
         return true;
       }
+      if (Message != other.Message) return false;
       return true;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
+      if (Message.Length != 0) hash ^= Message.GetHashCode();
       return hash;
     }
 
@@ -400,11 +443,18 @@ namespace Proto.Remote.Tests.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      if (Message.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Message);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
+      if (Message.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Message);
+      }
       return size;
     }
 
@@ -412,6 +462,9 @@ namespace Proto.Remote.Tests.Messages {
     public void MergeFrom(Pong other) {
       if (other == null) {
         return;
+      }
+      if (other.Message.Length != 0) {
+        Message = other.Message;
       }
     }
 
@@ -423,6 +476,10 @@ namespace Proto.Remote.Tests.Messages {
           default:
             input.SkipLastField();
             break;
+          case 10: {
+            Message = input.ReadString();
+            break;
+          }
         }
       }
     }

--- a/tests/Proto.Remote.Tests.Messages/Protos.proto
+++ b/tests/Proto.Remote.Tests.Messages/Protos.proto
@@ -7,5 +7,9 @@ message Start {}
 message StartRemote {
 	actor.PID Sender = 1;
 }
-message Ping {}
-message Pong {}
+message Ping {
+	string message=1;
+	}
+message Pong {
+	string message=1;
+	}

--- a/tests/Proto.Remote.Tests.Node/Program.cs
+++ b/tests/Proto.Remote.Tests.Node/Program.cs
@@ -8,9 +8,11 @@ namespace Proto.Remote.Tests.Node
     {
         static void Main(string[] args)
         {
-            Serialization.RegisterFileDescriptor(Tests.Messages.ProtosReflection.Descriptor);
-            Remote.Start("127.0.0.1", 12000);
-            var props = Actor.FromProducer(() => new EchoActor());
+            var host = "127.0.0.1";
+            var port = 12000;
+            Serialization.RegisterFileDescriptor(Messages.ProtosReflection.Descriptor);
+            Remote.Start(host, port);
+            var props = Actor.FromProducer(() => new EchoActor(host, port));
             Remote.RegisterKnownKind("remote", props);
             Actor.SpawnNamed(props, "remote");
             Console.ReadLine();
@@ -19,19 +21,21 @@ namespace Proto.Remote.Tests.Node
 
     public class EchoActor : IActor
     {
-        private PID _sender;
+        private readonly string _host;
+        private readonly int _port;
+
+        public EchoActor(string host, int port)
+        {
+            _host = host;
+            _port = port;
+        }
 
         public Task ReceiveAsync(IContext context)
         {
             switch (context.Message)
             {
-                case StartRemote sr:
-                    Console.WriteLine("Starting");
-                    _sender = sr.Sender;
-                    context.Respond(new Start());
-                    return Actor.Done;
-                case Ping _:
-                    _sender.Tell(new Pong());
+                case Ping ping:
+                    context.Sender.Tell(new Pong{Message= $"{_host}:{_port} {ping.Message}"});
                     return Actor.Done;
                 default:
                     return Actor.Done;

--- a/tests/Proto.Remote.Tests/RemoteTests.cs
+++ b/tests/Proto.Remote.Tests/RemoteTests.cs
@@ -12,64 +12,28 @@ namespace Proto.Remote.Tests
         [Fact]
         public async void CanSendAndReceiveRemote()
         {
-            var props = Actor.FromProducer(() => new LocalActor());
-            var pid = Actor.Spawn(props);
-            
             var remoteActor = new PID("127.0.0.1:12000", "remote");
-            await remoteActor.RequestAsync<Start>(new StartRemote { Sender = pid }, TimeSpan.FromMilliseconds(2500));
-
-            remoteActor.Tell(new Ping());
-            await Task.Delay(TimeSpan.FromSeconds(2));
-            var responseReceived = await pid.RequestAsync<bool>("?", TimeSpan.FromMilliseconds(2500));
-
-            Assert.True(responseReceived);
+            var pong = await remoteActor.RequestAsync<Pong>(new Ping { Message = "Hello" }, TimeSpan.FromMilliseconds(5000));
+            Assert.Equal("127.0.0.1:12000 Hello", pong.Message);
         }
 
         [Fact]
         public async void WhenRemoteActorNotFound_RequestAsyncTimesout()
         {
-            var props = Actor.FromProducer(() => new LocalActor());
-            var pid = Actor.Spawn(props);
-
             var unknownRemoteActor = new PID("127.0.0.1:12000", "doesn't exist");
             await Assert.ThrowsAsync<TimeoutException>(async () =>
             {
-                await unknownRemoteActor.RequestAsync<Start>(new StartRemote { Sender = pid }, TimeSpan.FromMilliseconds(2000));
+                await unknownRemoteActor.RequestAsync<Pong>(new Ping { Message = "Hello" }, TimeSpan.FromMilliseconds(2000));
             });
         }
 
         [Fact]
         public async void CanSpawnRemoteActor()
         {
-            var props = Actor.FromProducer(() => new LocalActor());
-            var pid = Actor.Spawn(props);
             var remoteActorName = Guid.NewGuid().ToString();
             var remoteActor = await Remote.SpawnNamedAsync("127.0.0.1:12000", remoteActorName, "remote", TimeSpan.FromSeconds(5));
-            await remoteActor.RequestAsync<Start>(new StartRemote { Sender = pid }, TimeSpan.FromMilliseconds(2500));
-            remoteActor.Tell(new Ping());
-            await Task.Delay(TimeSpan.FromSeconds(2));
-
-            var responseReceived = await pid.RequestAsync<bool>("?", TimeSpan.FromMilliseconds(2500));
-            Assert.True(responseReceived);
-        }
-
-        public class LocalActor : IActor
-        {
-            private bool _pongReceived;
-
-            public Task ReceiveAsync(IContext context)
-            {
-                switch (context.Message)
-                {
-                    case Pong _:
-                        _pongReceived = true;
-                        break;
-                    case string msg when msg == "?":
-                        context.Sender.Tell(_pongReceived);
-                        break;
-                }
-                return Actor.Done;
-            }
+            var pong = await remoteActor.RequestAsync<Pong>(new Ping{Message="Hello"}, TimeSpan.FromMilliseconds(5000));
+            Assert.Equal("127.0.0.1:12000 Hello", pong.Message);
         }
     }
 }


### PR DESCRIPTION
Changing tests to use ReceiveAsync rather than having a local actor and querying that. Should improve robustness of tests