### PR TITLE
Update protobuf+random nuget updates

### DIFF
--- a/examples/Chat/Client/Client.csproj
+++ b/examples/Chat/Client/Client.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/Chat/Messages/Chat.Messages.csproj
+++ b/examples/Chat/Messages/Chat.Messages.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
-    <PackageReference Include="Grpc.Tools" Version="1.1.0" />
+    <PackageReference Include="Grpc.Tools" Version="1.4.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/Chat/Messages/Chat.Messages.csproj
+++ b/examples/Chat/Messages/Chat.Messages.csproj
@@ -9,7 +9,7 @@
     <None Include="Chat.proto" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="Grpc.Tools" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/examples/Chat/Server/Server.csproj
+++ b/examples/Chat/Server/Server.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/ClusterGrainHelloWorld/Messages/Messages.csproj
+++ b/examples/ClusterGrainHelloWorld/Messages/Messages.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/ClusterGrainHelloWorld/Messages/Messages.csproj
+++ b/examples/ClusterGrainHelloWorld/Messages/Messages.csproj
@@ -10,7 +10,7 @@
     <None Include="Protos.proto" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/examples/ClusterGrainHelloWorld/Messages/Protos_protoactor.cs
+++ b/examples/ClusterGrainHelloWorld/Messages/Protos_protoactor.cs
@@ -74,7 +74,7 @@ namespace Messages
                 {
                     return await Inner();
                 }
-                catch(Exception x)
+                catch//(Exception x)
                 {
                     //ignore, TODO: exponential backoff?
                 }

--- a/examples/ClusterGrainHelloWorld/Node1/Node1.csproj
+++ b/examples/ClusterGrainHelloWorld/Node1/Node1.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options">
-      <Version>1.1.1</Version>
+      <Version>1.1.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/examples/ClusterGrainHelloWorld/Node2/Node2.csproj
+++ b/examples/ClusterGrainHelloWorld/Node2/Node2.csproj
@@ -7,7 +7,7 @@
     <Content Include="runtimeconfig.template.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="Microsoft.Extensions.Options">
       <Version>1.1.2</Version>
     </PackageReference>

--- a/examples/ClusterGrainHelloWorld/Node2/Node2.csproj
+++ b/examples/ClusterGrainHelloWorld/Node2/Node2.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Options">
       <Version>1.1.2</Version>
     </PackageReference>
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\ClusterProviders\Proto.Cluster.Consul\Proto.Cluster.Consul.csproj" />

--- a/examples/ClusterHelloWorld/Messages/Messages.csproj
+++ b/examples/ClusterHelloWorld/Messages/Messages.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/ClusterHelloWorld/Messages/Messages.csproj
+++ b/examples/ClusterHelloWorld/Messages/Messages.csproj
@@ -10,7 +10,7 @@
     <None Include="Protos.proto" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/examples/ClusterHelloWorld/Node1/Node1.csproj
+++ b/examples/ClusterHelloWorld/Node1/Node1.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options">
-      <Version>1.1.1</Version>
+      <Version>1.1.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/examples/ClusterHelloWorld/Node2/Node2.csproj
+++ b/examples/ClusterHelloWorld/Node2/Node2.csproj
@@ -7,7 +7,7 @@
     <Content Include="runtimeconfig.template.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="Microsoft.Extensions.Options">
       <Version>1.1.2</Version>
     </PackageReference>

--- a/examples/ClusterHelloWorld/Node2/Node2.csproj
+++ b/examples/ClusterHelloWorld/Node2/Node2.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Options">
       <Version>1.1.2</Version>
     </PackageReference>
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\ClusterProviders\Proto.Cluster.Consul\Proto.Cluster.Consul.csproj" />

--- a/examples/MailboxBenchmark/MailboxBenchmark.csproj
+++ b/examples/MailboxBenchmark/MailboxBenchmark.csproj
@@ -8,6 +8,6 @@
     <ProjectReference Include="..\..\src\Proto.Mailbox\Proto.Mailbox.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotnet" Version="0.10.8" />
+    <PackageReference Include="BenchmarkDotnet" Version="0.10.9" />
   </ItemGroup>
 </Project>

--- a/examples/Persistence/Messages/Messages.csproj
+++ b/examples/Persistence/Messages/Messages.csproj
@@ -13,6 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 </Project>

--- a/examples/Persistence/Messages/Messages.csproj
+++ b/examples/Persistence/Messages/Messages.csproj
@@ -12,7 +12,7 @@
     <None Include="Protos.proto" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/examples/RemoteBenchmark/Messages/Messages.csproj
+++ b/examples/RemoteBenchmark/Messages/Messages.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/RemoteBenchmark/Messages/Messages.csproj
+++ b/examples/RemoteBenchmark/Messages/Messages.csproj
@@ -10,7 +10,7 @@
     <None Include="Protos.proto" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/examples/RemoteBenchmark/Node2/Node2.csproj
