### PR TITLE
fix: print envelope message in sender middleware example

### DIFF
--- a/examples/Middleware/Program.cs
+++ b/examples/Middleware/Program.cs
@@ -52,15 +52,15 @@ class Program
                                        envelope.SetHeader("SpanID", c.Headers.GetOrDefault("SpanID"));
                                        envelope.SetHeader("ParentSpanID", c.Headers.GetOrDefault("ParentSpanID"));
 
-                                       Console.WriteLine($"sender middleware 1 enter {envelope.Message.GetType()}:{c.Message}");
+                                       Console.WriteLine($"sender middleware 1 enter {envelope.Message.GetType()}:{envelope.Message}");
                                        await next(c, target, envelope);
-                                       Console.WriteLine($"sender middleware 1 exit {envelope.Message.GetType()}:{c.Message}");
+                                       Console.WriteLine($"sender middleware 1 exit {envelope.Message.GetType()}:{envelope.Message}");
                                    },
                                    next => async (c, target, envelope) =>
                                    {
-                                       Console.WriteLine($"sender middleware 2 enter {envelope.Message.GetType()}:{c.Message}");
+                                       Console.WriteLine($"sender middleware 2 enter {envelope.Message.GetType()}:{envelope.Message}");
                                        await next(c, target, envelope);
-                                       Console.WriteLine($"sender middleware 2 exit {envelope.Message.GetType()}:{c.Message}");
+                                       Console.WriteLine($"sender middleware 2 exit {envelope.Message.GetType()}:{envelope.Message}");
                                    });
         //just wait for started message to be processed to make the output look less confusing
         Task.Delay(500).Wait();


### PR DESCRIPTION
Fix for issue #290 - the message in the sender middleware is wrapped in a MessageEnvelope per the [Middleware documenation](http://proto.actor/docs/dotnet/middleware).