### PR TITLE
Benchmarks for Mailbox

### DIFF
--- a/examples/MailboxBenchmark/MailboxBenchmark.cs
+++ b/examples/MailboxBenchmark/MailboxBenchmark.cs
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+//  <copyright file="MailboxBenchmark.cs" company="Asynkron HB">
+//      Copyright (C) 2015-2017 Asynkron HB All rights reserved
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Proto;
+using Proto.Mailbox;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Attributes.Jobs;
+
+[SimpleJob(launchCount: 1, warmupCount: 3, targetCount: 5, invocationCount: 100, id: "QuickJob")]
+[ShortRunJob]
+public class MailboxBenchmark
+{
+
+    [Benchmark]
+    public Task Unbounded() => RunTest(() => UnboundedMailbox.Create());
+
+    [Benchmark]
+    public Task Unbound() => RunTest(() => BoundedMailbox.Create(1024 * 1024));
+
+
+    public static async Task RunTest(Func<IMailbox> mailbox)
+    {
+        const int n = 10 * 1000;
+        var props = Actor.FromFunc(c =>
+            {
+                switch (c.Message)
+                {
+                    case string s:
+                        c.Respond("done");
+                        break;
+                }
+                return Actor.Done;
+            })
+            .WithMailbox(mailbox);
+        var pid = Actor.Spawn(props);
+        for (var i = 1; i <= n; i++)
+        {
+            pid.Tell(i);
+        }
+        await pid.RequestAsync<string>("stop");
+    }
+}

--- a/examples/MailboxBenchmark/MailboxBenchmark.csproj
+++ b/examples/MailboxBenchmark/MailboxBenchmark.csproj
@@ -7,4 +7,7 @@
     <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj" />
     <ProjectReference Include="..\..\src\Proto.Mailbox\Proto.Mailbox.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotnet" Version="0.10.8" />
+  </ItemGroup>
 </Project>

--- a/examples/MailboxBenchmark/Program.cs
+++ b/examples/MailboxBenchmark/Program.cs
@@ -4,53 +4,14 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using System;
 using System.Diagnostics;
-using Proto;
+using BenchmarkDotNet.Running;
 using Proto.Mailbox;
 
 class Program
 {
     static void Main(string[] args)
     {
-        Func<IMailbox> unboundedMailbox =
-            () => UnboundedMailbox.Create();
-        //Func<IMailbox> boundedMailbox =
-        //    () => BoundedMailbox.Create(1024 * 1024);
-
-        //RunTest(boundedMailbox, "Bounded mailbox");
-        RunTest(unboundedMailbox, "Unbounded mailbox");
-
-        Console.ReadLine();
-    }
-
-    private static void RunTest(Func<IMailbox> mailbox, string name)
-    {
-        Stopwatch sendSw = new Stopwatch(), recvSw = new Stopwatch();
-        const int n = 10 * 1000 * 1000;
-        var props = Actor.FromFunc(c =>
-            {
-                switch (c.Message)
-                {
-                    case int i:
-                        if (i == n)
-                        {
-                            recvSw.Stop();
-                            Console.WriteLine($"recv {(int) (n / recvSw.Elapsed.TotalSeconds / 1000)}K/sec ({name})");
-                        }
-                        break;
-                }
-                return Actor.Done;
-            })
-            .WithMailbox(mailbox);
-        var pid = Actor.Spawn(props);
-        sendSw.Start();
-        recvSw.Start();
-        for (var i = 1; i <= n; i++)
-        {
-            pid.Tell(i);
-        }
-        sendSw.Stop();
-        Console.WriteLine($"send {(int) (n / sendSw.Elapsed.TotalSeconds / 1000)}K/sec ({name})");
+        var summary = BenchmarkRunner.Run<MailboxBenchmark>();
     }
 }

--- a/src/Proto.Mailbox/Mailbox.cs
+++ b/src/Proto.Mailbox/Mailbox.cs
@@ -24,7 +24,7 @@ namespace Proto.Mailbox
         void Start();
     }
 
-    internal static class BoundedMailbox
+    public static class BoundedMailbox
     {
         public static IMailbox Create(int size, params IMailboxStatistics[] stats)
         {


### PR DESCRIPTION
Basic usage of BenchmarkDotnet

Output:
``` ini

BenchmarkDotNet=v0.10.8, OS=Mac OS X 10.12
Processor=Intel Core i7-4770HQ CPU 2.20GHz (Haswell), ProcessorCount=8
Frequency=1000000000 Hz, Resolution=1.0000 ns, Timer=UNKNOWN
dotnet cli version=1.0.4
  [Host]   : .NET Core 4.6.25211.01, 64bit RyuJIT
  QuickJob : .NET Core 4.6.25211.01, 64bit RyuJIT
  ShortRun : .NET Core 4.6.25211.01, 64bit RyuJIT

LaunchCount=1  WarmupCount=3  

```
 |    Method |      Job | InvocationCount | TargetCount | UnrollFactor |      Mean |      Error |    StdDev |
 |---------- |--------- |---------------- |------------ |------------- |----------:|-----------:|----------:|
 | Unbounded | QuickJob |             100 |           5 |            1 |  1.369 ms |  0.0915 ms | 0.0238 ms |
 |   Unbound | QuickJob |             100 |           5 |            1 | 25.431 ms | 16.7475 ms | 4.3501 ms |
 | Unbounded | ShortRun |               1 |           3 |           16 |  1.645 ms |  1.0896 ms | 0.0616 ms |
 |   Unbound | ShortRun |               1 |           3 |           16 | 22.843 ms | 93.0384 ms | 5.2568 ms |
