### PR TITLE
test: fix timing issue in mailbox/actor tests for #153

### DIFF
--- a/tests/Proto.Mailbox.Tests/EscalateFailureTests.cs
+++ b/tests/Proto.Mailbox.Tests/EscalateFailureTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using Proto.TestFixtures;
 using Xunit;
 
@@ -54,9 +53,10 @@ namespace Proto.Mailbox.Tests
 
             mailbox.PostUserMessage(msg1);
             var taskException = new Exception();
-            msg1.TaskCompletionSource.SetException(taskException);
 
-            Thread.Sleep(500);
+            Action resumeMailboxTrigger = () => msg1.TaskCompletionSource.SetException(taskException);
+            mailboxHandler.ResumeMailboxProcessingAndWait(resumeMailboxTrigger);
+
             Assert.Equal(1, mailboxHandler.EscalatedFailures.Count);
             var e = Assert.IsType<AggregateException>(mailboxHandler.EscalatedFailures[0]);
             Assert.Equal(taskException, e.InnerException);
@@ -73,9 +73,10 @@ namespace Proto.Mailbox.Tests
 
             mailbox.PostSystemMessage(msg1);
             var taskException = new Exception();
-            msg1.TaskCompletionSource.SetException(taskException);
 
-            Thread.Sleep(500);
+            Action resumeMailboxTrigger = () => msg1.TaskCompletionSource.SetException(taskException);
+            mailboxHandler.ResumeMailboxProcessingAndWait(resumeMailboxTrigger);
+
             Assert.Equal(1, mailboxHandler.EscalatedFailures.Count);
             var e = Assert.IsType<AggregateException>(mailboxHandler.EscalatedFailures[0]);
             Assert.Equal(taskException, e.InnerException);

--- a/tests/Proto.Mailbox.Tests/EscalateFailureTests.cs
+++ b/tests/Proto.Mailbox.Tests/EscalateFailureTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Proto.TestFixtures;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace Proto.Mailbox.Tests
 {
@@ -43,7 +44,7 @@ namespace Proto.Mailbox.Tests
         }
 
         [Fact]
-        public void GivenNonCompletedUserMessageTaskThrewException_ShouldEscalateFailure()
+        public async Task GivenNonCompletedUserMessageTaskThrewException_ShouldEscalateFailure()
         {
             var mailboxHandler = new TestMailboxHandler();
             var mailbox = UnboundedMailbox.Create();
@@ -55,7 +56,8 @@ namespace Proto.Mailbox.Tests
             var taskException = new Exception();
 
             Action resumeMailboxTrigger = () => msg1.TaskCompletionSource.SetException(taskException);
-            mailboxHandler.ResumeMailboxProcessingAndWait(resumeMailboxTrigger);
+            await mailboxHandler.ResumeMailboxProcessingAndWaitAsync(resumeMailboxTrigger)
+                .ConfigureAwait(false);
 
             Assert.Equal(1, mailboxHandler.EscalatedFailures.Count);
             var e = Assert.IsType<AggregateException>(mailboxHandler.EscalatedFailures[0]);
@@ -63,7 +65,7 @@ namespace Proto.Mailbox.Tests
         }
 
         [Fact]
-        public void GivenNonCompletedSystemMessageTaskThrewException_ShouldEscalateFailure()
+        public async Task GivenNonCompletedSystemMessageTaskThrewException_ShouldEscalateFailure()
         {
             var mailboxHandler = new TestMailboxHandler();
             var mailbox = UnboundedMailbox.Create();
@@ -75,7 +77,8 @@ namespace Proto.Mailbox.Tests
             var taskException = new Exception();
 
             Action resumeMailboxTrigger = () => msg1.TaskCompletionSource.SetException(taskException);
-            mailboxHandler.ResumeMailboxProcessingAndWait(resumeMailboxTrigger);
+            await mailboxHandler.ResumeMailboxProcessingAndWaitAsync(resumeMailboxTrigger)
+                .ConfigureAwait(false);
 
             Assert.Equal(1, mailboxHandler.EscalatedFailures.Count);
             var e = Assert.IsType<AggregateException>(mailboxHandler.EscalatedFailures[0]);

--- a/tests/Proto.Mailbox.Tests/MailboxSchedulingTests.cs
+++ b/tests/Proto.Mailbox.Tests/MailboxSchedulingTests.cs
@@ -1,5 +1,6 @@
 ﻿using Proto.TestFixtures;
 using System;
+using System.Threading.Tasks;
 using Xunit;
 using TestMessage = Proto.TestFixtures.TestMessage;
 
@@ -8,7 +9,7 @@ namespace Proto.Mailbox.Tests
     public class MailboxSchedulingTests
     {
         [Fact]
-        public void GivenNonCompletedUserMessage_ShouldHaltProcessingUntilCompletion()
+        public async Task GivenNonCompletedUserMessage_ShouldHaltProcessingUntilCompletion()
         {
             var mailboxHandler = new TestMailboxHandler();
             var userMailbox = new UnboundedMailboxQueue();
@@ -31,8 +32,9 @@ namespace Proto.Mailbox.Tests
                 msg1.TaskCompletionSource.SetResult(0);
             };
 
-            mailboxHandler.ResumeMailboxProcessingAndWait(resumeMailboxTrigger);
-            
+            await mailboxHandler.ResumeMailboxProcessingAndWaitAsync(resumeMailboxTrigger)
+                .ConfigureAwait(false);
+
             Assert.False(userMailbox.HasMessages, "Mailbox should have processed msg2 because processing of msg1 is completed.");
         }
 
@@ -56,7 +58,7 @@ namespace Proto.Mailbox.Tests
         }
 
         [Fact]
