### PR TITLE
Remote test additions

### DIFF
--- a/src/Proto.Remote/EndpointReader.cs
+++ b/src/Proto.Remote/EndpointReader.cs
@@ -35,7 +35,7 @@ namespace Proto.Remote
                         var rt = new RemoteTerminate(target, msg.Who);
                         Remote.EndpointManagerPid.Tell(rt);
                     }
-                    if (message is SystemMessage sys)
+                    else if (message is SystemMessage sys)
                     {
                         target.SendSystemMessage(sys);
                     }

--- a/src/Proto.Remote/EndpointWatcher.cs
+++ b/src/Proto.Remote/EndpointWatcher.cs
@@ -29,8 +29,7 @@ namespace Proto.Remote
                     //create a terminated event for the Watched actor
                     var t = new Terminated
                     {
-                        Who = msg.Watchee,
-                        AddressTerminated = true
+                        Who = msg.Watchee
                     };
                     //send the address Terminated event to the Watcher
                     msg.Watcher.SendSystemMessage(t);

--- a/tests/Proto.Remote.Tests.Node/Program.cs
+++ b/tests/Proto.Remote.Tests.Node/Program.cs
@@ -22,8 +22,7 @@ namespace Proto.Remote.Tests.Node
                 {
                     int.TryParse(portString, out port);
                 }
-                Console.WriteLine(host);
-                Console.WriteLine(port);
+
                 Serialization.RegisterFileDescriptor(Messages.ProtosReflection.Descriptor);
                 Remote.Start(host, port);
                 var props = Actor.FromProducer(() => new EchoActor(host, port));

--- a/tests/Proto.Remote.Tests/DisplayTestMethodNameAttribute.cs
+++ b/tests/Proto.Remote.Tests/DisplayTestMethodNameAttribute.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Proto.Remote.Tests
+{
+    public class DisplayTestMethodNameAttribute : BeforeAfterTestAttribute
+    {
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"******** Running '{methodUnderTest.Name}.' ********");
+        }
+
+        public override void After(MethodInfo methodUnderTest)
+        {
+            Console.WriteLine($"******** Finished '{methodUnderTest.Name}.' ********");
+        }
+    }
+}

--- a/tests/Proto.Remote.Tests/RemoteKindsRegistrationTests.cs
+++ b/tests/Proto.Remote.Tests/RemoteKindsRegistrationTests.cs
@@ -1,0 +1,36 @@
+using System;
+using Xunit;
+
+namespace Proto.Remote.Tests
+{
+    public class RemoteKindsRegistrationTests
+    {
+        [Fact]
+        public void CanRegisterKind()
+        {
+            var props = new Props();
+            var kind = Guid.NewGuid().ToString();
+            Remote.RegisterKnownKind(kind, props);
+            Assert.Equal(props, Remote.GetKnownKind(kind));
+        }
+
+        [Fact]
+        public void CanRegisterMultipleKinds()
+        {
+            var props = new Props();
+            var kind1 = Guid.NewGuid().ToString();
+            var kind2 = Guid.NewGuid().ToString();
+            Remote.RegisterKnownKind(kind1, props);
+            Remote.RegisterKnownKind(kind2, props);
+            var kinds = Remote.GetKnownKinds();
+            Assert.Contains(kind1, kinds);
+            Assert.Contains(kind2, kinds);
+        }
+
+        [Fact]
+        public void UnknownKindThrowsException()
+        {
+            Assert.Throws<ArgumentException>(() => { Remote.GetKnownKind("not registered"); });
+        }
+    }
+}

