### PR TITLE
Custom serializers

### DIFF
--- a/src/Proto.Remote/EndpointReader.cs
+++ b/src/Proto.Remote/EndpointReader.cs
@@ -4,6 +4,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Core.Utils;
@@ -28,7 +29,8 @@ namespace Proto.Remote
                     var target = new PID(ProcessRegistry.Instance.Address, targetName);
                     var sender = envelope.Sender;
                     var typeName = typeNames[envelope.TypeId];
-                    var message = Serialization.Deserialize(typeName, envelope.MessageData);
+
+                    var message = Serialization.Deserialize(typeName, envelope.MessageData, envelope.SerializerId);
 
                     if (message is Terminated msg)
                     {

--- a/src/Proto.Remote/EndpointWatcher.cs
+++ b/src/Proto.Remote/EndpointWatcher.cs
@@ -56,7 +56,7 @@ namespace Proto.Remote
                     _watched[msg.Watcher.Id] = null;
 
                     var w = new Unwatch(msg.Watcher);
-                    RemoteProcess.SendRemoteMessage(msg.Watchee, w);
+                    RemoteProcess.SendRemoteMessage(msg.Watchee, w,Serialization.DefaultSerializerId);
                     break;
                 }
                 case RemoteWatch msg:
@@ -64,12 +64,9 @@ namespace Proto.Remote
                     _watched[msg.Watcher.Id] = msg.Watchee;
 
                     var w = new Watch(msg.Watcher);
-                    RemoteProcess.SendRemoteMessage(msg.Watchee, w);
+                    RemoteProcess.SendRemoteMessage(msg.Watchee, w, Serialization.DefaultSerializerId);
                     break;
                 }
-
-                default:
-                    break;
             }
             return Actor.Done;
         }

--- a/src/Proto.Remote/EndpointWriter.cs
+++ b/src/Proto.Remote/EndpointWriter.cs
@@ -62,20 +62,21 @@ namespace Proto.Remote
                             targetNameList.Add(targetName);
                         }
 
-                        var typeName = rd.Message.Descriptor.File.Package + "." + rd.Message.Descriptor.Name;
+                        var typeName = Serialization.GetTypeName(rd.Message, rd.SerializerId);
                         if (!typeNames.TryGetValue(typeName, out var typeId))
                         {
                             typeId = typeNames[typeName] = typeNames.Count;
                             typeNameList.Add(typeName);
                         }
 
-                        var bytes = Serialization.Serialize(rd.Message);
+                        var bytes = Serialization.Serialize(rd.Message,rd.SerializerId);
                         var envelope = new MessageEnvelope
                         {
                             MessageData = bytes,
                             Sender = rd.Sender,
                             Target = targetId,
                             TypeId = typeId,
+                            SerializerId = rd.SerializerId,
                         };
                         envelopes.Add(envelope);
                     }

--- a/src/Proto.Remote/Proto.Remote.csproj
+++ b/src/Proto.Remote/Proto.Remote.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Grpc" Version="1.1.0" />
+    <PackageReference Include="protobuf" Version="2.6.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Proto.Actor\Proto.Actor.csproj" />

