### PR TITLE
Rename props method WithSupervisor to WithChildSupervisorStrategy

### DIFF
--- a/examples/Supervision/Program.cs
+++ b/examples/Supervision/Program.cs
@@ -18,7 +18,7 @@ class Program
         Proto.Log.SetLoggerFactory(new LoggerFactory()
             .AddConsole(minLevel: LogLevel.Debug));
 
-        var props = Actor.FromProducer(() => new ParentActor()).WithSupervisor(new OneForOneStrategy(Decider.Decide, 1, null));
+        var props = Actor.FromProducer(() => new ParentActor()).WithChildSupervisorStrategy(new OneForOneStrategy(Decider.Decide, 1, null));
 
         var actor = Actor.Spawn(props);
         actor.Tell(new Hello

--- a/src/Proto.Actor/Props.cs
+++ b/src/Proto.Actor/Props.cs
@@ -55,7 +55,7 @@ namespace Proto
 
         public Props WithMailbox(Func<IMailbox> mailboxProducer) => Copy(props => props.MailboxProducer = mailboxProducer);
 
-        public Props WithSupervisor(ISupervisorStrategy supervisor) => Copy(props => props.SupervisorStrategy = supervisor);
+        public Props WithChildSupervisorStrategy(ISupervisorStrategy supervisorStrategy) => Copy(props => props.SupervisorStrategy = supervisorStrategy);
 
         public Props WithReceiveMiddleware(params Func<Receive, Receive>[] middleware) => Copy(props =>
         {

--- a/tests/Proto.Actor.Tests/DisposableActorTests.cs
+++ b/tests/Proto.Actor.Tests/DisposableActorTests.cs
@@ -30,10 +30,10 @@ namespace Proto.Tests
             var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 0, null);
             var childProps = Actor.FromProducer(() => new DisposableActor(() => disposeCalled = true))
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats))
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var props = Actor.FromProducer(() => new SupervisingActor(childProps))
                 .WithMailbox(() => new TestMailbox())
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var parentPID = Actor.Spawn(props);
             parentPID.Tell("crash");
             childMailboxStats.Reset.Wait(1000);
@@ -48,10 +48,10 @@ namespace Proto.Tests
             var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Resume, 0, null);
             var childProps = Actor.FromProducer(() => new DisposableActor(() => disposeCalled = true))
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats))
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var props = Actor.FromProducer(() => new SupervisingActor(childProps))
                 .WithMailbox(() => new TestMailbox())
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var parentPID = Actor.Spawn(props);
             parentPID.Tell("crash");
             childMailboxStats.Reset.Wait(1000);
@@ -71,7 +71,7 @@ namespace Proto.Tests
             var child2Props = Actor.FromProducer(() => new DisposableActor(() => child2Disposed = true))
                 .WithMailbox(() => UnboundedMailbox.Create(child2MailboxStats));
             var parentProps = Actor.FromProducer(() => new ParentWithMultipleChildrenActor(child1Props, child2Props))
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var parent = Actor.Spawn(parentProps);
 
             parent.Tell("crash");

--- a/tests/Proto.Actor.Tests/PropsTests.cs
+++ b/tests/Proto.Actor.Tests/PropsTests.cs
@@ -119,7 +119,7 @@ namespace Proto.Tests
             var supervision = new DoNothingSupervisorStrategy();
 
             var props = new Props();
-            var props2 = props.WithSupervisor(supervision);
+            var props2 = props.WithChildSupervisorStrategy(supervision);
 
             Assert.NotEqual(props, props2);
             Assert.Equal(supervision, props2.SupervisorStrategy);

--- a/tests/Proto.Actor.Tests/SupervisionTests_AllForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_AllForOne.cs
@@ -66,7 +66,7 @@ namespace Proto.Tests
             var child2Props = Actor.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(child2MailboxStats));
             var parentProps = Actor.FromProducer(() => new ParentActor(child1Props, child2Props))
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var parent = Actor.Spawn(parentProps);
 
             parent.Tell("hello");
@@ -89,7 +89,7 @@ namespace Proto.Tests
             var child2Props = Actor.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(child2MailboxStats));
             var parentProps = Actor.FromProducer(() => new ParentActor(child1Props, child2Props))
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var parent = Actor.Spawn(parentProps);
 
             parent.Tell("hello");