--- a/tests/Proto.Remote.Tests/RemoteTests.cs
+++ b/tests/Proto.Remote.Tests/RemoteTests.cs
@@ -1,12 +1,13 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 using System.Threading.Tasks;
 using Proto.Remote.Tests.Messages;
 
 namespace Proto.Remote.Tests
 {
-    [Collection("RemoteTests")]
-    [Trait("Category", "Remote")]
+    [Collection("RemoteTests"), Trait("Category", "Remote")]
     public class RemoteTests
     {
         private readonly RemoteManager _remoteManager;
@@ -16,15 +17,15 @@ namespace Proto.Remote.Tests
             _remoteManager = remoteManager;
         }
 
-        [Fact]
-        public async void CanSendAndReceiveRemote()
+        [Fact, DisplayTestMethodName]
+        public async void CanSendAndReceiveToExistingRemote()
         {
             var remoteActor = new PID(_remoteManager.DefaultNode.Address, "EchoActorInstance");
             var pong = await remoteActor.RequestAsync<Pong>(new Ping { Message = "Hello" }, TimeSpan.FromMilliseconds(5000));
             Assert.Equal($"{_remoteManager.DefaultNode.Address} Hello", pong.Message);
         }
 
-        [Fact]
+        [Fact, DisplayTestMethodName]
         public async void WhenRemoteActorNotFound_RequestAsyncTimesout()
         {
             var unknownRemoteActor = new PID(_remoteManager.DefaultNode.Address, "doesn't exist");
@@ -34,7 +35,7 @@ namespace Proto.Remote.Tests
             });
         }
 
-        [Fact]
+        [Fact, DisplayTestMethodName]
         public async void CanSpawnRemoteActor()
         {
             var remoteActorName = Guid.NewGuid().ToString();
@@ -43,45 +44,147 @@ namespace Proto.Remote.Tests
             Assert.Equal($"{_remoteManager.DefaultNode.Address} Hello", pong.Message);
         }
 
-        [Fact]
+        [Fact, DisplayTestMethodName]
         public async void CanWatchRemoteActor()
         {
-            var remoteActorName = Guid.NewGuid().ToString();
-            var remoteActor = await Remote.SpawnNamedAsync(_remoteManager.DefaultNode.Address, remoteActorName, "EchoActor", TimeSpan.FromSeconds(5));
-
-            var props = Actor.FromProducer(() => new LocalActor(remoteActor));
-            var localActor = Actor.Spawn(props);
+            var remoteActor = await SpawnRemoteActor(_remoteManager.DefaultNode.Address);
+            var localActor = await SpawnLocalActorAndWatch(remoteActor);
+            
             remoteActor.Stop();
-            await Task.Delay(TimeSpan.FromSeconds(3)); // wait for stop to propagate...
-            var terminatedMessageReceived = await localActor.RequestAsync<bool>("?", TimeSpan.FromSeconds(5));
-            Assert.True(terminatedMessageReceived);
+            Assert.True(await PollUntilTrue(() => 
+            localActor.RequestAsync<bool>(new TerminatedMessageReceived(_remoteManager.DefaultNode.Address, remoteActor.Id), TimeSpan.FromSeconds(5))), 
+                "Watching actor did not receive Termination message");
         }
 
