### PR TITLE
Merge router actor and router process

### DIFF
--- a/src/Proto.Actor/LocalContext.cs
+++ b/src/Proto.Actor/LocalContext.cs
@@ -22,7 +22,7 @@ namespace Proto
         Stopping
     }
 
-    internal class LocalContext : IMessageInvoker, IContext, ISupervisor
+    public class LocalContext : IMessageInvoker, IContext, ISupervisor
     {
         private static ILogger Logger { get; } = Log.CreateLogger<LocalContext>();
         public static readonly IReadOnlyCollection<PID> EmptyChildren = new List<PID>();
@@ -64,7 +64,7 @@ namespace Proto
 
         public IActor Actor { get; private set; }
         public PID Parent { get; }
-        public PID Self { get; internal set; }
+        public PID Self { get; set; }
 
         public object Message
         {

--- a/src/Proto.Actor/Props.cs
+++ b/src/Proto.Actor/Props.cs
@@ -30,7 +30,7 @@ namespace Proto
             private set => _spawner = value;
         }
 
-        public static Spawner DefaultSpawner = (name, props, parent) =>
+        public static PID DefaultSpawner (string name,Props props,PID parent)
         {
             var ctx = new LocalContext(props.Producer, props.SupervisorStrategy, props.ReceiveMiddlewareChain, props.SenderMiddlewareChain, parent);
             var mailbox = props.MailboxProducer();
@@ -47,7 +47,7 @@ namespace Proto
             mailbox.Start();
 
             return pid;
-        };
+        }
 
         public Props WithProducer(Func<IActor> producer) => Copy(props => props.Producer = producer);
 

--- a/src/Proto.Router/RouterProcess.cs
+++ b/src/Proto.Router/RouterProcess.cs
@@ -1,42 +1,36 @@
 // -----------------------------------------------------------------------
-//  <copyright file="RouterProcess.cs" company="Asynkron HB">
-//      Copyright (C) 2015-2017 Asynkron HB All rights reserved
-//  </copyright>
+//   <copyright file="RouterProcess.cs" company="Asynkron HB">
+//       Copyright (C) 2015-2017 Asynkron HB All rights reserved
+//   </copyright>
 // -----------------------------------------------------------------------
 
+using Proto.Mailbox;
 using Proto.Router.Messages;
 using Proto.Router.Routers;
 
 namespace Proto.Router
 {
-    public class RouterProcess : Process
+    public class RouterProcess : LocalProcess
     {
-        private readonly PID _router;
         private readonly RouterState _state;
 
-        public RouterProcess(PID router, RouterState state)
+        public RouterProcess(RouterState state, IMailbox mailbox) : base(mailbox)
         {
-            _router = router;
             _state = state;
         }
 
         protected override void SendUserMessage(PID pid, object message)
         {
-            var env = MessageEnvelope.Unwrap(message);
-            switch (env.message)
+            var (msg,_,_) = MessageEnvelope.Unwrap(message);
+            switch (msg)
             {
                 case RouterManagementMessage _:
-                    _router.Tell(message);
+                    base.SendUserMessage(pid,message);
                     break;
                 default:
                     _state.RouteMessage(message);
                     break;
             }
-        }
-
-        protected override void SendSystemMessage(PID pid, object message)
-        {
-            _router.SendSystemMessage(message);
         }
     }
 }


### PR DESCRIPTION
This PR merges the router actor and the router process.
Previously, we had one router process then pointing to a separate router actor, with its own local process.

TLDR; the RouterProcess was a proxy before directing messages either to the router actor, or to the routees.
Now the router process and the router actor are the same thing