### PR TITLE
Persistence API - Allow replaying of events within a range

### DIFF
--- a/src/PersistenceProviders/Proto.Persistence.Couchbase/CouchbaseProvider.cs
+++ b/src/PersistenceProviders/Proto.Persistence.Couchbase/CouchbaseProvider.cs
@@ -20,28 +20,20 @@ namespace Proto.Persistence.Couchbase
         {
             _bucket = bucket;
         }
-
-        public Task GetEventsAsync(string actorName, long indexStart, Action<object> callback)
-        {
-            var q = GenerateGetEventsQuery(actorName, indexStart);
-            return ExecuteGetEventsQueryAsync(q, callback);
-        }
-
+        
         public Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
         {
             var q = GenerateGetEventsQuery(actorName, indexStart, indexEnd);
             return ExecuteGetEventsQueryAsync(q, callback);
         }
 
-        private string GenerateGetEventsQuery(string actorName, long indexStart, long? indexEnd = null)
+        private string GenerateGetEventsQuery(string actorName, long indexStart, long indexEnd)
         {
-            var s = $"SELECT b.* FROM `{_bucket.Name}` b WHERE b.actorName = '{actorName}' AND b.type = 'event' AND b.eventIndex >= {indexStart} ";
-            if (indexEnd.HasValue)
-            {
-                s += $"AND b.eventIndex <= {indexEnd.Value} ";
-            } 
-            s += "ORDER BY b.eventIndex ASC";
-            return s;
+            return $"SELECT b.* FROM `{_bucket.Name}` b WHERE b.actorName = '{actorName}' " +
+                   "AND b.type = 'event' " +
+                   $"AND b.eventIndex >= {indexStart} " +
+                   $"AND b.eventIndex <= {indexEnd} " +
+                   "ORDER BY b.eventIndex ASC";
         }
 
         private async Task ExecuteGetEventsQueryAsync(string query, Action<object> callback)

--- a/src/PersistenceProviders/Proto.Persistence.Marten/MartenProvider.cs
+++ b/src/PersistenceProviders/Proto.Persistence.Marten/MartenProvider.cs
@@ -13,24 +13,14 @@ namespace Proto.Persistence.Marten
         {
             _store = store;
         }
-
-        public Task GetEventsAsync(string actorName, long indexStart, Action<object> callback)
-        {
-            return GetEventsAsync(actorName, x => x.Index >= indexStart, callback);
-        }
-
-        public Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
-        {
-            return GetEventsAsync(actorName, x => x.Index >= indexStart && x.Index <= indexEnd, callback);
-        }
-
-        private async Task GetEventsAsync(string actorName, System.Linq.Expressions.Expression<Func<Event, bool>> filterIndexPredicate, Action<object> callback)
+        
+        public async Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
         {
             using (var session = _store.OpenSession())
             {
                 var events = await session.Query<Event>()
                     .Where(x => x.ActorName == actorName)
-                    .Where(filterIndexPredicate)
+                    .Where(x => x.Index >= indexStart && x.Index <= indexEnd)
                     .OrderBy(x => x.Index)
                     .ToListAsync();
 
@@ -40,6 +30,7 @@ namespace Proto.Persistence.Marten
                 }
             }
         }
