### PR TITLE
add check if address already in the _connections.

### DIFF
--- a/src/Proto.Remote/EndpointManager.cs
+++ b/src/Proto.Remote/EndpointManager.cs
@@ -87,7 +87,16 @@ namespace Proto.Remote
                 var watcher = SpawnWatcher(address, context);
 
                 endpoint = new Endpoint(writer, watcher);
-                _connections.Add(address, endpoint);
+
+                try
+                {
+                    _connections.Add(address, endpoint);
+                }
+                catch (ArgumentException)
+                {
+                    return _connections[address];
+                }
+                
             }
 
             return endpoint;


### PR DESCRIPTION
@rogeralsing  . The check that element is already was added into the dictionary. I believe that if element already was added into the _connections then it should be returned. Forgot to add it earlier. 
https://github.com/AsynkronIT/protoactor-dotnet/pull/149