@@ -113,7 +113,7 @@ namespace Proto.Tests
             var child2Props = Actor.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(child2MailboxStats));
             var parentProps = Actor.FromProducer(() => new ParentActor(child1Props, child2Props))
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var parent = Actor.Spawn(parentProps);
 
             parent.Tell("hello");
@@ -137,7 +137,7 @@ namespace Proto.Tests
             var child2Props = Actor.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(child2MailboxStats));
             var parentProps = Actor.FromProducer(() => new ParentActor(child1Props, child2Props))
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var parent = Actor.Spawn(parentProps);
 
             parent.Tell("hello");
@@ -157,7 +157,7 @@ namespace Proto.Tests
             var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Escalate, 1, null);
             var childProps = Actor.FromProducer(() => new ChildActor());
             var parentProps = Actor.FromProducer(() => new ParentActor(childProps, childProps))
-                .WithSupervisor(strategy)
+                .WithChildSupervisorStrategy(strategy)
                 .WithMailbox(() => UnboundedMailbox.Create(parentMailboxStats));
             var parent = Actor.Spawn(parentProps);
 

--- a/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
@@ -69,7 +69,7 @@ namespace Proto.Tests
             var childProps = Actor.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
             var parentProps = Actor.FromProducer(() => new ParentActor(childProps))
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var parent = Actor.Spawn(parentProps);
 
             parent.Tell("hello");
@@ -87,7 +87,7 @@ namespace Proto.Tests
             var childProps = Actor.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
             var parentProps = Actor.FromProducer(() => new ParentActor(childProps))
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var parent = Actor.Spawn(parentProps);
 
             parent.Tell("hello");
@@ -105,7 +105,7 @@ namespace Proto.Tests
             var childProps = Actor.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
             var parentProps = Actor.FromProducer(() => new ParentActor(childProps))
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var parent = Actor.Spawn(parentProps);
 
             parent.Tell("hello");
@@ -123,7 +123,7 @@ namespace Proto.Tests
             var childProps = Actor.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
             var parentProps = Actor.FromProducer(() => new ParentActor(childProps))
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var parent = Actor.Spawn(parentProps);
 
             parent.Tell("hello");
@@ -141,7 +141,7 @@ namespace Proto.Tests
             var childProps = Actor.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
             var parentProps = Actor.FromProducer(() => new ParentActor(childProps))
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var parent = Actor.Spawn(parentProps);
 
             parent.Tell("hello");
@@ -158,7 +158,7 @@ namespace Proto.Tests
             var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Escalate, 1, null);
             var childProps = Actor.FromProducer(() => new ThrowOnStartedChildActor());
             var parentProps = Actor.FromProducer(() => new ParentActor(childProps))
-                .WithSupervisor(strategy)
+                .WithChildSupervisorStrategy(strategy)
                 .WithMailbox(() => UnboundedMailbox.Create(parentMailboxStats));
             var parent = Actor.Spawn(parentProps);
 
@@ -188,7 +188,7 @@ namespace Proto.Tests
             var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Escalate, 1, null);
             var childProps = Actor.FromProducer(() => new ChildActor());
             var parentProps = Actor.FromProducer(() => new ParentActor(childProps))
-                .WithSupervisor(strategy)
+                .WithChildSupervisorStrategy(strategy)
                 .WithMailbox(() => UnboundedMailbox.Create(parentMailboxStats));
             var parent = Actor.Spawn(parentProps);
 
@@ -207,7 +207,7 @@ namespace Proto.Tests
             var childProps = Actor.FromProducer(() => new ThrowOnStartedChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
             var parentProps = Actor.FromProducer(() => new ParentActor(childProps))
-                .WithSupervisor(strategy);
+                .WithChildSupervisorStrategy(strategy);
             var parent = Actor.Spawn(parentProps);
 
             childMailboxStats.Reset.Wait(1000);


### PR DESCRIPTION
This is to make it clearer that the supervision strategy you are creating is for the actor you are creating's children... i.e. Is-A supervisor rather than Has-A supervisor

Also has the advantage of appearing in intellisense still when you type With :)