### PR TITLE
Remove call to _actor.UpdateState on taking a snapshot and update exa…

### DIFF
--- a/examples/Persistence/Persistence/Program.cs
+++ b/examples/Persistence/Persistence/Program.cs
@@ -70,9 +70,6 @@ class Program
                         Console.WriteLine("MyPersistenceActor - RecoverSnapshot = Snapshot.Index = {0}, Snapshot.State = {1}", Persistence.Index, ss.Name);
                     }
                     break;
-                case PersistedSnapshot msg:
-                    Console.WriteLine("MyPersistenceActor - PersistedSnapshot = Snapshot.Index = {0}, Snapshot.State = {1}", msg.Index, msg.State);
-                    break;
             }
         }
 
@@ -132,7 +129,7 @@ class Program
             Console.WriteLine("MyPersistenceActor - RequestSnapshot");
 
             await Persistence.PersistSnapshotAsync(_state);
-
+            Console.WriteLine("MyPersistenceActor - PersistedSnapshot = Snapshot.Index = {0}, Snapshot.State = {1}", Persistence.Index, _state);
             context.Self.Tell(new TimeToSnapshot());
         }
 

--- a/src/Proto.Persistence/Persistence.cs
+++ b/src/Proto.Persistence/Persistence.cs
@@ -54,7 +54,6 @@ namespace Proto.Persistence
         {
             var index = Index;
             await _state.PersistSnapshotAsync(ActorId, index, snapshot);
-            _actor.UpdateState(new PersistedSnapshot(snapshot, index));
         }
 
         public async Task DeleteSnapshotsAsync(long inclusiveToIndex)


### PR DESCRIPTION
…mple app

- we shouldn't be calling _actor.UpdateState(new PersistedSnapshot(snapshot, index)) after taking a snapshot, as there is nothing to update

- I updated the example app to write to the console after taking a snapshot to preserve existing behaviour  