+++ b/examples/RemoteBenchmark/Node2/Node2.csproj
@@ -7,7 +7,7 @@
     <Content Include="runtimeconfig.template.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/examples/RemoteBenchmark/Node2/Node2.csproj
+++ b/examples/RemoteBenchmark/Node2/Node2.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/RemoteBenchmarkWireSerializer/Messages/Messages.csproj
+++ b/examples/RemoteBenchmarkWireSerializer/Messages/Messages.csproj
@@ -6,7 +6,7 @@
     <OutputType>library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/RemoteBenchmarkWireSerializer/Messages/Messages.csproj
+++ b/examples/RemoteBenchmarkWireSerializer/Messages/Messages.csproj
@@ -6,7 +6,7 @@
     <OutputType>library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/RemoteBenchmarkWireSerializer/Node2/Node2.csproj
+++ b/examples/RemoteBenchmarkWireSerializer/Node2/Node2.csproj
@@ -7,7 +7,7 @@
     <Content Include="runtimeconfig.template.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/examples/RemoteBenchmarkWireSerializer/Node2/Node2.csproj
+++ b/examples/RemoteBenchmarkWireSerializer/Node2/Node2.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor.Wire\Proto.Serialization.Wire.csproj" />

--- a/examples/RemoteBenchmarkWireSerializer/Node2/Node2.csproj
+++ b/examples/RemoteBenchmarkWireSerializer/Node2/Node2.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor.Wire\Proto.Serialization.Wire.csproj" />

--- a/examples/SpawnBenchmark/SpawnBenchmark.csproj
+++ b/examples/SpawnBenchmark/SpawnBenchmark.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/SpawnBenchmark/SpawnBenchmark.csproj
+++ b/examples/SpawnBenchmark/SpawnBenchmark.csproj
@@ -7,7 +7,7 @@
     <Content Include="runtimeconfig.template.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/protobuf/ProtoGrainGenerator/ProtoGrainGenerator.csproj
+++ b/protobuf/ProtoGrainGenerator/ProtoGrainGenerator.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Handlebars.Net" Version="1.9.0" />
-    <PackageReference Include="protobuf-net" Version="2.2.1" />
+    <PackageReference Include="protobuf-net" Version="2.3.2" />
     <PackageReference Include="protobuf-net.Reflection" Version="0.9.0" />
   </ItemGroup>
 

--- a/src/ClusterProviders/Proto.Cluster.Consul/Proto.Cluster.Consul.csproj
+++ b/src/ClusterProviders/Proto.Cluster.Consul/Proto.Cluster.Consul.csproj
@@ -20,7 +20,7 @@
     <FileVersion>0.1.2.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Consul" Version="0.7.2.1" />
+    <PackageReference Include="Consul" Version="0.7.2.3" />
     <PackageReference Include="Microsoft.Extensions.Options">
       <Version>1.1.2</Version>
     </PackageReference>

--- a/src/ClusterProviders/Proto.Cluster.Consul/Proto.Cluster.Consul.csproj
+++ b/src/ClusterProviders/Proto.Cluster.Consul/Proto.Cluster.Consul.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Consul" Version="0.7.2.1" />
     <PackageReference Include="Microsoft.Extensions.Options">
-      <Version>1.1.1</Version>
+      <Version>1.1.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/PersistenceProviders/Proto.Persistence.Couchbase/Proto.Persistence.Couchbase.csproj
+++ b/src/PersistenceProviders/Proto.Persistence.Couchbase/Proto.Persistence.Couchbase.csproj
@@ -19,7 +19,7 @@
     <FileVersion>0.1.2.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="2.4.0" />
+    <PackageReference Include="CouchbaseNetClient" Version="2.4.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Proto.Actor\Proto.Actor.csproj" />

--- a/src/PersistenceProviders/Proto.Persistence.Marten/Proto.Persistence.Marten.csproj
+++ b/src/PersistenceProviders/Proto.Persistence.Marten/Proto.Persistence.Marten.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Marten" Version="1.4.1" />
+    <PackageReference Include="Marten" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PersistenceProviders/Proto.Persistence.MongoDB/Proto.Persistence.MongoDB.csproj
+++ b/src/PersistenceProviders/Proto.Persistence.MongoDB/Proto.Persistence.MongoDB.csproj
@@ -25,9 +25,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.4.3" />
-    <PackageReference Include="MongoDB.Driver.Core" Version="2.4.3" />
-    <PackageReference Include="MongoDB.Bson" Version="2.4.3" />
+    <PackageReference Include="MongoDB.Driver" Version="2.4.4" />
+    <PackageReference Include="MongoDB.Driver.Core" Version="2.4.4" />
+    <PackageReference Include="MongoDB.Bson" Version="2.4.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PersistenceProviders/Proto.Persistence.RavenDB/Proto.Persistence.RavenDB.csproj
+++ b/src/PersistenceProviders/Proto.Persistence.RavenDB/Proto.Persistence.RavenDB.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RavenDB.Client" Version="3.5.3" />
+    <PackageReference Include="RavenDB.Client" Version="3.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Proto.Actor/Proto.Actor.csproj
+++ b/src/Proto.Actor/Proto.Actor.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Proto.Mailbox\Proto.Mailbox.csproj" />