-        [Fact]
+        [Fact, DisplayTestMethodName]
+        public async void CanWatchMultipleRemoteActors()
+        {
+            var remoteActor1 = await SpawnRemoteActor(_remoteManager.DefaultNode.Address);
+            var remoteActor2 = await SpawnRemoteActor(_remoteManager.DefaultNode.Address);
+            var localActor = await SpawnLocalActorAndWatch(remoteActor1, remoteActor2);
+
+            remoteActor1.Stop();
+            remoteActor2.Stop();
+            Assert.True(await PollUntilTrue(() => 
+            localActor.RequestAsync<bool>(new TerminatedMessageReceived(_remoteManager.DefaultNode.Address, remoteActor1.Id), TimeSpan.FromSeconds(5))),
+                "Watching actor did not receive Termination message");
+            Assert.True(await PollUntilTrue(() =>
+                    localActor.RequestAsync<bool>(new TerminatedMessageReceived(_remoteManager.DefaultNode.Address, remoteActor2.Id), TimeSpan.FromSeconds(5))),
+                "Watching actor did not receive Termination message");
+        }
+
+        [Fact, DisplayTestMethodName]
+        public async void MultipleLocalActorsCanWatchRemoteActor()
+        {
+            var remoteActor = await SpawnRemoteActor(_remoteManager.DefaultNode.Address);
+
+            var localActor1 = await SpawnLocalActorAndWatch(remoteActor);
+            var localActor2 = await SpawnLocalActorAndWatch(remoteActor);
+            remoteActor.Stop();
+
+            Assert.True(await PollUntilTrue(() =>
+                    localActor1.RequestAsync<bool>(new TerminatedMessageReceived(_remoteManager.DefaultNode.Address, remoteActor.Id), TimeSpan.FromSeconds(5))),
+                "Watching actor did not receive Termination message");
+            Assert.True(await PollUntilTrue(() =>
+                    localActor2.RequestAsync<bool>(new TerminatedMessageReceived(_remoteManager.DefaultNode.Address, remoteActor.Id), TimeSpan.FromSeconds(5))),
+                "Watching actor did not receive Termination message");
+        }
+
+        [Fact, DisplayTestMethodName]
+        public async void CanUnwatchRemoteActor()
+        {
+            var remoteActor = await SpawnRemoteActor(_remoteManager.DefaultNode.Address);
+            var localActor1 = await SpawnLocalActorAndWatch(remoteActor);
+            var localActor2 = await SpawnLocalActorAndWatch(remoteActor);
+            localActor2.Tell(new Unwatch(remoteActor));
+            await Task.Delay(TimeSpan.FromSeconds(3)); // wait for unwatch to propagate...
+            remoteActor.Stop();
+
+            // localActor1 is still watching so should get notified
+            Assert.True(await PollUntilTrue(() => 
+                localActor1.RequestAsync<bool>(new TerminatedMessageReceived(_remoteManager.DefaultNode.Address, remoteActor.Id), TimeSpan.FromSeconds(5))), 
+                "Watching actor did not receive Termination message");
+            // localActor2 is NOT watching so should not get notified
+            Assert.False(await localActor2.RequestAsync<bool>(new TerminatedMessageReceived(_remoteManager.DefaultNode.Address, remoteActor.Id), TimeSpan.FromSeconds(5)), 
+                "Unwatch did not succeed.");
+        }
+
+        [Fact, DisplayTestMethodName]
         public async void WhenRemoteTerminated_LocalWatcherReceivesNotification()
         {
-            var (address, process) = _remoteManager.StartRemote("127.0.0.1", 12002);
-            await Task.Delay(TimeSpan.FromSeconds(3));
-            var remoteActorName = Guid.NewGuid().ToString();
-            var remoteActor = await Remote.SpawnNamedAsync(address, remoteActorName, "EchoActor", TimeSpan.FromSeconds(5));
-
-            var props = Actor.FromProducer(() => new LocalActor(remoteActor));
-            var localActor = Actor.Spawn(props);
+            var (address, process) = _remoteManager.ProvisionNode("127.0.0.1", 12002);
+            
+            var remoteActor = await SpawnRemoteActor(address);
+            var localActor = await SpawnLocalActorAndWatch(remoteActor);
+            Console.WriteLine($"Killing remote process {address}!");
             process.Kill();
-            await Task.Delay(TimeSpan.FromSeconds(3)); // wait for kill to propagate...
-            var terminatedMessageReceived = await localActor.RequestAsync<bool>("?", TimeSpan.FromSeconds(5));
-            Assert.True(terminatedMessageReceived);
+            Assert.True(await PollUntilTrue(() => 
+            localActor.RequestAsync<bool>(new TerminatedMessageReceived(address, remoteActor.Id), TimeSpan.FromSeconds(5))), 
+                "Watching actor did not receive Termination message");
+            Assert.Equal(1, await localActor.RequestAsync<int>(new GetTerminatedMessagesCount(), TimeSpan.FromSeconds(5)));
+        }
+
+        private static async Task<PID> SpawnRemoteActor(string address)
+        {
+            var remoteActorName = Guid.NewGuid().ToString();
+            return await Remote.SpawnNamedAsync(address, remoteActorName, "EchoActor", TimeSpan.FromSeconds(5));
+        }
+
+        private async Task<PID> SpawnLocalActorAndWatch(params PID[] remoteActors)
+        {
+            var props = Actor.FromProducer(() => new LocalActor(remoteActors));
+            var actor = Actor.Spawn(props);
+            // The local actor watches the remote one - we wait here for the RemoteWatch 
+            // message to propagate to the remote actor
+            Console.WriteLine("Waiting for RemoteWatch to propagate...");
+            await Task.Delay(2000);
+            return actor;
+        }
+
+        private Task<bool> PollUntilTrue(Func<Task<bool>> predicate)
+        {
+            return PollUntilTrue(predicate, 10, TimeSpan.FromMilliseconds(500));
+        }
+
+        private async Task<bool> PollUntilTrue(Func<Task<bool>> predicate, int attempts, TimeSpan interval)
+        {
+            var attempt = 1;
+            while (attempt <= attempts)
+            {
+                Console.WriteLine($"Attempting assertion (attempt {attempt} of {attempts})");
+                if (await predicate())
+                {
+                    Console.WriteLine($"Passed!");
+                    return true;
+                }
+                attempt++;
+                await Task.Delay(interval);
+            }
+            return false;
         }
     }