--- a/src/Proto.Remote/Protos.g.cs
+++ b/src/Proto.Remote/Protos.g.cs
@@ -25,18 +25,19 @@ namespace Proto.Remote {
             "CgxQcm90b3MucHJvdG8SBnJlbW90ZRoYUHJvdG8uQWN0b3IvcHJvdG9zLnBy",
             "b3RvImQKDE1lc3NhZ2VCYXRjaBISCgp0eXBlX25hbWVzGAEgAygJEhQKDHRh",
             "cmdldF9uYW1lcxgCIAMoCRIqCgllbnZlbG9wZXMYAyADKAsyFy5yZW1vdGUu",
-            "TWVzc2FnZUVudmVsb3BlImQKD01lc3NhZ2VFbnZlbG9wZRIPCgd0eXBlX2lk",
+            "TWVzc2FnZUVudmVsb3BlInsKD01lc3NhZ2VFbnZlbG9wZRIPCgd0eXBlX2lk",
             "GAEgASgFEhQKDG1lc3NhZ2VfZGF0YRgCIAEoDBIOCgZ0YXJnZXQYAyABKAUS",
-            "GgoGc2VuZGVyGAQgASgLMgouYWN0b3IuUElEIi0KD0FjdG9yUGlkUmVxdWVz",
-            "dBIMCgRuYW1lGAEgASgJEgwKBGtpbmQYAiABKAkiKwoQQWN0b3JQaWRSZXNw",
-            "b25zZRIXCgNwaWQYASABKAsyCi5hY3Rvci5QSUQiBgoEVW5pdDI/CghSZW1v",
-            "dGluZxIzCgdSZWNlaXZlEhQucmVtb3RlLk1lc3NhZ2VCYXRjaBoMLnJlbW90",
-            "ZS5Vbml0IgAoATABQg+qAgxQcm90by5SZW1vdGViBnByb3RvMw=="));
+            "GgoGc2VuZGVyGAQgASgLMgouYWN0b3IuUElEEhUKDXNlcmlhbGl6ZXJfaWQY",
+            "BSABKAUiLQoPQWN0b3JQaWRSZXF1ZXN0EgwKBG5hbWUYASABKAkSDAoEa2lu",
+            "ZBgCIAEoCSIrChBBY3RvclBpZFJlc3BvbnNlEhcKA3BpZBgBIAEoCzIKLmFj",
+            "dG9yLlBJRCIGCgRVbml0Mj8KCFJlbW90aW5nEjMKB1JlY2VpdmUSFC5yZW1v",
+            "dGUuTWVzc2FnZUJhdGNoGgwucmVtb3RlLlVuaXQiACgBMAFCD6oCDFByb3Rv",
+            "LlJlbW90ZWIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Proto.ProtosReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Proto.Remote.MessageBatch), global::Proto.Remote.MessageBatch.Parser, new[]{ "TypeNames", "TargetNames", "Envelopes" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Proto.Remote.MessageEnvelope), global::Proto.Remote.MessageEnvelope.Parser, new[]{ "TypeId", "MessageData", "Target", "Sender" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Proto.Remote.MessageEnvelope), global::Proto.Remote.MessageEnvelope.Parser, new[]{ "TypeId", "MessageData", "Target", "Sender", "SerializerId" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Proto.Remote.ActorPidRequest), global::Proto.Remote.ActorPidRequest.Parser, new[]{ "Name", "Kind" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Proto.Remote.ActorPidResponse), global::Proto.Remote.ActorPidResponse.Parser, new[]{ "Pid" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Proto.Remote.Unit), global::Proto.Remote.Unit.Parser, null, null, null, null)
@@ -223,6 +224,7 @@ namespace Proto.Remote {
       messageData_ = other.messageData_;
       target_ = other.target_;
       Sender = other.sender_ != null ? other.Sender.Clone() : null;
+      serializerId_ = other.serializerId_;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -274,6 +276,17 @@ namespace Proto.Remote {
       }
     }
 
+    /// <summary>Field number for the "serializer_id" field.</summary>
+    public const int SerializerIdFieldNumber = 5;
+    private int serializerId_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int SerializerId {
+      get { return serializerId_; }
+      set {
+        serializerId_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as MessageEnvelope);
@@ -291,6 +304,7 @@ namespace Proto.Remote {
       if (MessageData != other.MessageData) return false;
       if (Target != other.Target) return false;
       if (!object.Equals(Sender, other.Sender)) return false;
+      if (SerializerId != other.SerializerId) return false;
       return true;
     }
 
@@ -301,6 +315,7 @@ namespace Proto.Remote {
       if (MessageData.Length != 0) hash ^= MessageData.GetHashCode();
       if (Target != 0) hash ^= Target.GetHashCode();
       if (sender_ != null) hash ^= Sender.GetHashCode();
+      if (SerializerId != 0) hash ^= SerializerId.GetHashCode();
       return hash;
     }
 
@@ -327,6 +342,10 @@ namespace Proto.Remote {
         output.WriteRawTag(34);
         output.WriteMessage(Sender);
       }
+      if (SerializerId != 0) {
+        output.WriteRawTag(40);
+        output.WriteInt32(SerializerId);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -343,6 +362,9 @@ namespace Proto.Remote {
       }
       if (sender_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Sender);
+      }
+      if (SerializerId != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(SerializerId);
       }
       return size;
     }
