### PR TITLE
fix issue with persistence when recovering state

### DIFF
--- a/src/Proto.Persistence/Persistence.cs
+++ b/src/Proto.Persistence/Persistence.cs
@@ -76,7 +76,7 @@ namespace Proto.Persistence
 
             if (UsingEventSourcing)
             {
-                await _provider.GetEventsAsync(_actorId, Index, @event =>
+                await _provider.GetEventsAsync(_actorId, Index + 1, @event =>
                 {
                     Index++;
                     _applyEvent(new RecoverEvent(@event, Index));

--- a/tests/Proto.Persistence.Tests/InMemoryProvider.cs
+++ b/tests/Proto.Persistence.Tests/InMemoryProvider.cs
@@ -36,7 +36,7 @@ namespace Proto.Persistence.Tests
         {
             if (_events.TryGetValue(actorName, out Dictionary<long, object> events))
             {
-                foreach (var e in events.Where(e => e.Key > indexStart))
+                foreach (var e in events.Where(e => e.Key >= indexStart))
                 {
                     callback(e.Value);
                 }


### PR DESCRIPTION
After loading a snapshot, the recover state method would then attempt to replay events from the index that the snapshot was taken at (i.e. 10). However, it would include the last event the snapshot was taken at (i.e. 10!) which isn't correct - it should replay events from the next index (i.e. 11)

example
what happened: 1,2,3,4,Snapshot,5,6
recover state: snapshot,4,5,6 < THE 4 HERE IS WRONG

should be:
what happened: 1,2,3,4,Snapshot,5,6
recover state: snapshot,5,6