-        public void GivenNonCompletedSystemMessage_ShouldHaltProcessingUntilCompletion()
+        public async Task GivenNonCompletedSystemMessage_ShouldHaltProcessingUntilCompletion()
         {
             var mailboxHandler = new TestMailboxHandler();
             var userMailbox = new UnboundedMailboxQueue();
@@ -79,8 +81,8 @@ namespace Proto.Mailbox.Tests
                 msg1.TaskCompletionSource.SetResult(0);
             };
 
-            mailboxHandler.ResumeMailboxProcessingAndWait(resumeMailboxTrigger);
-
+            await mailboxHandler.ResumeMailboxProcessingAndWaitAsync(resumeMailboxTrigger)
+                .ConfigureAwait(false);
 
             Assert.False(systemMessages.HasMessages, "Mailbox should have processed msg2 because processing of msg1 is completed.");
         }
@@ -105,7 +107,7 @@ namespace Proto.Mailbox.Tests
         }
 
         [Fact]
-        public void GivenNonCompletedUserMessage_ShouldSetMailboxToIdleAfterCompletion()
+        public async Task GivenNonCompletedUserMessage_ShouldSetMailboxToIdleAfterCompletion()
         {
             var mailboxHandler = new TestMailboxHandler();
             var userMailbox = new UnboundedMailboxQueue();
@@ -117,7 +119,8 @@ namespace Proto.Mailbox.Tests
             mailbox.PostUserMessage(msg1);
 
             Action resumeMailboxTrigger = () => msg1.TaskCompletionSource.SetResult(0);
-            mailboxHandler.ResumeMailboxProcessingAndWait(resumeMailboxTrigger);
+            await mailboxHandler.ResumeMailboxProcessingAndWaitAsync(resumeMailboxTrigger)
+                .ConfigureAwait(false);
 
             Assert.True(mailbox.Status == MailboxStatus.Idle, "Mailbox should be set back to Idle after completion of message.");
         }

--- a/tests/Proto.Mailbox.Tests/MailboxStatisticsTests.cs
+++ b/tests/Proto.Mailbox.Tests/MailboxStatisticsTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Proto.TestFixtures;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace Proto.Mailbox.Tests
 {
@@ -54,7 +55,7 @@ namespace Proto.Mailbox.Tests
         }
 
         [Fact]
-        public void GivenNonCompletedUserMessage_ShouldInvokeMessageReceivedAfterCompletion()
+        public async Task GivenNonCompletedUserMessage_ShouldInvokeMessageReceivedAfterCompletion()
         {
             var mailboxHandler = new TestMailboxHandler();
             var userMailbox = new UnboundedMailboxQueue();
@@ -69,7 +70,8 @@ namespace Proto.Mailbox.Tests
             Assert.DoesNotContain(msg1, mailboxStatistics.Received);
 
             Action resumeMailboxTrigger = () => msg1.TaskCompletionSource.SetResult(0);
-            mailboxHandler.ResumeMailboxProcessingAndWait(resumeMailboxTrigger);
+            await mailboxHandler.ResumeMailboxProcessingAndWaitAsync(resumeMailboxTrigger)
+                .ConfigureAwait(false);
 
             Assert.Contains(msg1, mailboxStatistics.Posted);
         }
@@ -92,7 +94,7 @@ namespace Proto.Mailbox.Tests
         }
 
         [Fact]
-        public void GivenNonCompletedUserMessageThrewException_ShouldNotInvokeMessageReceived()
+        public async Task GivenNonCompletedUserMessageThrewException_ShouldNotInvokeMessageReceived()
         {
             var mailboxHandler = new TestMailboxHandler();
             var userMailbox = new UnboundedMailboxQueue();
@@ -106,7 +108,8 @@ namespace Proto.Mailbox.Tests
             mailbox.PostUserMessage(msg1);
 
             Action resumeMailboxTrigger = () => msg1.TaskCompletionSource.SetException(new Exception());
-            mailboxHandler.ResumeMailboxProcessingAndWait(resumeMailboxTrigger);
+            await mailboxHandler.ResumeMailboxProcessingAndWaitAsync(resumeMailboxTrigger)
+                .ConfigureAwait(false);
 
             Assert.DoesNotContain(msg1, mailboxStatistics.Received);
         }