@@ -366,6 +388,9 @@ namespace Proto.Remote {
           sender_ = new global::Proto.PID();
         }
         Sender.MergeFrom(other.Sender);
+      }
+      if (other.SerializerId != 0) {
+        SerializerId = other.SerializerId;
       }
     }
 
@@ -394,6 +419,10 @@ namespace Proto.Remote {
               sender_ = new global::Proto.PID();
             }
             input.ReadMessage(sender_);
+            break;
+          }
+          case 40: {
+            SerializerId = input.ReadInt32();
             break;
           }
         }

--- a/src/Proto.Remote/Protos.proto
+++ b/src/Proto.Remote/Protos.proto
@@ -16,6 +16,7 @@ message MessageEnvelope {
   bytes message_data = 2;
   int32 target = 3;
   actor.PID sender = 4;
+  int32 serializer_id = 5;
 }
 
 message ActorPidRequest {

--- a/src/Proto.Remote/RemoteProcess.cs
+++ b/src/Proto.Remote/RemoteProcess.cs
@@ -42,17 +42,17 @@ namespace Proto.Remote
             }
             else
             {
-                SendRemoteMessage(_pid, msg);
+                SendRemoteMessage(_pid, msg,Serialization.DefaultSerializerId);
             }
         }
 
-        public static void SendRemoteMessage(PID pid, object msg)
+        public static void SendRemoteMessage(PID pid, object msg,int serializerId)
         {
             var (message, sender, _) = Proto.MessageEnvelope.Unwrap(msg);
 
             if (message is IMessage protoMessage)
             {
-                var env = new RemoteDeliver(protoMessage, pid, sender);
+                var env = new RemoteDeliver(protoMessage, pid, sender, serializerId);
                 Remote.EndpointManagerPid.Tell(env);
             }
             else
@@ -64,14 +64,17 @@ namespace Proto.Remote
 
     public class RemoteDeliver
     {
-        public RemoteDeliver(IMessage message, PID target,PID sender)
+        public RemoteDeliver(object message, PID target,PID sender,int serializerId)
         {
             Message = message;
             Target = target;
             Sender = sender;
+            SerializerId = serializerId;
         }
-        public IMessage Message { get;  }
+        public object Message { get;  }
         public PID Target { get;  }
         public PID Sender { get;  }
+
+        public int SerializerId { get; }
     }
 }

--- a/src/Proto.Remote/Serialization.cs
+++ b/src/Proto.Remote/Serialization.cs
@@ -1,7 +1,7 @@
 ﻿// -----------------------------------------------------------------------
-//  <copyright file="Serialization.cs" company="Asynkron HB">
-//      Copyright (C) 2015-2017 Asynkron HB All rights reserved
-//  </copyright>
+//   <copyright file="Serialization.cs" company="Asynkron HB">
+//       Copyright (C) 2015-2017 Asynkron HB All rights reserved
+//   </copyright>
 // -----------------------------------------------------------------------
 
 using System.Collections.Generic;
