### PR TITLE
Snapshot strategies

### DIFF
--- a/src/Proto.Persistence/ISnapshotStrategy.cs
+++ b/src/Proto.Persistence/ISnapshotStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Proto.Persistence
+{
+    public interface ISnapshotStrategy
+    {
+        bool ShouldTakeSnapshot(PersistedEvent persistedEvent);
+    }
+}

--- a/src/Proto.Persistence/Persistence.cs
+++ b/src/Proto.Persistence/Persistence.cs
@@ -15,54 +15,50 @@ namespace Proto.Persistence
         private readonly IProviderState _state;
         private readonly Action<Event> _applyEvent;
         private readonly Action<Snapshot> _applySnapshot;
+        private readonly Func<object> _getState;
+        private readonly ISnapshotStrategy _snapshotStrategy;
         private bool UsingSnapshotting => _applySnapshot != null;
         private bool UsingEventSourcing => _applyEvent != null;
         private readonly string _actorId;
 
-        /// <summary>
-        /// Provides Event Sourcing and snapshotting functionality to persist an actor's state.
-        /// </summary>
-        /// <param name="provider">The database provider to use for persistence</param>
-        /// <param name="actorId">The id of the actor. This should be a unique string</param>
-        /// <param name="applyEvent"></param>
-        /// <param name="applySnapshot"></param>
-        private Persistence(IProvider provider, string actorId, Action<Event> applyEvent = null, Action<Snapshot> applySnapshot = null)
+        private Persistence(IProvider provider, string actorId, Action<Event> applyEvent = null, 
+            Action<Snapshot> applySnapshot = null, ISnapshotStrategy snapshotStrategy = null, Func<object> getState = null)
         {
             _actorId = actorId;
             _state = provider.GetState();
             _applyEvent = applyEvent;
             _applySnapshot = applySnapshot;
+            _getState = getState;
+            _snapshotStrategy = snapshotStrategy ?? new NoSnapshots();
         }
 
         public static Persistence WithEventSourcing(IProvider provider, string actorId, Action<Event> applyEvent)
         {
-            if (applyEvent == null)
-            {
-                throw new ArgumentNullException(nameof(applyEvent));
-            }
-            return new Persistence(provider, actorId, applyEvent, null);
+            if (applyEvent == null) throw new ArgumentNullException(nameof(applyEvent));
+            return new Persistence(provider, actorId, applyEvent);
         }
 
         public static Persistence WithSnapshotting(IProvider provider, string actorId, Action<Snapshot> applySnapshot)
         {
-            if (applySnapshot == null)
-            {
-                throw new ArgumentNullException(nameof(applySnapshot));
-            }
+            if (applySnapshot == null) throw new ArgumentNullException(nameof(applySnapshot));
             return new Persistence(provider, actorId, null, applySnapshot);
         }
 
         public static Persistence WithEventSourcingAndSnapshotting(IProvider provider, string actorId, Action<Event> applyEvent, Action<Snapshot> applySnapshot)
         {
-            if (applyEvent == null)
-            {
-                throw new ArgumentNullException(nameof(applyEvent));
-            }
-            if (applySnapshot == null)
-            {
-                throw new ArgumentNullException(nameof(applySnapshot));
-            }
+            if (applyEvent == null) throw new ArgumentNullException(nameof(applyEvent));
+            if (applySnapshot == null) throw new ArgumentNullException(nameof(applySnapshot));
             return new Persistence(provider, actorId, applyEvent, applySnapshot);
+        }
+
+        public static Persistence WithEventSourcingAndSnapshotting(IProvider provider, string actorId, Action<Event> applyEvent, 
+            Action<Snapshot> applySnapshot, ISnapshotStrategy snapshotStrategy, Func<object> getState)
+        {
+            if (applyEvent == null) throw new ArgumentNullException(nameof(applyEvent));
+            if (applySnapshot == null) throw new ArgumentNullException(nameof(applySnapshot));
+            if (snapshotStrategy == null) throw new ArgumentNullException(nameof(snapshotStrategy));
+            if (getState == null) throw new ArgumentNullException(nameof(getState));
+            return new Persistence(provider, actorId, applyEvent, applySnapshot, snapshotStrategy, getState);
         }
 
         public async Task RecoverStateAsync()
@@ -96,7 +92,12 @@ namespace Proto.Persistence
             }
             Index++;
             await _state.PersistEventAsync(_actorId, Index, @event);
-            _applyEvent(new PersistedEvent(@event, Index));
+            var persistedEvent = new PersistedEvent(@event, Index);
+            _applyEvent(persistedEvent);
+            if (_snapshotStrategy.ShouldTakeSnapshot(persistedEvent))
+            {
+                await _state.PersistSnapshotAsync(_actorId, Index, _getState());
+            }
         }
 
         public async Task PersistSnapshotAsync(object snapshot)
