### PR TITLE
add CancelReceiveTimeout method on IContext and fix bug in SetReceive…

### DIFF
--- a/src/Proto.Actor/IContext.cs
+++ b/src/Proto.Actor/IContext.cs
@@ -92,10 +92,12 @@ namespace Proto
         /// <summary>
         ///     Sets the receive timeout. If no message is received for the given duration, a ReceiveTimeout message will be sent
         ///     to the actor. If a message is received within the given duration, the timer is reset, unless the message implements
-        ///     INotInfluenceReceiveTimeout. Setting a duration of less than 1ms will disable the timer.
+        ///     INotInfluenceReceiveTimeout.
         /// </summary>
         /// <param name="duration">The receive timeout duration</param>
         void SetReceiveTimeout(TimeSpan duration);
+
+        void CancelReceiveTimeout();
 
         Task ReceiveAsync(object message);
         void Tell(PID target, object message);

--- a/tests/Proto.Actor.Tests/ReceiveTimeoutTests.cs
+++ b/tests/Proto.Actor.Tests/ReceiveTimeoutTests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Threading;
+using Xunit;
+
+namespace Proto.Tests
+{
+    public class ReceiveTimeoutTests
+    {
+        [Fact]
+        public void receive_timeout_received_within_expected_time()
+        {
+            var timeoutReceived = false;
+            var props = Actor.FromFunc((context) =>
+            {
+                switch (context.Message)
+                {
+                        case Started _:
+                            context.SetReceiveTimeout(TimeSpan.FromMilliseconds(150));
+                            break;
+                        case ReceiveTimeout _:
+                            timeoutReceived = true;
+                            break;
+                }
+                return Actor.Done;
+            });
+            Actor.Spawn(props);
+            
+            Thread.Sleep(500);
+            Assert.True(timeoutReceived);
+        }
+        
+        [Fact]
+        public void receive_timeout_not_received_within_expected_time()
+        {
+            var timeoutReceived = false;
+            var props = Actor.FromFunc((context) =>
+            {
+                switch (context.Message)
+                {
+                    case Started _:
+                        context.SetReceiveTimeout(TimeSpan.FromMilliseconds(1500));
+                        break;
+                    case ReceiveTimeout _:
+                        timeoutReceived = true;
+                        break;
+                }
+                return Actor.Done;
+            });
+            Actor.Spawn(props);
+            
+            Thread.Sleep(500);
+            Assert.False(timeoutReceived);
+        }
+        
+        [Fact]
+        public void can_cancel_receive_timeout()
+        {
+            var timeoutReceived = false;
+            var props = Actor.FromFunc((context) =>
+            {
+                switch (context.Message)
+                {
+                    case Started _:
+                        context.SetReceiveTimeout(TimeSpan.FromMilliseconds(150));
+                        context.CancelReceiveTimeout();
+                        break;
+                    case ReceiveTimeout _:
+                        timeoutReceived = true;
+                        break;
+                }
+                return Actor.Done;
+            });
+            Actor.Spawn(props);
+            
+            Thread.Sleep(500);
+            Assert.False(timeoutReceived);
+        }
+        
+        [Fact]
+        public void can_still_set_receive_timeout_after_cancelling()
+        {
+            var timeoutReceived = false;
+            var props = Actor.FromFunc((context) =>
+            {
+                switch (context.Message)
+                {
+                    case Started _:
+                        context.SetReceiveTimeout(TimeSpan.FromMilliseconds(150));
+                        context.CancelReceiveTimeout();
+                        context.SetReceiveTimeout(TimeSpan.FromMilliseconds(150));
+                        break;
+                    case ReceiveTimeout _:
+                        timeoutReceived = true;
+                        break;
+                }
+                return Actor.Done;
+            });
+            Actor.Spawn(props);
+            
+            Thread.Sleep(500);
+            Assert.True(timeoutReceived);
+        }
+    }
+}


### PR DESCRIPTION
…Timeout where anything less than 1 millisecond was converted to 1 millisecond

fixes #253 