- 
+
+    public class TerminatedMessageReceived
+    {
+        public TerminatedMessageReceived(string address, string actorId)
+        {
+            Address = address;
+            ActorId = actorId;
+        }
+        public string Address { get; }
+        public string ActorId { get; }
+    }
+
+    public class GetTerminatedMessagesCount { }
+
     public class LocalActor : IActor
     {
-        private readonly PID _remoteActor;
-        private bool _terminateReceived;
+        private readonly List<PID> _remoteActors = new List<PID>();
+        private readonly List<Terminated> _terminatedMessages = new List<Terminated>();
 
-        public LocalActor(PID remoteActor)
+        public LocalActor(params PID[] remoteActors)
         {
-            _remoteActor = remoteActor;
+            _remoteActors.AddRange(remoteActors);
         }
 
         public Task ReceiveAsync(IContext context)
@@ -89,16 +192,56 @@ namespace Proto.Remote.Tests
             switch (context.Message)
             {
                 case Started _:
-                    context.Watch(_remoteActor);
+                    HandleStarted(context);
                     break;
-                case string msg when msg == "?":
-                    context.Sender.Tell(_terminateReceived);
+                case Unwatch msg:
+                    HandleUnwatch(context, msg);
                     break;
-                case Terminated _:
-                    _terminateReceived = true;
+                case TerminatedMessageReceived msg:
+                    HandleTerminatedMessageReceived(context, msg);
+                    break;
+                case GetTerminatedMessagesCount _:
+                    HandleCountOfMessagesReceived(context);
+                    break;
+                case Terminated msg:
+                    HandleTerminated(msg);
                     break;
             }
             return Actor.Done;
+        }
+
+        private void HandleCountOfMessagesReceived(IContext context)
+        {
+            context.Sender.Tell(_terminatedMessages.Count);
+        }
+
+        private void HandleTerminatedMessageReceived(IContext context, TerminatedMessageReceived msg)
+        {
+            var messageReceived = _terminatedMessages.Any(tm => tm.Who.Address == msg.Address &&
+                                                                tm.Who.Id == msg.ActorId);
+            context.Sender.Tell(messageReceived);
+        }
+
+        private void HandleTerminated(Terminated msg)
+        {
+            Console.WriteLine($"Received Terminated message for {msg.Who.Address}: {msg.Who.Id}. Address terminated? {msg.AddressTerminated}");
+            _terminatedMessages.Add(msg);
+        }
+
+        private void HandleUnwatch(IContext context, Unwatch msg)
+        {
+            var remoteActor =_remoteActors.Single(ra => ra.Id == msg.Watcher.Id && 
+                                                        ra.Address == msg.Watcher.Address);
+
+            context.Unwatch(remoteActor);
+        }
+
+        private void HandleStarted(IContext context)
+        {
+            foreach (var remoteActor in _remoteActors)
+            {
+                context.Watch(remoteActor);
+            }
         }
     }
 }


### PR DESCRIPTION
- add test for unwatching remote actor
- add test for watching multiple remote actors
- add test for multiple local actors watch one remote
- add assertion on killing remote node that only a single Terminated message is received. 
- add tests for registration of remote kinds

Refactorings:

- removed duplication around starting local and remote actors
- local actor now keeps a record of all Terminated messages it has received and use this to satisfy "did the actor receive a Terminated message for this remote actor" queries 
- better console logging. This is primarily because there are a few delays in the code to allow propagation of messages. Adding logging around this helps to understand what's going on when reading the test output
- added a polling mechanism for asserting on conditions where we cannot just using RecevieAsync. This should result in faster and more robust test execution

Test output should look like:

![capture](https://cloud.githubusercontent.com/assets/1437372/25035239/057490ba-20f5-11e7-99f1-d44d918967f9.JPG)