### PR TITLE
Cleanup Consul provider from Couchbase client

### DIFF
--- a/src/ClusterProviders/Proto.Cluster.Consul/Proto.Cluster.Consul.csproj
+++ b/src/ClusterProviders/Proto.Cluster.Consul/Proto.Cluster.Consul.csproj
@@ -21,7 +21,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Consul" Version="0.7.2.1" />
-    <PackageReference Include="CouchbaseNetClient" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Options">
       <Version>1.1.1</Version>
     </PackageReference>


### PR DESCRIPTION
The Consul provider has a reference to CouchbaseNetClient that is not needed.