### PR TITLE
#283 Support for server-drive event index (stream version)

### DIFF
--- a/src/PersistenceProviders/Proto.Persistence.Marten/MartenProvider.cs
+++ b/src/PersistenceProviders/Proto.Persistence.Marten/MartenProvider.cs
@@ -14,7 +14,7 @@ namespace Proto.Persistence.Marten
             _store = store;
         }
         
-        public async Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+        public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
         {
             using (var session = _store.OpenSession())
             {
@@ -28,6 +28,8 @@ namespace Proto.Persistence.Marten
                 {
                     callback(@event.Data);
                 }
+                
+                return events.Any() ? events.LastOrDefault().Index : -1;
             }
         }
 
@@ -44,13 +46,15 @@ namespace Proto.Persistence.Marten
             }
         }
 
-        public async Task PersistEventAsync(string actorName, long index, object @event)
+        public async Task<long> PersistEventAsync(string actorName, long index, object @event)
         {
             using (var session = _store.OpenSession())
             {
                 session.Store(new Event(actorName, index, @event));
 
                 await session.SaveChangesAsync();
+
+                return index++;
             }
         }
 

--- a/src/PersistenceProviders/Proto.Persistence.SqlServer/SqlServerProvider.cs
+++ b/src/PersistenceProviders/Proto.Persistence.SqlServer/SqlServerProvider.cs
@@ -148,7 +148,7 @@ namespace Proto.Persistence.SqlServer
             await ExecuteNonQueryAsync(sql, parameters);
         }
 
-        public async Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+        public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
         {
             var sql = GenerateGetEventsSqlString();
             var sqlParameters = GenerateGetEventsParameters(actorName, indexStart, indexEnd);
@@ -170,6 +170,8 @@ namespace Proto.Persistence.SqlServer
                     {
                         callback(JsonConvert.DeserializeObject<object>(eventReader["EventData"].ToString(), new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto }));
                     }
+
+                    return eventReader.HasRows ? (long) eventReader["EventIndex"] : -1;
                 }
             }
             catch (Exception ex)
@@ -250,7 +252,7 @@ namespace Proto.Persistence.SqlServer
             return (snapshotData, snapshotIndex);
         }
 
-        public async Task PersistEventAsync(string actorName, long index, object @event)
+        public async Task<long> PersistEventAsync(string actorName, long index, object @event)
         {
             var item = new Event(actorName, index, @event);
 
@@ -285,6 +287,8 @@ namespace Proto.Persistence.SqlServer
             };
 
             await ExecuteNonQueryAsync(sql, parameters);
+
+            return index++;
         }
 
         public async Task PersistSnapshotAsync(string actorName, long index, object snapshot)

--- a/src/PersistenceProviders/Proto.Persistence.Sqlite/SqliteProvider.cs
+++ b/src/PersistenceProviders/Proto.Persistence.Sqlite/SqliteProvider.cs
@@ -69,7 +69,7 @@ namespace Proto.Persistence.Sqlite
             }
         }
 
-        public Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+        public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
         {
             try
             {
@@ -84,14 +84,13 @@ namespace Proto.Persistence.Sqlite
                     {
                         callback(JsonConvert.DeserializeObject<object>(item.EventData, new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto }));
                     }
+                    return items.Any() ? items.LastOrDefault().EventIndex : -1;
                 }
             }
             catch (Exception ex)
             {
                 throw ex;
             }
-
-            return Task.FromResult(0);
         }
 
         public Task<(object Snapshot, long Index)> GetSnapshotAsync(string actorName)
@@ -123,7 +122,7 @@ namespace Proto.Persistence.Sqlite
             return Task.FromResult((snapshot, index));
         }
 
-        public async Task PersistEventAsync(string actorName, long index, object @event)
+        public async Task<long> PersistEventAsync(string actorName, long index, object @event)
         {
             try
             {
@@ -134,6 +133,8 @@ namespace Proto.Persistence.Sqlite
                     await db.Events.AddAsync(item);
 
                     await db.SaveChangesAsync();
+
+                    return index++;
                 }
             }
             catch (Exception ex)

--- a/src/Proto.Persistence/IProvider.cs
+++ b/src/Proto.Persistence/IProvider.cs
@@ -18,11 +18,12 @@ namespace Proto.Persistence
 
     public interface IEventStore
     {
-        Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback);
-        Task PersistEventAsync(string actorName, long index, object @event);
+        Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback);
+        Task<long> PersistEventAsync(string actorName, long index, object @event);
         Task DeleteEventsAsync(string actorName, long inclusiveToIndex);
     }
-    
-    public interface IProvider : IEventStore, ISnapshotStore {}
-    
+
+    public interface IProvider : IEventStore, ISnapshotStore
+    {
+    }
 }

--- a/src/Proto.Persistence/Persistence.cs
+++ b/src/Proto.Persistence/Persistence.cs
@@ -149,14 +149,14 @@ namespace Proto.Persistence
         
         private class NoEventStore : IEventStore
         {
-            public Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+            public Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
             {
-                return Task.FromResult(0);
+                return Task.FromResult(-1L);
             }
 
-            public Task PersistEventAsync(string actorName, long index, object @event)
+            public Task<long> PersistEventAsync(string actorName, long index, object @event)
             {
-                return Task.FromResult(0);
+                return Task.FromResult(0L);
             }
 
             public Task DeleteEventsAsync(string actorName, long inclusiveToIndex)

--- a/tests/Proto.Persistence.Tests/InMemoryProvider.cs
+++ b/tests/Proto.Persistence.Tests/InMemoryProvider.cs
@@ -32,7 +32,7 @@ namespace Proto.Persistence.Tests
             return Task.FromResult((snapshot.Value, snapshot.Key));
         }
 
-        public Task GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+        public Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
         {
             if (_events.TryGetValue(actorName, out Dictionary<long, object> events))
             {
@@ -41,10 +41,10 @@ namespace Proto.Persistence.Tests
                     callback(e.Value);
                 }
             }
-            return Task.FromResult(0);
+            return Task.FromResult(0L);
         }
 
-        public Task PersistEventAsync(string actorName, long index, object @event)
+        public Task<long> PersistEventAsync(string actorName, long index, object @event)
         {
             var events = _events.GetOrAdd(actorName, new Dictionary<long, object>());
             long nextEventIndex = 1;
@@ -54,7 +54,7 @@ namespace Proto.Persistence.Tests
             }
             events.Add(nextEventIndex, @event);
 
-            return Task.FromResult(0);
+            return Task.FromResult(0L);
         }
 
         public Task PersistSnapshotAsync(string actorName, long index, object snapshot)


### PR DESCRIPTION
Check my attempt to solve it. I am not sure about the API change impact. It only concerns providers since call results were not used anyway, so all usages are not affected.