### PR TITLE
Make a devbuild target.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ language: csharp
 solution: ProtoActor.sln
 matrix:
   include:
-    - dotnet: 1.0.0-preview4-004233
+    - dotnet: 1.0.4
       mono: none
       env: DOTNETCORE=1
 script:
-  - dotnet restore
-  - dotnet build
-  - dotnet test ./tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj
+  - ./build.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
 before_build:
 - nuget install Cake -ExcludeVersion
 build_script:
+- .\Cake\Cake.exe --target=Restore
 - .\Cake\Cake.exe --target=Build --buildNumber=%APPVEYOR_BUILD_NUMBER% --currentBranch=%APPVEYOR_REPO_BRANCH%
 test_script:
 - .\Cake\Cake.exe --target=UnitTest

--- a/build.cake
+++ b/build.cake
@@ -71,13 +71,6 @@ Task("Push")
     });
 
 Task("Default")
-    .IsDependentOn("PatchVersion")
-    .IsDependentOn("Restore")
-    .IsDependentOn("Build")
-    .IsDependentOn("UnitTest")
-    .IsDependentOn("Pack");
-
-Task("DevBuild")
     .IsDependentOn("Restore")
     .IsDependentOn("Build")
     .IsDependentOn("UnitTest");

--- a/build.cake
+++ b/build.cake
@@ -26,18 +26,19 @@ Task("PatchVersion")
             XmlPoke(proj, "/Project/PropertyGroup/Version", packageVersion);
         }
     });
+
 Task("Restore")
-    .IsDependentOn("PatchVersion")
     .Does(() => {
         DotNetCoreRestore();
     });
+
 Task("Build")
-    .IsDependentOn("Restore")
     .Does(() => {
         DotNetCoreBuild("ProtoActor.sln", new DotNetCoreBuildSettings {
             Configuration = configuration,
         });
     });
+
 Task("UnitTest")
     .Does(() => {
         foreach(var proj in GetFiles("tests/**/*.Tests.csproj")) {
@@ -47,6 +48,7 @@ Task("UnitTest")
             });
         }
     });
+
 Task("Pack")
     .Does(() => {
         foreach(var proj in GetFiles("src/**/*.csproj")) {
@@ -69,11 +71,15 @@ Task("Push")
     });
 
 Task("Default")
-    .IsDependentOn("Restore")
     .IsDependentOn("PatchVersion")
+    .IsDependentOn("Restore")
     .IsDependentOn("Build")
     .IsDependentOn("UnitTest")
-    .IsDependentOn("Pack")
-    ;
+    .IsDependentOn("Pack");
+
+Task("DevBuild")
+    .IsDependentOn("Restore")
+    .IsDependentOn("Build")
+    .IsDependentOn("UnitTest");
 
 RunTarget(target);


### PR DESCRIPTION
It was annoying to have my csprojs be modified when I used this script.  I thought it would be helpful to have a target that was explicitly just restore/build/tests for dev on my local machine.

run: `./build.sh -t devbuild`

I removed the task dependencies to allow reordering with new targets.  The default one runs in the old order now.