+
         public async Task<(object Snapshot, long Index)> GetSnapshotAsync(string actorName)
         {
             using (var session = _store.OpenSession())

--- a/src/PersistenceProviders/Proto.Persistence.MongoDB/MongoDBProvider.cs
+++ b/src/PersistenceProviders/Proto.Persistence.MongoDB/MongoDBProvider.cs
@@ -18,23 +18,12 @@ namespace Proto.Persistence.MongoDB
         {
             _mongoDB = mongoDB;
         }
-
-        public Task GetEventsAsync(string actorName, long indexStart, Action<object> callback)
-        {
-            return GetEventsAsync(actorName, e => e.ActorName == actorName && e.EventIndex >= indexStart, callback);
-        }
-
-        public Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
-        {
-            return GetEventsAsync(actorName,
-                e => e.ActorName == actorName && e.EventIndex >= indexStart && e.EventIndex <= indexEnd, callback);
-        }
-
-        private async Task GetEventsAsync(string actorName, System.Linq.Expressions.Expression<Func<Event, bool>> filterIndexPredicate, Action<object> callback)
+        
+        public async Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
         {
             var sort = Builders<Event>.Sort.Ascending("eventIndex");
             var events = await EventCollection
-                .Find(filterIndexPredicate)
+                .Find(e => e.ActorName == actorName && e.EventIndex >= indexStart && e.EventIndex <= indexEnd)
                 .Sort(sort)
                 .ToListAsync();
 

--- a/src/PersistenceProviders/Proto.Persistence.RavenDB/RavenDBProvider.cs
+++ b/src/PersistenceProviders/Proto.Persistence.RavenDB/RavenDBProvider.cs
@@ -25,24 +25,14 @@ namespace Proto.Persistence.RavenDB
             await IndexCreation.CreateIndexesAsync(typeof(DeleteEventIndex).Assembly(), _store);
             await IndexCreation.CreateIndexesAsync(typeof(DeleteSnapshotIndex).Assembly(), _store);
         }
-
-        public Task GetEventsAsync(string actorName, long indexStart, Action<object> callback)
-        {
-            return GetEventsAsync(actorName, x => x.Index >= indexStart, callback);
-        }
-
-        public Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
-        {
-            return GetEventsAsync(actorName, x => x.Index >= indexStart && x.Index <= indexEnd, callback);
-        }
-
-        private async Task GetEventsAsync(string actorName, System.Linq.Expressions.Expression<Func<Event, bool>> filterIndexPredicate, Action<object> callback)
+        
+        public async Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
         {
             using (var session = _store.OpenAsyncSession())
             {
                 var events = await session.Query<Event>()
                     .Where(x => x.ActorName == actorName)
-                    .Where(filterIndexPredicate)
+                    .Where(x => x.Index >= indexStart && x.Index <= indexEnd)
                     .OrderBy(x => x.Index)
                     .ToListAsync();
 

--- a/src/PersistenceProviders/Proto.Persistence.Sqlite/SqliteProvider.cs
+++ b/src/PersistenceProviders/Proto.Persistence.Sqlite/SqliteProvider.cs
@@ -69,17 +69,7 @@ namespace Proto.Persistence.Sqlite
             }
         }
 
-        public Task GetEventsAsync(string actorName, long indexStart, Action<object> callback)
-        {
-            return GetEventsAsync(actorName, x => x.EventIndex >= indexStart, callback);
-        }
-
         public Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
-        {
-            return GetEventsAsync(actorName, x => x.EventIndex >= indexStart && x.EventIndex <= indexEnd, callback);
-        }
-
-        private Task GetEventsAsync(string actorName, System.Linq.Expressions.Expression<Func<Event, bool>> indexFilterPredicate, Action<object> callback)
         {
             try
             {
@@ -87,7 +77,7 @@ namespace Proto.Persistence.Sqlite
                 {
                     var items = db.Events
                         .Where(x => x.ActorName == actorName)
-                        .Where(indexFilterPredicate)
+                        .Where(x => x.EventIndex >= indexStart && x.EventIndex <= indexEnd)
                         .ToList();
 
                     foreach (var item in items)

--- a/src/PersistenceProviders/Proto.Persistence.Sqlite/SqliteProvider.cs
+++ b/src/PersistenceProviders/Proto.Persistence.Sqlite/SqliteProvider.cs
@@ -71,14 +71,24 @@ namespace Proto.Persistence.Sqlite
 
         public Task GetEventsAsync(string actorName, long indexStart, Action<object> callback)
         {
+            return GetEventsAsync(actorName, x => x.EventIndex >= indexStart, callback);
+        }
+
+        public Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+        {
+            return GetEventsAsync(actorName, x => x.EventIndex >= indexStart && x.EventIndex <= indexEnd, callback);
+        }
+
+        private Task GetEventsAsync(string actorName, System.Linq.Expressions.Expression<Func<Event, bool>> indexFilterPredicate, Action<object> callback)
+        {
             try
             {
                 using (var db = new SqlitePersistenceContext(_datasource))
                 {
                     var items = db.Events
-                                    .Where(x => x.ActorName == actorName)
-                                    .Where(x => x.EventIndex >= indexStart)
-                                    .ToList();
+                        .Where(x => x.ActorName == actorName)
+                        .Where(indexFilterPredicate)
+                        .ToList();
 
                     foreach (var item in items)
                     {

--- a/src/Proto.Persistence/IProvider.cs
+++ b/src/Proto.Persistence/IProvider.cs
@@ -11,7 +11,6 @@ namespace Proto.Persistence
 {
     public interface IProvider
     {
-        Task GetEventsAsync(string actorName, long indexStart, Action<object> callback);
         Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback);
         Task<(object Snapshot, long Index)> GetSnapshotAsync(string actorName);
         Task PersistEventAsync(string actorName, long index, object @event);

--- a/src/Proto.Persistence/IProvider.cs
+++ b/src/Proto.Persistence/IProvider.cs
@@ -12,6 +12,7 @@ namespace Proto.Persistence
     public interface IProvider
     {
         Task GetEventsAsync(string actorName, long indexStart, Action<object> callback);
+        Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback);
         Task<(object Snapshot, long Index)> GetSnapshotAsync(string actorName);
         Task PersistEventAsync(string actorName, long index, object @event);
         Task PersistSnapshotAsync(string actorName, long index, object snapshot);

--- a/src/Proto.Persistence/Persistence.cs
+++ b/src/Proto.Persistence/Persistence.cs
@@ -80,7 +80,7 @@ namespace Proto.Persistence
 
             if (UsingEventSourcing)
             {
-                await _provider.GetEventsAsync(_actorId, Index + 1, @event =>
+                await _provider.GetEventsAsync(_actorId, Index + 1, long.MaxValue, @event =>
                 {
                     Index++;
                     _applyEvent(new RecoverEvent(@event, Index));

--- a/src/Proto.Persistence/Persistence.cs
+++ b/src/Proto.Persistence/Persistence.cs
@@ -60,7 +60,11 @@ namespace Proto.Persistence
             if (getState == null) throw new ArgumentNullException(nameof(getState));
             return new Persistence(provider, actorId, applyEvent, applySnapshot, snapshotStrategy, getState);
         }
-
+        
+        /// <summary>
+        /// Recovers the actor to the latest state
+        /// </summary>
+        /// <returns></returns>
         public async Task RecoverStateAsync()
         {
             if (UsingSnapshotting)
@@ -83,7 +87,25 @@ namespace Proto.Persistence
                 });
             }
         }
-        
+
+        /// <summary>
+        /// Allows the replaying of events to rebuild state from a range. For example, if we want to replay until just before something happened 
+        /// (i.e. unexpected behavior of the system, bug, crash etc..) then apply some messages and observe what happens.
+        /// </summary>
+        public async Task ReplayEvents(long fromIndex, long toIndex)
+        {
+            if (!UsingEventSourcing)
+            {
+                throw new Exception("Events cannot be replayed without using Event Sourcing.");
+            }
+
+            await _provider.GetEventsAsync(_actorId, fromIndex, toIndex, @event =>
+                {
+                    Index++;
+                    _applyEvent(new RecoverEvent(@event, Index));
+                });
+        }
+
         public async Task PersistEventAsync(object @event)
         {
             if (!UsingEventSourcing)

--- a/tests/Proto.Persistence.Tests/ExamplePersistentActorTests.cs
+++ b/tests/Proto.Persistence.Tests/ExamplePersistentActorTests.cs
@@ -16,7 +16,7 @@ namespace Proto.Persistence.Tests
             var (pid, _, actorId, providerState) = CreateTestActor();
             pid.Tell(new Multiply { Amount = 2 });
             await providerState
-                .GetEventsAsync(actorId, 0, o =>
+                .GetEventsAsync(actorId, 0, long.MaxValue, o =>
                 {
                     Assert.IsType(typeof(Multiplied), o);
                     Assert.Equal(2, (o as Multiplied).Amount);
@@ -41,7 +41,7 @@ namespace Proto.Persistence.Tests
             pid.Tell(new Multiply { Amount = 10 });
             await providerState.DeleteEventsAsync(actorId, 1);
             var events = new List<object>();
-            await providerState.GetEventsAsync(actorId, 0, v => events.Add(v));
+            await providerState.GetEventsAsync(actorId, 0, long.MaxValue, v => events.Add(v));
 
             Assert.Equal(0, events.Count);
         }

--- a/tests/Proto.Persistence.Tests/ExamplePersistentActorTests.cs
+++ b/tests/Proto.Persistence.Tests/ExamplePersistentActorTests.cs
@@ -187,6 +187,22 @@ namespace Proto.Persistence.Tests
             Assert.Equal(InitialState * 2 * 4, state);
         }
 
+        [Fact]
+        public async void GivenEvents_CanReplayFromStartIndexToEndIndex()
+        {
+            var (pid, props, actorId, providerState) = CreateTestActor();
+
+            pid.Tell(new Multiply { Amount = 2 });
+            pid.Tell(new Multiply { Amount = 2 });
+            pid.Tell(new Multiply { Amount = 4 });
+            pid.Tell(new Multiply { Amount = 8 });
+            var messages = new List<object>();
+            await providerState.GetEventsAsync(actorId, 2, 3, msg => messages.Add(msg));
+            Assert.Equal(2, messages.Count);
+            Assert.Equal(2, (messages[0] as Multiplied).Amount);
+            Assert.Equal(4, (messages[1] as Multiplied).Amount);
+        }
+
         private (PID pid, Props props, string actorId, IProvider provider) CreateTestActor()
         {
             var actorId = Guid.NewGuid().ToString();

--- a/tests/Proto.Persistence.Tests/InMemoryProvider.cs
+++ b/tests/Proto.Persistence.Tests/InMemoryProvider.cs
@@ -32,22 +32,11 @@ namespace Proto.Persistence.Tests
             return Task.FromResult((snapshot.Value, snapshot.Key));
         }
 
-        public Task GetEventsAsync(string actorName, long indexStart, Action<object> callback)
-        {
-            return GetEventsAsync(actorName, e => e.Key >= indexStart, callback);
-        }
-
         public Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
-        {
-            return GetEventsAsync(actorName, e => e.Key >= indexStart && e.Key <= indexEnd, callback);
-        }
-
-        private Task GetEventsAsync(string actorName, Func<KeyValuePair<long, object>, bool> predicate,
-            Action<object> callback)
         {
             if (_events.TryGetValue(actorName, out Dictionary<long, object> events))
             {
-                foreach (var e in events.Where(predicate))
+                foreach (var e in events.Where(e => e.Key >= indexStart && e.Key <= indexEnd))
                 {
                     callback(e.Value);
                 }

--- a/tests/Proto.Persistence.Tests/InMemoryProvider.cs
+++ b/tests/Proto.Persistence.Tests/InMemoryProvider.cs
@@ -34,9 +34,20 @@ namespace Proto.Persistence.Tests
 
         public Task GetEventsAsync(string actorName, long indexStart, Action<object> callback)
         {
+            return GetEventsAsync(actorName, e => e.Key >= indexStart, callback);
+        }
+
+        public Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+        {
+            return GetEventsAsync(actorName, e => e.Key >= indexStart && e.Key <= indexEnd, callback);
+        }
+
+        private Task GetEventsAsync(string actorName, Func<KeyValuePair<long, object>, bool> predicate,
+            Action<object> callback)
+        {
             if (_events.TryGetValue(actorName, out Dictionary<long, object> events))
             {
-                foreach (var e in events.Where(e => e.Key >= indexStart))
+                foreach (var e in events.Where(predicate))
                 {
                     callback(e.Value);
                 }


### PR DESCRIPTION
There are use cases (mainly debugging / testing) where it would be useful to be able to replay up to a certain index. For example, if we want to replay until just before something happened (i.e. unexpected behavior of the system, bug, crash, "the system went down at 12:00" etc..) then apply some messages and observe what happens.

closes #188