### PR TITLE
Persistence refactor

### DIFF
--- a/src/Proto.Persistence/IPersistentActor.cs
+++ b/src/Proto.Persistence/IPersistentActor.cs
@@ -9,5 +9,6 @@ namespace Proto.Persistence
     public interface IPersistentActor : IActor
     {
         Persistence Persistence { get; set; }
+        void UpdateState(object message);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/AsynkronIT/protoactor-dotnet/issues/171

- Add UpdateState method to IPersistentActor
- Added base types for Event and Snapshot so that if you don't care about PersistedEvent vs RecoverEvent or PersistedSnapshot vs RecoveredSnapshot you don't have to - you can just look for Event and Snapshot 
- Updated example and tests

NOTE: I considered having the IPersistentActor interface look like

```
public interface IPersistentActor : IActor
     {		     
         {
             Persistence Persistence { get; set; }		         
             void Apply(Event @event)
             void Apply(Snapshot snapshot);
         }		     
     }
```

but didn't want to force consumers to implement Apply(Snapshot snapshot) as snapshots are not always used.  