@@ -112,6 +113,14 @@ namespace Proto.Persistence
         public async Task DeleteEventsAsync(long inclusiveToIndex)
         {
             await _state.DeleteEventsAsync(_actorId, inclusiveToIndex);
+        }
+
+        private class NoSnapshots : ISnapshotStrategy
+        {
+            public bool ShouldTakeSnapshot(PersistedEvent persistedEvent)
+            {
+                return false;
+            }
         }
     }
 

--- a/src/Proto.Persistence/SnapshotStrategies/EventTypeStrategy.cs
+++ b/src/Proto.Persistence/SnapshotStrategies/EventTypeStrategy.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Proto.Persistence.SnapshotStrategies
+{
+    public class EventTypeStrategy : ISnapshotStrategy
+    {
+        private readonly Type _eventType;
+
+        public EventTypeStrategy(Type eventType)
+        {
+            _eventType = eventType;
+        }
+        public bool ShouldTakeSnapshot(PersistedEvent persistedEvent)
+        {
+            return persistedEvent.Data.GetType() == _eventType;
+        }
+    }
+}

--- a/src/Proto.Persistence/SnapshotStrategies/IntervalStrategy.cs
+++ b/src/Proto.Persistence/SnapshotStrategies/IntervalStrategy.cs
@@ -1,0 +1,17 @@
+namespace Proto.Persistence.SnapshotStrategies
+{
+    public class IntervalStrategy : ISnapshotStrategy
+    {
+        private readonly int _eventsPerSnapshot;
+
+        public IntervalStrategy(int eventsPerSnapshot)
+        {
+            _eventsPerSnapshot = eventsPerSnapshot;
+        }
+
+        public bool ShouldTakeSnapshot(PersistedEvent persistedEvent)
+        {
+            return persistedEvent.Index % _eventsPerSnapshot == 0;
+        }
+    }
+}