@@ -10,35 +10,84 @@ using Google.Protobuf.Reflection;
 
 namespace Proto.Remote
 {
-    public static class Serialization
+    public interface ISerializer
     {
-        private static readonly Dictionary<string, MessageParser> TypeLookup = new Dictionary<string, MessageParser>();
+        ByteString Serialize(object obj);
+        object Deserialize(ByteString bytes, string typeName);
+        string GetTypeName(object message);
+    }
 
-        static Serialization()
+    public class ProtoBufSerializer : ISerializer
+    {
+        private readonly Dictionary<string, MessageParser> _typeLookup = new Dictionary<string, MessageParser>();
+
+        public ProtoBufSerializer()
         {
             RegisterFileDescriptor(Proto.ProtosReflection.Descriptor);
             RegisterFileDescriptor(ProtosReflection.Descriptor);
         }
 
-        public static void RegisterFileDescriptor(FileDescriptor fd)
+        public ByteString Serialize(object obj)
+        {
+            var message = obj as IMessage;
+            return message.ToByteString();
+        }
+
+        public object Deserialize(ByteString bytes, string typeName)
+        {
+            var parser = _typeLookup[typeName];
+            var o = parser.ParseFrom(bytes);
+            return o;
+        }
+
+        public string GetTypeName(object obj)
+        {
+            var message = obj as IMessage;
+            return message.Descriptor.File.Package + "." + message.Descriptor.Name;
+        }
+
+        public void RegisterFileDescriptor(FileDescriptor fd)
         {
             foreach (var msg in fd.MessageTypes)
             {
                 var name = fd.Package + "." + msg.Name;
-                TypeLookup.Add(name, msg.Parser);
+                _typeLookup.Add(name, msg.Parser);
             }
         }
+    }
 
-        public static ByteString Serialize(IMessage message)
+    public static class Serialization
+    {
+        private static readonly List<ISerializer> Serializers = new List<ISerializer>();
+        private static readonly ProtoBufSerializer ProtoBufSerializer = new ProtoBufSerializer();
+
+        static Serialization()
         {
-            return message.ToByteString();
+            Serializers.Add(ProtoBufSerializer);
+            DefaultSerializerId = 0;
         }
 
-        public static object Deserialize(string typeName, ByteString bytes)
+        public static int DefaultSerializerId { get; set; }
+
+        //TODO: remove from this class and let users register on the protobuf serializer?
+        public static void RegisterFileDescriptor(FileDescriptor fd)
         {
-            var parser = TypeLookup[typeName];
-            var o = parser.ParseFrom(bytes);
-            return o;
+            ProtoBufSerializer.RegisterFileDescriptor(fd);
+        }
+
+        public static ByteString Serialize(object message,int serializerId)
+        {
+            return Serializers[serializerId].Serialize(message);
+        }
+
+        public static string GetTypeName(object message, int serializerId)
+        {
+            return Serializers[serializerId].GetTypeName(message);
+        }
+
+        public static object Deserialize(string typeName, ByteString bytes, int serializerId)
+        {
+            return Serializers[serializerId].Deserialize(bytes, typeName);
         }
     }
 }

--- a/src/Proto.Remote/Serialization.cs
+++ b/src/Proto.Remote/Serialization.cs
@@ -67,27 +67,24 @@ namespace Proto.Remote
             DefaultSerializerId = 0;
         }
 
+        public static void RegisterSerializer(ISerializer serializer, bool makeDefault = false)
+        {
+            Serializers.Add(serializer);
+            if (makeDefault)
+            {
+                DefaultSerializerId = Serializers.Count - 1;
+            }
+        }
+
         public static int DefaultSerializerId { get; set; }
 
         //TODO: remove from this class and let users register on the protobuf serializer?
-        public static void RegisterFileDescriptor(FileDescriptor fd)
-        {
-            ProtoBufSerializer.RegisterFileDescriptor(fd);
-        }
+        public static void RegisterFileDescriptor(FileDescriptor fd) => ProtoBufSerializer.RegisterFileDescriptor(fd);
 
-        public static ByteString Serialize(object message,int serializerId)
-        {
-            return Serializers[serializerId].Serialize(message);
-        }
+        public static ByteString Serialize(object message,int serializerId) => Serializers[serializerId].Serialize(message);
 
-        public static string GetTypeName(object message, int serializerId)
-        {
-            return Serializers[serializerId].GetTypeName(message);
-        }
+        public static string GetTypeName(object message, int serializerId) => Serializers[serializerId].GetTypeName(message);
 
-        public static object Deserialize(string typeName, ByteString bytes, int serializerId)
-        {
-            return Serializers[serializerId].Deserialize(bytes, typeName);
-        }
+        public static object Deserialize(string typeName, ByteString bytes, int serializerId) => Serializers[serializerId].Deserialize(bytes, typeName);
     }
 }


### PR DESCRIPTION
This PR adds initial support for custom serializers.
There is now an ISerializer interface in the remote package.
There is also a list of serializers available in the Serializer class. currently the only supported serializer is Protobuf, but now we have the ability to add more.

Each serializer gets an ID which is then used in the payload to identify what serializer to use.

This does not work like serializers in Akka, where each type or base type can have their own serializer. this is are used for all objects. 
The purpose of this is to allow multiple serializers to be used at the same time for the same message.
e.g. We default to Protobuf for everything, but using JSON for CLI integration.
Or replace the default serializer completely with e.g. Wire for .NET based systems.