--- a/src/Proto.Actor/Proto.Actor.csproj
+++ b/src/Proto.Actor/Proto.Actor.csproj
@@ -25,7 +25,7 @@
     <None Include="Protos.proto" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>

--- a/src/Proto.Persistence/Proto.Persistence.csproj
+++ b/src/Proto.Persistence/Proto.Persistence.csproj
@@ -20,6 +20,6 @@
     <FileVersion>0.1.6.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 </Project>

--- a/src/Proto.Remote/EndpointReader.cs
+++ b/src/Proto.Remote/EndpointReader.cs
@@ -14,12 +14,12 @@ namespace Proto.Remote
 {
     public class EndpointReader : Remoting.RemotingBase
     {
-        public override async Task<ConnectResponse> Connect(ConnectRequest request, ServerCallContext context)
+        public override Task<ConnectResponse> Connect(ConnectRequest request, ServerCallContext context)
         {
-            return new ConnectResponse()
+            return Task.FromResult(new ConnectResponse()
             {
                 DefaultSerializerId = Serialization.DefaultSerializerId
-            };
+            });
         }
 
         public override async Task Receive(IAsyncStreamReader<MessageBatch> requestStream,

--- a/src/Proto.Remote/Proto.Remote.csproj
+++ b/src/Proto.Remote/Proto.Remote.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
-    <PackageReference Include="Grpc" Version="1.1.0" />
+    <PackageReference Include="Grpc" Version="1.4.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Proto.Actor\Proto.Actor.csproj" />

--- a/src/Proto.Remote/Proto.Remote.csproj
+++ b/src/Proto.Remote/Proto.Remote.csproj
@@ -20,8 +20,8 @@
     <None Include="Protos.proto" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="Grpc" Version="1.1.0" />
-    <PackageReference Include="protobuf" Version="2.6.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Proto.Actor\Proto.Actor.csproj" />

--- a/tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj
+++ b/tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj
@@ -3,8 +3,11 @@
     <RootNamespace>Proto.Tests</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <ApplicationIcon />
+    <OutputTypeEx>library</OutputTypeEx>
+    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Fixture\**" />
@@ -12,7 +15,7 @@
     <None Remove="Fixture\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/tests/Proto.Mailbox.Tests/Proto.Mailbox.Tests.csproj
+++ b/tests/Proto.Mailbox.Tests/Proto.Mailbox.Tests.csproj
@@ -1,10 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <ApplicationIcon />
+    <OutputTypeEx>library</OutputTypeEx>
+    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/tests/Proto.Persistence.Tests/Proto.Persistence.Tests.csproj
+++ b/tests/Proto.Persistence.Tests/Proto.Persistence.Tests.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/tests/Proto.Remote.Tests.Messages/Proto.Remote.Tests.Messages.csproj
+++ b/tests/Proto.Remote.Tests.Messages/Proto.Remote.Tests.Messages.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Proto.Remote.Tests.Node/Proto.Remote.Tests.Node.csproj
+++ b/tests/Proto.Remote.Tests.Node/Proto.Remote.Tests.Node.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Google.Protobuf" Version="3.3.0" />
         <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-        <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+        <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/tests/Proto.Remote.Tests.Node/Proto.Remote.Tests.Node.csproj
+++ b/tests/Proto.Remote.Tests.Node/Proto.Remote.Tests.Node.csproj
@@ -7,7 +7,7 @@
         <RootNamespace>Proto.Remote.Tests.Node</RootNamespace>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.2.0" />
+        <PackageReference Include="Google.Protobuf" Version="3.3.0" />
         <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
         <PackageReference Include="System.ValueTuple" Version="4.3.1" />
     </ItemGroup>

--- a/tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj
+++ b/tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/tests/Proto.Router.Tests/Proto.Router.Tests.csproj
+++ b/tests/Proto.Router.Tests/Proto.Router.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/tests/Proto.Router.Tests/Proto.Router.Tests.csproj
+++ b/tests/Proto.Router.Tests/Proto.Router.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />


### PR DESCRIPTION
For some reason, Google.Protobuf was replaced with Protobuf nuget (and it was on my commit)
This PR use the correct Google.Protobuf lib again and also consolidates a lot of other nugets.

Preferably, we should try to scan for different versions used on PR. not sure if there is such tool though.