### PR TITLE
removed RecoveryStarted and Completed messages due to un-needed

### DIFF
--- a/examples/Persistence/Persistence/Program.cs
+++ b/examples/Persistence/Persistence/Program.cs
@@ -12,6 +12,7 @@ using Proto.Persistence;
 using Proto.Persistence.Sqlite;
 using Event = Proto.Persistence.Event;
 using Snapshot = Proto.Persistence.Snapshot;
+using System.Text;
 
 class Program
 {
@@ -51,7 +52,11 @@ class Program
             switch (@event)
             {
                 case RecoverEvent msg:
-                    Console.WriteLine("MyPersistenceActor - RecoverEvent = Event.Index = {0}, Event.Data = {1}", msg.Index, msg.Data);
+                    if(msg.Data is RenameEvent re)
+                    {
+                        _state.Name = re.Name;
+                        Console.WriteLine("MyPersistenceActor - RecoverEvent = Event.Index = {0}, Event.Data = {1}", msg.Index, msg.Data);
+                    }
                     break;
                 case PersistedEvent msg:
                     Console.WriteLine("MyPersistenceActor - PersistedEvent = Event.Index = {0}, Event.Data = {1}", msg.Index, msg.Data);
@@ -89,36 +94,30 @@ class Program
 
                     Console.WriteLine("MyPersistenceActor - Started");
 
-                    context.Self.Tell(new StartLoopActor());
-
-                    break;
-                case RecoveryStarted msg:
-
-                    Console.WriteLine("MyPersistenceActor - RecoveryStarted");
-
-                    break;
-                case RecoveryCompleted msg:
-
-                    Console.WriteLine("MyPersistenceActor - RecoveryCompleted");
+                    Console.WriteLine("MyPersistenceActor - Current State: {0}", _state);
 
                     context.Self.Tell(new StartLoopActor());
 
                     break;
+     
                 case RequestSnapshot msg:
 
                     await Handle(context, msg);
 
                     break;
+
                 case TimeToSnapshot msg:
 
                     await Handle(context, msg);
 
                     break;
+
                 case StartLoopActor msg:
 
                     await Handle(context, msg);
 
                     break;
+
                 case RenameCommand msg:
 
                     await Handle(msg);
@@ -196,7 +195,7 @@ class Program
 
                     Task.Run(async () => {
                         
-                        context.Parent.Tell(new RenameCommand { Name = "Daniel" });
+                        context.Parent.Tell(new RenameCommand { Name = GeneratePronounceableName(5) });
 
                         await Task.Delay(TimeSpan.FromSeconds(2));
 
@@ -207,6 +206,26 @@ class Program
             }
 
             return Actor.Done;
+        }
+
+        static string GeneratePronounceableName(int length)
+        {
+            const string vowels = "aeiou";
+            const string consonants = "bcdfghjklmnpqrstvwxyz";
+
+            var rnd = new Random();
+            var name = new StringBuilder();
+
+            length = length % 2 == 0 ? length : length + 1;
+
+            for (var i = 0; i < length / 2; i++)
+            {
+                name
+                    .Append(vowels[rnd.Next(vowels.Length)])
+                    .Append(consonants[rnd.Next(consonants.Length)]);
+            }
+
+            return name.ToString();
         }
     }
 }

--- a/src/Proto.Persistence/Persistence.cs
+++ b/src/Proto.Persistence/Persistence.cs
@@ -23,8 +23,6 @@ namespace Proto.Persistence
             _context = context;
             _actor = actor;
 
-            await _context.ReceiveAsync(new RecoveryStarted());
-
             var (snapshot, index) = await _state.GetSnapshotAsync(ActorId);
 
             if (snapshot != null)
@@ -38,8 +36,6 @@ namespace Proto.Persistence
                 Index++;
                 _actor.UpdateState(new RecoverEvent(@event, Index));
             });
-            
-            await _context.ReceiveAsync(new RecoveryCompleted());
         }
 
         public async Task PersistEventAsync(object @event)
@@ -74,13 +70,14 @@ namespace Proto.Persistence
                 switch (context.Message)
                 {
                     case Started _:
-                        if(context.Actor is IPersistentActor actor)
+                        if (context.Actor is IPersistentActor actor)
                         {
                             actor.Persistence = new Persistence();
                             await actor.Persistence.InitAsync(provider, context, actor);
                         }
                         break;
                 }
+                
                 await next(context);
             };
         }

--- a/src/Proto.Persistence/Persistence.cs
+++ b/src/Proto.Persistence/Persistence.cs
@@ -110,9 +110,6 @@ namespace Proto.Persistence
         }
     }
 
-    public class RecoveryStarted { }
-    public class RecoveryCompleted { }
-
     public class Event
     {
         public object Data { get; }


### PR DESCRIPTION
Due to new changes in the api (updatestate) we don't need to send messages for recoverystarted and recoverycompleted anymore.