### PR TITLE
Mailbox tuning

### DIFF
--- a/src/Proto.Actor/PID.cs
+++ b/src/Proto.Actor/PID.cs
@@ -12,7 +12,7 @@ namespace Proto
 {
     public partial class PID
     {
-        private Process _p;
+        private Process _process;
 
         public PID(string address, string id)
         {
@@ -20,27 +20,32 @@ namespace Proto
             Id = id;
         }
 
+        internal PID(string address, string id, Process process) : this(address, id)
+        {
+            _process = process;
+        }
+
         internal Process Ref
         {
             get
             {
-                var p = _p;
+                var p = _process;
                 if (p != null)
                 {
                     if (p is LocalProcess lp && lp.IsDead)
                     {
-                        _p = null;
+                        _process = null;
                     }
-                    return _p;
+                    return _process;
                 }
 
                 var reff = ProcessRegistry.Instance.Get(this);
                 if (!(reff is DeadLetterProcess))
                 {
-                    _p = reff;
+                    _process = reff;
                 }
 
-                return _p;
+                return _process;
             }
         }
 

--- a/src/Proto.Actor/ProcessRegistry.cs
+++ b/src/Proto.Actor/ProcessRegistry.cs
@@ -40,21 +40,18 @@ namespace Proto
                 throw new NotSupportedException("Unknown host");
             }
 
-            if (!_localActorRefs.TryGetValue(pid.Id, out var aref))
+            if (_localActorRefs.TryGetValue(pid.Id, out var process))
             {
-                return DeadLetterProcess.Instance;
+                return process;
             }
-            return aref;
+            return DeadLetterProcess.Instance;
         }
 
-        public (PID pid, bool ok) TryAdd(string id, Process aref)
+        public (PID pid, bool ok) TryAdd(string id, Process process)
         {
-            var pid = new PID
-            {
-                Id = id,
-                Address = Address // local
-            };
-            var ok = _localActorRefs.TryAdd(pid.Id, aref);
+            var pid = new PID(Address, id, process);
+            
+            var ok = _localActorRefs.TryAdd(pid.Id, process);
             return (pid, ok);
         }
 

--- a/src/Proto.Actor/Props.cs
+++ b/src/Proto.Actor/Props.cs
@@ -36,8 +36,8 @@ namespace Proto
             var ctx = new LocalContext(props.Producer, props.SupervisorStrategy, props.ReceiveMiddlewareChain, props.SenderMiddlewareChain, parent);
             var mailbox = props.MailboxProducer();
             var dispatcher = props.Dispatcher;
-            var reff = new LocalProcess(mailbox);
-            var (pid, absent) = ProcessRegistry.Instance.TryAdd(name, reff);
+            var process = new LocalProcess(mailbox);
+            var (pid, absent) = ProcessRegistry.Instance.TryAdd(name, process);
             if (!absent)
             {
                 throw new ProcessNameExistException(name);

--- a/src/Proto.Mailbox/Mailbox.cs
+++ b/src/Proto.Mailbox/Mailbox.cs
@@ -49,6 +49,7 @@ namespace Proto.Mailbox
         private IMessageInvoker _invoker;
 
         private int _status = MailboxStatus.Idle;
+        private long _systemMessageCount;
         private bool _suspended;
 
         internal int Status => _status;
@@ -63,9 +64,9 @@ namespace Proto.Mailbox
         public void PostUserMessage(object msg)
         {
             _userMailbox.Push(msg);
-            for (var i = 0; i < _stats.Length; i++)
+            foreach (var t in _stats)
             {
-                _stats[i].MessagePosted(msg);
+                t.MessagePosted(msg);
             }
             Schedule();
         }
@@ -73,9 +74,10 @@ namespace Proto.Mailbox
         public void PostSystemMessage(object msg)
         {
             _systemMessages.Push(msg);
-            for (var i = 0; i < _stats.Length; i++)
+            Interlocked.Increment(ref _systemMessageCount);
+            foreach (var t in _stats)
             {
-                _stats[i].MessagePosted(msg);
+                t.MessagePosted(msg);
             }
             Schedule();
         }
@@ -88,9 +90,9 @@ namespace Proto.Mailbox
 
         public void Start()
         {
-            for (var i = 0; i < _stats.Length; i++)
+            foreach (var t in _stats)
             {
-                _stats[i].MailboxStarted();
+                t.MailboxStarted();
             }
         }
 
@@ -104,15 +106,15 @@ namespace Proto.Mailbox
 
             Interlocked.Exchange(ref _status, MailboxStatus.Idle);
 
-            if (_systemMessages.HasMessages || (!_suspended && _userMailbox.HasMessages))
+            if (_systemMessages.HasMessages || !_suspended && _userMailbox.HasMessages)
             {
                 Schedule();
             }
             else
             {
-                for (var i = 0; i < _stats.Length; i++)
+                foreach (var t in _stats)
                 {
-                    _stats[i].MailboxEmpty();
+                    t.MailboxEmpty();
                 }
             }
             return Task.FromResult(0);
@@ -125,8 +127,9 @@ namespace Proto.Mailbox
             {
                 for (var i = 0; i < _dispatcher.Throughput; i++)
                 {
-                    if ((msg = _systemMessages.Pop()) != null)
+                    if (Interlocked.Read(ref _systemMessageCount) > 0 && (msg = _systemMessages.Pop()) != null)
                     {
+                        Interlocked.Decrement(ref _systemMessageCount);
                         if (msg is SuspendMailbox)
                         {
                             _suspended = true;
@@ -147,9 +150,9 @@ namespace Proto.Mailbox
                             t.ContinueWith(RescheduleOnTaskComplete, msg);
                             return false;
                         }
-                        for (var si = 0; si < _stats.Length; si++)
+                        foreach (var t1 in _stats)
                         {
-                            _stats[si].MessageReceived(msg);
+                            t1.MessageReceived(msg);
                         }
                         continue;
                     }
@@ -171,9 +174,9 @@ namespace Proto.Mailbox
                             t.ContinueWith(RescheduleOnTaskComplete, msg);
                             return false;
                         }
-                        for (var si = 0; si < _stats.Length; si++)
+                        foreach (var t1 in _stats)
                         {
-                            _stats[si].MessageReceived(msg);
+                            t1.MessageReceived(msg);
                         }
                     }
                     else
@@ -197,9 +200,9 @@ namespace Proto.Mailbox
             }
             else
             {
-                for (var si = 0; si < _stats.Length; si++)
+                foreach (var t in _stats)
                 {
-                    _stats[si].MessageReceived(message);
+                    t.MessageReceived(message);
                 }
             }
             _dispatcher.Schedule(RunAsync);

--- a/src/Proto.Mailbox/UnboundedMailboxQueue.cs
+++ b/src/Proto.Mailbox/UnboundedMailboxQueue.cs
@@ -23,6 +23,6 @@ namespace Proto.Mailbox
             return _messages.TryDequeue(out message) ? message : null;
         }
 
-        public bool HasMessages => _messages.Count > 0;
+        public bool HasMessages => !_messages.IsEmpty;
     }
 }


### PR DESCRIPTION
This PR implements the same mailbox tweak as I did on the Kotlin version.
TLDR, it maintains an atomic message counter for system messages.
So instead of asking the backing queue for empty state, it checks the counter.

This raised throughput from 80 to 90 mil (ish)
```
Is Server GC True
Dispatcher              Elapsed         Msg/sec
300                     202             79207920
400                     174             91954022
500                     218             73394495
600                     192             83333333
700                     177             90395480
800                     176             90909090
900                     174             91954022
```

ps. also some number tweaking in the inprocbenchmark for more consistent numbers