### PR TITLE
Avoid additional dictionary scans

### DIFF
--- a/src/Proto.Actor/MessageEnvelope.cs
+++ b/src/Proto.Actor/MessageEnvelope.cs
@@ -30,7 +30,7 @@
             {
                 return @default;
             }
-            return Header.ContainsKey(key) ? Header[key] : @default;
+            return Header.TryGetValue(key, out string value) ? value : @default;
         }
 
         public void SetHeader(string key, string value)

--- a/src/Proto.Actor/MessageHeader.cs
+++ b/src/Proto.Actor/MessageHeader.cs
@@ -8,11 +8,7 @@ namespace Proto
 
         public string GetOrDefault(string key, string @default = null)
         {
-            if (ContainsKey(key))
-            {
-                return this[key];
-            }
-            return @default;
+            return TryGetValue(key, out string value) ? value : @default;
         }
     }
 }

--- a/src/Proto.Remote/EndpointWriter.cs
+++ b/src/Proto.Remote/EndpointWriter.cs
@@ -56,20 +56,18 @@ namespace Proto.Remote
                     foreach(var rd in m)
                     {
                         var targetName = rd.Target.Id;
-                        if (!targetNames.ContainsKey(targetName))
+                        if (!targetNames.TryGetValue(targetName, out var targetId))
                         {
-                            targetNames.Add(targetName, typeNames.Count);
+                            targetId = targetNames[targetName] = typeNames.Count;
                             targetNameList.Add(targetName);
                         }
-                        var targetId = targetNames[targetName];
 
                         var typeName = rd.Message.Descriptor.File.Package + "." + rd.Message.Descriptor.Name;
-                        if (!typeNames.ContainsKey(typeName))
+                        if (!typeNames.TryGetValue(typeName, out var typeId))
                         {
-                            typeNames.Add(typeName, typeNames.Count);
+                            typeId = typeNames[typeName] = typeNames.Count;
                             typeNameList.Add(typeName);
                         }
-                        var typeId = typeNames[typeName];
 
                         var bytes = Serialization.Serialize(rd.Message);
                         var envelope = new MessageEnvelope


### PR DESCRIPTION
This PR replaces the ContainsKey/[] pattern with the TryGetValue
pattern. This avoids duplicate dictionary scans and may be a slight
performance improvement.