### PR TITLE
Fix bug: HashAlgorithm not Initialize before ComputeHash.

### DIFF
--- a/src/Proto.Cluster/HashRing.cs
+++ b/src/Proto.Cluster/HashRing.cs
@@ -44,6 +44,7 @@ namespace Proto.Cluster
 
         private static uint Hash(string s)
         {
+            HashAlgorithm.Initialize();
             var digest = HashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(s));
             var hash = BitConverter.ToUInt32(digest, 0);
             return hash;


### PR DESCRIPTION
Fix bug where HashAlgorithm not being Initialized before computing hash.
This will result in wrong hash number since initial prime number is not applied.