@@ -130,7 +133,7 @@ namespace Proto.Mailbox.Tests
         }
 
         [Fact]
-        public void GivenNonCompletedSystemMessageThrewException_ShouldNotInvokeMessageReceived()
+        public async Task GivenNonCompletedSystemMessageThrewException_ShouldNotInvokeMessageReceived()
         {
             var mailboxHandler = new TestMailboxHandler();
             var userMailbox = new UnboundedMailboxQueue();
@@ -144,7 +147,8 @@ namespace Proto.Mailbox.Tests
             mailbox.PostSystemMessage(msg1);
 
             Action resumeMailboxTrigger = () => msg1.TaskCompletionSource.SetException(new Exception());
-            mailboxHandler.ResumeMailboxProcessingAndWait(resumeMailboxTrigger);
+            await mailboxHandler.ResumeMailboxProcessingAndWaitAsync(resumeMailboxTrigger)
+                .ConfigureAwait(false);
 
             Assert.DoesNotContain(msg1, mailboxStatistics.Received);
         }

--- a/tests/Proto.Mailbox.Tests/MailboxStatisticsTests.cs
+++ b/tests/Proto.Mailbox.Tests/MailboxStatisticsTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 using Proto.TestFixtures;
 using Xunit;
 
@@ -69,8 +68,9 @@ namespace Proto.Mailbox.Tests
             mailbox.PostUserMessage(msg1);
             Assert.DoesNotContain(msg1, mailboxStatistics.Received);
 
-            msg1.TaskCompletionSource.SetResult(0);
-            Thread.Sleep(10);
+            Action resumeMailboxTrigger = () => msg1.TaskCompletionSource.SetResult(0);
+            mailboxHandler.ResumeMailboxProcessingAndWait(resumeMailboxTrigger);
+
             Assert.Contains(msg1, mailboxStatistics.Posted);
         }
 
@@ -104,9 +104,10 @@ namespace Proto.Mailbox.Tests
             var msg1 = new TestMessage();
 
             mailbox.PostUserMessage(msg1);
-            msg1.TaskCompletionSource.SetException(new Exception());
 
-            Thread.Sleep(10);
+            Action resumeMailboxTrigger = () => msg1.TaskCompletionSource.SetException(new Exception());
+            mailboxHandler.ResumeMailboxProcessingAndWait(resumeMailboxTrigger);
+
             Assert.DoesNotContain(msg1, mailboxStatistics.Received);
         }
 
@@ -141,9 +142,10 @@ namespace Proto.Mailbox.Tests
             var msg1 = new TestMessage();
 
             mailbox.PostSystemMessage(msg1);
-            msg1.TaskCompletionSource.SetException(new Exception());
 
-            Thread.Sleep(10);
+            Action resumeMailboxTrigger = () => msg1.TaskCompletionSource.SetException(new Exception());
+            mailboxHandler.ResumeMailboxProcessingAndWait(resumeMailboxTrigger);
+
             Assert.DoesNotContain(msg1, mailboxStatistics.Received);
         }
 

--- a/tests/Proto.TestFixtures/TestMailboxHandler.cs
+++ b/tests/Proto.TestFixtures/TestMailboxHandler.cs
@@ -2,11 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Proto.Mailbox;
+using System.Threading;
 
 namespace Proto.TestFixtures
 {
     public class TestMailboxHandler : IMessageInvoker, IDispatcher
     {
+        private AutoResetEvent _onScheduleCompleted;
+
         public List<Exception> EscalatedFailures { get; set; } = new List<Exception>();
 
         public Task InvokeSystemMessageAsync(object msg)
@@ -28,7 +31,19 @@ namespace Proto.TestFixtures
 
         public void Schedule(Func<Task> runner)
         {
-            runner();
+            runner().Wait();
+            _onScheduleCompleted?.Set();
+        }
+
+        /// <summary>
+        /// Wraps around an action that resumes and waits for mailbox processing to finish
+        /// </summary>
+        /// <param name="resumeMailboxProcessing">A trigger that will cause message processing to resume</param>
+        public void ResumeMailboxProcessingAndWait(Action resumeMailboxProcessing)
+        {
+            _onScheduleCompleted = new AutoResetEvent(false);
+            resumeMailboxProcessing();
+            _onScheduleCompleted.WaitOne();
         }
     }
 }


### PR DESCRIPTION
Replaces Thread.Sleep usages in the tests with more deterministic code that waits for the mailbox to complete processing before Asserting.

Originally fixed only EscalateFailureTests and MailboxSchedulingTests based on the example build failures, but also updated ReceiveTimeoutTests as one of the tests failed randomly in VS.