--- a/src/Proto.Persistence/SnapshotStrategies/TimeStrategy.cs
+++ b/src/Proto.Persistence/SnapshotStrategies/TimeStrategy.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Proto.Persistence.SnapshotStrategies
+{
+    public class TimeStrategy : ISnapshotStrategy
+    {
+        private readonly TimeSpan _interval;
+        private readonly Func<DateTime> _getNow;
+        private DateTime _lastTaken;
+
+        public TimeStrategy(TimeSpan interval, Func<DateTime> getNow = null)
+        {
+            _interval = interval;
+            _getNow = getNow ?? (() => DateTime.Now);
+            _lastTaken = _getNow();
+        }
+
+        public bool ShouldTakeSnapshot(PersistedEvent persistedEvent)
+        {
+            var now = _getNow();
+            if (_lastTaken.Add(_interval) <= now)
+            {
+                _lastTaken = now;
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/tests/Proto.Persistence.Tests/ExamplePersistentActorTests.cs
+++ b/tests/Proto.Persistence.Tests/ExamplePersistentActorTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Dynamic;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Proto.TestFixtures;

--- a/tests/Proto.Persistence.Tests/InMemoryProviderState.cs
+++ b/tests/Proto.Persistence.Tests/InMemoryProviderState.cs
@@ -19,6 +19,10 @@ namespace Proto.Persistence.Tests
 
         private readonly ConcurrentDictionary<string, Dictionary<long, object>> _snapshots = new ConcurrentDictionary<string, Dictionary<long, object>>();
 
+        public Dictionary<long, object> GetSnapshots(string actorId)
+        {
+            return _snapshots[actorId];
+        }
         public Task<(object Snapshot, long Index)> GetSnapshotAsync(string actorName)
         {
             if (!_snapshots.TryGetValue(actorName, out Dictionary<long, object> snapshots))

--- a/tests/Proto.Persistence.Tests/PersistenceWithSnapshotStrategiesTests.cs
+++ b/tests/Proto.Persistence.Tests/PersistenceWithSnapshotStrategiesTests.cs
@@ -1,0 +1,31 @@
+using System;
+using Proto.Persistence.SnapshotStrategies;
+using Xunit;
+
+namespace Proto.Persistence.Tests
+{
+    public class PersistenceWithSnapshotStrategiesTests
+    {
+        [Fact]
+        public async void GivenAnIntervalStrategy_ShouldSaveSnapshotAccordingly()
+        {
+            var state = 1;
+            var inMemoryProviderState = new InMemoryProviderState();
+            var provider = new InMemoryProvider(inMemoryProviderState);
+            var actorId = Guid.NewGuid().ToString();
+            var persistence = Persistence.WithEventSourcingAndSnapshotting(provider, actorId, 
+                @event => { state = state * (@event.Data as Multiplied).Amount; },
+                snapshot => { state = (int)snapshot.State; }, 
+                new IntervalStrategy(1), () => state);
+
+            await persistence.PersistEventAsync(new Multiplied { Amount = 2 });
+            await persistence.PersistEventAsync(new Multiplied { Amount = 2 });
+            await persistence.PersistEventAsync(new Multiplied { Amount = 2 });
+            var snapshots = inMemoryProviderState.GetSnapshots(actorId);
+            Assert.Equal(3, snapshots.Count);
+            Assert.Equal(2, snapshots[1]);
+            Assert.Equal(4, snapshots[2]);
+            Assert.Equal(8, snapshots[3]);
+        }
+    }
+}

--- a/tests/Proto.Persistence.Tests/SnapshotStrategies/EventTypeStrategyTests.cs
+++ b/tests/Proto.Persistence.Tests/SnapshotStrategies/EventTypeStrategyTests.cs
@@ -1,0 +1,16 @@
+using Proto.Persistence.SnapshotStrategies;
+using Xunit;
+
+namespace Proto.Persistence.Tests.SnapshotStrategies
+{
+    public class EventTypeStrategyTests
+    {
+        [Fact]
+        public void EventTypeStrategy_ShouldSnapshotAccordingToTheEventType()
+        {
+            var strategy = new EventTypeStrategy(typeof(int));
+            Assert.True(strategy.ShouldTakeSnapshot(new PersistedEvent(1, 0)));
+            Assert.False(strategy.ShouldTakeSnapshot(new PersistedEvent("not an int", 0)));
+        }
+    }
+}

--- a/tests/Proto.Persistence.Tests/SnapshotStrategies/IntervalStrategyTests.cs
+++ b/tests/Proto.Persistence.Tests/SnapshotStrategies/IntervalStrategyTests.cs
@@ -1,0 +1,29 @@
+﻿using System.Linq;
+using Proto.Persistence.SnapshotStrategies;
+using Xunit;
+
+namespace Proto.Persistence.Tests.SnapshotStrategies
+{
+    public class IntervalStrategyTests
+    {
+        [Theory]
+        [InlineData(1, new[] { 1, 2, 3, 4, 5 })]
+        [InlineData(2, new[] { 2, 4, 6, 8, 10 })]
+        [InlineData(5, new[] { 5, 10, 15, 20, 25 })]
+        public void IntervalStrategy_ShouldSnapshotAccordingToTheInterval(int interval, int[] expected)
+        {
+            var strategy = new IntervalStrategy(interval);
+            for (int index = 1; index <= expected.Last(); index++)
+            {
+                if (expected.Contains(index))
+                {
+                    Assert.True(strategy.ShouldTakeSnapshot(new PersistedEvent(null, index)));
+                }
+                else
+                {
+                    Assert.False(strategy.ShouldTakeSnapshot(new PersistedEvent(null, index)));
+                }
+            }
+        }
+    }
+}

--- a/tests/Proto.Persistence.Tests/SnapshotStrategies/TimeStrategyTests.cs
+++ b/tests/Proto.Persistence.Tests/SnapshotStrategies/TimeStrategyTests.cs
@@ -1,0 +1,25 @@
+using System;
+using Proto.Persistence.SnapshotStrategies;
+using Xunit;
+
+namespace Proto.Persistence.Tests.SnapshotStrategies
+{
+    public class TimeStrategyTests
+    {
+        [Fact]
+        public void TimeStrategy_ShouldSnapshotAccordingToTheInterval()
+        {
+            var now = DateTime.Parse("2000-01-01 12:00:00");
+            var strategy = new TimeStrategy(TimeSpan.FromSeconds(10), () => now);
+            Assert.False(strategy.ShouldTakeSnapshot(new PersistedEvent(null, 0)));
+            now = now.AddSeconds(5);
+            Assert.False(strategy.ShouldTakeSnapshot(new PersistedEvent(null, 0)));
+            now = now.AddSeconds(5);
+            Assert.True(strategy.ShouldTakeSnapshot(new PersistedEvent(null, 0)));
+            now = now.AddSeconds(5);
+            Assert.False(strategy.ShouldTakeSnapshot(new PersistedEvent(null, 0)));
+            now = now.AddSeconds(5);
+            Assert.True(strategy.ShouldTakeSnapshot(new PersistedEvent(null, 0)));
+        }
+    }
+}


### PR DESCRIPTION
Adds functionality for automatically saving snapshots according to a strategy. This takes the burden away from the actor for having to save snapshots. Supported strategies are

- Interval strategy: save snapshot every N events, i.e. every 100 events
- Time strategy: save snapshot based upon a timeframe, i.e. every day
- EventType strategy: save snapshot when a certain event type is seen i.e. ReallyImportantEvent

Snapshot strategies are an optional feature available when using Event sourcing and Snapshotting together only (it makes no sense to use them in the other supported modes)