### PR TITLE
Remote watch test

### DIFF
--- a/src/Proto.Remote/EndpointWatcher.cs
+++ b/src/Proto.Remote/EndpointWatcher.cs
@@ -57,8 +57,7 @@ namespace Proto.Remote
                     _watched[msg.Watcher.Id] = null;
 
                     var w = new Unwatch(msg.Watcher);
-                    msg.Watchee.SendSystemMessage(w);
-
+                    RemoteProcess.SendRemoteMessage(msg.Watchee, w);
                     break;
                 }
                 case RemoteWatch msg:
@@ -66,8 +65,7 @@ namespace Proto.Remote
                     _watched[msg.Watcher.Id] = msg.Watchee;
 
                     var w = new Watch(msg.Watcher);
-                    msg.Watchee.SendSystemMessage(w);
-
+                    RemoteProcess.SendRemoteMessage(msg.Watchee, w);
                     break;
                 }
 

--- a/src/Proto.Remote/RemoteProcess.cs
+++ b/src/Proto.Remote/RemoteProcess.cs
@@ -53,7 +53,6 @@ namespace Proto.Remote
             if (message is IMessage protoMessage)
             {
                 var env = new RemoteDeliver(protoMessage, pid, sender);
-
                 Remote.EndpointManagerPid.Tell(env);
             }
             else

--- a/tests/Proto.Remote.Tests/RemoteTests.cs
+++ b/tests/Proto.Remote.Tests/RemoteTests.cs
@@ -35,5 +35,47 @@ namespace Proto.Remote.Tests
             var pong = await remoteActor.RequestAsync<Pong>(new Ping{Message="Hello"}, TimeSpan.FromMilliseconds(5000));
             Assert.Equal("127.0.0.1:12000 Hello", pong.Message);
         }
+
+        [Fact]
+        public async void CanWatchRemoteActor()
+        {
+            var remoteActorName = Guid.NewGuid().ToString();
+            var remoteActor = await Remote.SpawnNamedAsync("127.0.0.1:12000", remoteActorName, "remote", TimeSpan.FromSeconds(5));
+
+            var props = Actor.FromProducer(() => new LocalActor(remoteActor));
+            var localActor = Actor.SpawnNamed(props, "local watcher");
+            remoteActor.Stop();
+            await Task.Delay(TimeSpan.FromSeconds(3)); // wait for stop to propagate...
+            var terminatedMessageReceived = await localActor.RequestAsync<bool>("?", TimeSpan.FromSeconds(5));
+            Assert.True(terminatedMessageReceived);
+        }
+    }
+ 
+    public class LocalActor : IActor
+    {
+        private readonly PID _remoteActor;
+        private bool _terminateReceived;
+
+        public LocalActor(PID remoteActor)
+        {
+            _remoteActor = remoteActor;
+        }
+
+        public Task ReceiveAsync(IContext context)
+        {
+            switch (context.Message)
+            {
+                case Started msg:
+                    context.Watch(_remoteActor);
+                    break;
+                case string msg when msg == "?":
+                    context.Sender.Tell(_terminateReceived);
+                    break;
+                case Terminated msg:
+                    _terminateReceived = true;
+                    break;
+            }
+            return Actor.Done;
+        }
     }
 }


### PR DESCRIPTION
The current code in RemoteProcess.Send causes an infinite loop when watching a remote actor. Before removing the code in this PR, I was seeing 10,000s of RemoteWatch messages until the test timed out - RemoteProcess was passing the RemoteWatch message back to the EndpointManager, which then passed it to the RemoteProcess, which then passed it back to the EndpointManager...... and on.

