### PR TITLE
Remove Message setter property

### DIFF
--- a/src/Proto.Actor/LocalContext.cs
+++ b/src/Proto.Actor/LocalContext.cs
@@ -79,7 +79,6 @@ namespace Proto
                 var r = _message as MessageEnvelope;
                 return r != null ? r.Message : _message;
             }
-            private set => _message = value;
         }
 
         public PID Sender => (_message as MessageEnvelope)?.Sender;
@@ -345,12 +344,8 @@ namespace Proto
 
         private Task ProcessMessageAsync(object msg)
         {
-            Message = msg;
-            if (_receiveMiddleware != null)
-            {
-                return _receiveMiddleware(this);
-            }
-            return DefaultReceive(this);
+            _message = msg;
+            return _receiveMiddleware != null ? _receiveMiddleware(this) : DefaultReceive(this);
         }
 
         public void Tell(PID target, object message)


### PR DESCRIPTION
This is a very minor clean up.
It removes the LocalContext.Message setter in favor for the LocalContext _message.

The reason for this is that `_message` contains the raw message, be it a message or a MessageEnvelope.
The Message, Sender and Headers properties then unwrap the message if it is a MessageEnvelope.

So the three different properties are getters only that unwraps potential envelopes.
Thus, it makes sense to just store the message directly via the field.