### PR TITLE
add mono path export to build.sh to fix build on mac

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,9 @@ CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
 PACKAGES_CONFIG=$TOOLS_DIR/packages.config
 PACKAGES_CONFIG_MD5=$TOOLS_DIR/packages.config.md5sum
 
+# Find mono
+export FrameworkPathOverride=$(dirname $(which mono))/../lib/mono/4.5.2-api/
+
 # Define md5sum or md5 depending on Linux/OSX
 MD5_EXE=
 if [[ "$(uname -s)" == "Darwin" ]]; then


### PR DESCRIPTION
As discussed here https://github.com/AsynkronIT/protoactor-dotnet/issues/223

note this PR doesn't do anything to address lowering the versions of netstandard we support, it just gets it building on mac. Would be good for someone else to test this on their mac :)