### PR TITLE
Graceful shutdown and others

### DIFF
--- a/examples/ClusterGrainHelloWorld/Node1/Program.cs
+++ b/examples/ClusterGrainHelloWorld/Node1/Program.cs
@@ -16,8 +16,7 @@ class Program
     static void Main(string[] args)
     {
         Serialization.RegisterFileDescriptor(ProtosReflection.Descriptor);
-        Remote.Start("127.0.0.1", 12001);
-        Cluster.Start("MyCluster", new ConsulProvider(new ConsulProviderOptions()));
+        Cluster.Start("MyCluster", "127.0.0.1", 12001, new ConsulProvider(new ConsulProviderOptions()));
 
         var client = Grains.HelloGrain("TheName");
 

--- a/examples/ClusterGrainHelloWorld/Node2/Program.cs
+++ b/examples/ClusterGrainHelloWorld/Node2/Program.cs
@@ -30,9 +30,8 @@ namespace Node2
         {
             Serialization.RegisterFileDescriptor(ProtosReflection.Descriptor);          
             Grains.HelloGrainFactory(() => new HelloGrain());
-           
-            Remote.Start("127.0.0.1", 12000);
-            Cluster.Start("MyCluster", new ConsulProvider(new ConsulProviderOptions()));
+
+            Cluster.Start("MyCluster", "127.0.0.1", 12000, new ConsulProvider(new ConsulProviderOptions()));
 
             Console.ReadLine();
         }

--- a/examples/ClusterHelloWorld/Node1/Program.cs
+++ b/examples/ClusterHelloWorld/Node1/Program.cs
@@ -17,8 +17,7 @@ class Program
     static void Main(string[] args)
     {
         Serialization.RegisterFileDescriptor(ProtosReflection.Descriptor);
-        Remote.Start("127.0.0.1", 12001);
-        Cluster.Start("MyCluster", new ConsulProvider(new ConsulProviderOptions()));
+        Cluster.Start("MyCluster", "127.0.0.1", 12001, new ConsulProvider(new ConsulProviderOptions()));
         var pid = Cluster.GetAsync("TheName", "HelloKind").Result;
         var res = pid.RequestAsync<HelloResponse>(new HelloRequest()).Result;
         Console.WriteLine(res.Message);

--- a/examples/ClusterHelloWorld/Node2/Program.cs
+++ b/examples/ClusterHelloWorld/Node2/Program.cs
@@ -34,8 +34,7 @@ namespace Node2
             });
 
             Remote.RegisterKnownKind("HelloKind", props);
-            Remote.Start("127.0.0.1", 12000);
-            Cluster.Start("MyCluster", new ConsulProvider(new ConsulProviderOptions()));
+            Cluster.Start("MyCluster", "127.0.0.1", 12000, new ConsulProvider(new ConsulProviderOptions()));
 
             Console.ReadLine();
         }

--- a/src/ClusterProviders/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/ClusterProviders/Proto.Cluster.Consul/ConsulProvider.cs
@@ -139,7 +139,7 @@ namespace Proto.Cluster.Consul
                 }
             });
         }
-        
+
         private void UpdateTtl()
         {
             Task.Run(async () =>

--- a/src/ClusterProviders/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/ClusterProviders/Proto.Cluster.Consul/ConsulProvider.cs
@@ -122,7 +122,7 @@ namespace Proto.Cluster.Consul
             _deregistered = true;
         }
 
-        public async Task StopProvider()
+        public async Task Shutdown()
         {
             _shutdown = true;
             if (!_deregistered)

--- a/src/ClusterProviders/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/ClusterProviders/Proto.Cluster.Consul/ConsulProvider.cs
@@ -40,6 +40,8 @@ namespace Proto.Cluster.Consul
     {
         private readonly ConsulClient _client;
         private string _clusterName;
+        private string _host;
+        private int _port;
         private TimeSpan _serviceTtl;
         private TimeSpan _blockingWaitTime;
         private TimeSpan _deregisterCritical;
@@ -75,6 +77,8 @@ namespace Proto.Cluster.Consul
         {
             _id = $"{clusterName}@{host}:{port}";
             _clusterName = clusterName;
+            _host = host;
+            _port = port;
             _index = 0;
 
             var s = new AgentServiceRegistration
@@ -107,6 +111,13 @@ namespace Proto.Cluster.Consul
             await BlockingUpdateTtlAsync();
             await BlockingStatusChangeAsync();
             UpdateTtl();
+        }
+
+        public async Task StopClusterProvider()
+        {
+            _shutdown = true;
+            var kvKey = $"{_clusterName}/{_host}:{_port}"; //slash should be present
+            await _client.KV.Delete(kvKey);
         }
 
         public void MonitorMemberStatusChanges()

--- a/src/ClusterProviders/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/ClusterProviders/Proto.Cluster.Consul/ConsulProvider.cs
@@ -98,7 +98,7 @@ namespace Proto.Cluster.Consul
 
             //register a semi unique ID for the current process
             _kvKey = $"{_clusterName}/{host}:{port}"; //slash should be present
-            var value = Encoding.UTF8.GetBytes(DateTime.UtcNow.ToString());
+            var value = Encoding.UTF8.GetBytes(DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ssK"));
             await _client.KV.Put(new KVPair(_kvKey)
                                  {
                                      //Write the ID for this member.

--- a/src/ClusterProviders/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/ClusterProviders/Proto.Cluster.Consul/ConsulProvider.cs
@@ -113,11 +113,16 @@ namespace Proto.Cluster.Consul
             UpdateTtl();
         }
 
-        public async Task StopClusterProvider()
+        public async Task DeregisterMemberAsync()
         {
-            _shutdown = true;
             var kvKey = $"{_clusterName}/{_host}:{_port}"; //slash should be present
             await _client.KV.Delete(kvKey);
+        }
+
+        public Task StopProvider()
+        {
+            _shutdown = true;
+            return Task.FromResult(0);
         }
 
         public void MonitorMemberStatusChanges()
@@ -130,7 +135,7 @@ namespace Proto.Cluster.Consul
                 }
             });
         }
-
+        
         private void UpdateTtl()
         {
             Task.Run(async () =>

--- a/src/Proto.Actor/EventStream.cs
+++ b/src/Proto.Actor/EventStream.cs
@@ -93,7 +93,7 @@ namespace Proto
             }
         }
 
-        internal void Unsubscribe(Guid id)
+        public void Unsubscribe(Guid id)
         {
             _subscriptions.TryRemove(id, out var _);
         }

--- a/src/Proto.Actor/FastSet.cs
+++ b/src/Proto.Actor/FastSet.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace Proto
 {
-    internal class FastSet<T> : IEnumerable<T>
+    public class FastSet<T> : IEnumerable<T>
     {
         private T _first;
         private HashSet<T> _set;

--- a/src/Proto.Actor/ProcessRegistry.cs
+++ b/src/Proto.Actor/ProcessRegistry.cs
@@ -49,7 +49,7 @@ namespace Proto
 
         public (PID pid, bool ok) TryGet(string id)
         {
-            return _localActorRefs.TryGetValue(id, out var process) && process is LocalProcess && !((LocalProcess)process).IsDead
+            return _localActorRefs.TryGetValue(id, out var process)
                        ? (new PID(Address, id, process), true)
                        : (null, false);
         }
@@ -60,18 +60,6 @@ namespace Proto
             
             var ok = _localActorRefs.TryAdd(pid.Id, process);
             return (pid, ok);
-        }
-        
-        public PID ForceAdd(string id, Process process)
-        {
-            var pid = new PID(Address, id, process);
-
-            if (_localActorRefs.TryAdd(pid.Id, process))
-                return pid;
-
-            _localActorRefs.Remove(pid.Id);
-            _localActorRefs.TryAdd(pid.Id, process);
-            return pid;
         }
 
         public void Remove(PID pid)

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -30,6 +30,7 @@ namespace Proto.Cluster
             Partition.SpawnPartitionActors(kinds);
             Partition.SubscribeToEventStream();
             PidCache.Spawn();
+            PidCache.SubscribeToEventStream();
             MemberList.Spawn();
             MemberList.SubscribeToEventStream();
             cp.RegisterMemberAsync(clusterName, h, p, kinds).Wait();
@@ -51,6 +52,7 @@ namespace Proto.Cluster
 
                 MemberList.UnsubEventStream();
                 MemberList.Stop();
+                PidCache.UnsubEventStream();
                 PidCache.Stop();
                 Partition.UnsubEventStream();
                 Partition.StopPartitionActors();

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -17,8 +17,10 @@ namespace Proto.Cluster
 
         private static IClusterProvider cp;
         
-        public static void Start(string clusterName, IClusterProvider provider)
+        public static void Start(string clusterName, string address, int port, IClusterProvider provider)
         {
+            Remote.Remote.Start(address, port);
+
             cp = provider;
             
             Serialization.RegisterFileDescriptor(ProtosReflection.Descriptor);
@@ -41,15 +43,20 @@ namespace Proto.Cluster
             cp.DeregisterMemberAsync();
         }
         
-        public static void Stop()
+        public static void Stop(bool gracefull = true)
         {
-            cp.StopProvider();
-            
-            MemberList.UnsubEventStream();
-            MemberList.Stop();
-            PidCache.Stop();
-            Partition.UnsubEventStream();
-            Partition.StopPartitionActors();
+            if (gracefull)
+            {
+                cp.StopProvider();
+
+                MemberList.UnsubEventStream();
+                MemberList.Stop();
+                PidCache.Stop();
+                Partition.UnsubEventStream();
+                Partition.StopPartitionActors();
+            }
+
+            Remote.Remote.Stop(gracefull);
 
             Logger.LogInformation("Stopped Cluster");
         }

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -39,7 +39,7 @@ namespace Proto.Cluster
             Logger.LogInformation("Started Cluster");
         }
         
-        public static void Stop(bool gracefull = true)
+        public static void Shutdown(bool gracefull = true)
         {
             if (gracefull)
             {
@@ -53,7 +53,7 @@ namespace Proto.Cluster
                 Partition.StopPartitionActors();
             }
 
-            Remote.Remote.Stop(gracefull);
+            Remote.Remote.Shutdown(gracefull);
 
             Logger.LogInformation("Stopped Cluster");
         }

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -36,9 +36,14 @@ namespace Proto.Cluster
             Logger.LogInformation("Started Cluster");
         }
 
+        public static void SetUnavailable()
+        {
+            cp.DeregisterMemberAsync();
+        }
+        
         public static void Stop()
         {
-            cp.StopClusterProvider();
+            cp.StopProvider();
             
             MemberList.UnsubEventStream();
             MemberList.Stop();

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -38,17 +38,12 @@ namespace Proto.Cluster
 
             Logger.LogInformation("Started Cluster");
         }
-
-        public static void SetUnavailable()
-        {
-            cp.DeregisterMemberAsync();
-        }
         
         public static void Stop(bool gracefull = true)
         {
             if (gracefull)
             {
-                cp.StopProvider();
+                cp.Shutdown();
 
                 MemberList.UnsubEventStream();
                 MemberList.Stop();

--- a/src/Proto.Cluster/IClusterProvider.cs
+++ b/src/Proto.Cluster/IClusterProvider.cs
@@ -8,10 +8,11 @@ using System.Threading.Tasks;
 
 namespace Proto.Cluster
 {
-    public interface IClusterProvider
-    {
-        Task RegisterMemberAsync(string clusterName, string h, int p, string[] kinds);
-        void MonitorMemberStatusChanges();
-        Task StopClusterProvider();
-    }
+	public interface IClusterProvider
+	{
+		Task RegisterMemberAsync(string clusterName, string h, int p, string[] kinds);
+		void MonitorMemberStatusChanges();
+		Task DeregisterMemberAsync();
+		Task StopProvider();
+	}
 }

--- a/src/Proto.Cluster/IClusterProvider.cs
+++ b/src/Proto.Cluster/IClusterProvider.cs
@@ -12,5 +12,6 @@ namespace Proto.Cluster
     {
         Task RegisterMemberAsync(string clusterName, string h, int p, string[] kinds);
         void MonitorMemberStatusChanges();
+        Task StopClusterProvider();
     }
 }

--- a/src/Proto.Cluster/IClusterProvider.cs
+++ b/src/Proto.Cluster/IClusterProvider.cs
@@ -13,6 +13,6 @@ namespace Proto.Cluster
 		Task RegisterMemberAsync(string clusterName, string h, int p, string[] kinds);
 		void MonitorMemberStatusChanges();
 		Task DeregisterMemberAsync();
-		Task StopProvider();
+		Task Shutdown();
 	}
 }

--- a/src/Proto.Cluster/MemberList.cs
+++ b/src/Proto.Cluster/MemberList.cs
@@ -15,14 +15,26 @@ namespace Proto.Cluster
         private static readonly Random Random = new Random();
         public static PID Pid { get; private set; }
 
+        private static Subscription<object> clusterTopologyEvnSub;
+        
         internal static void SubscribeToEventStream()
         {
-            Actor.EventStream.Subscribe<ClusterTopologyEvent>(Pid.Tell);
+            clusterTopologyEvnSub = Actor.EventStream.Subscribe<ClusterTopologyEvent>(Pid.Tell);
+        }
+
+        internal static void UnsubEventStream()
+        {
+            Actor.EventStream.Unsubscribe(clusterTopologyEvnSub.Id);
         }
 
         internal static void Spawn()
         {
             Pid = Actor.SpawnNamed(Actor.FromProducer(() => new MemberListActor()), "memberlist");
+        }
+
+        internal static void Stop()
+        {
+            Pid.Stop();
         }
 
         public static async Task<string[]> GetMembersAsync(string kind)

--- a/src/Proto.Cluster/MemberList.cs
+++ b/src/Proto.Cluster/MemberList.cs
@@ -49,8 +49,8 @@ namespace Proto.Cluster
         public static async Task<string> GetMemberAsync(string name, string kind)
         {
             var members = await GetMembersAsync(kind);
-            var hashring = new HashRing(members);
-            var member = hashring.GetNode(name);
+            var hdv = new Rendezvous(members);
+            var member = hdv.GetNode(name);
             return member;
         }
     }

--- a/src/Proto.Cluster/Partition.cs
+++ b/src/Proto.Cluster/Partition.cs
@@ -91,7 +91,7 @@ namespace Proto.Cluster
                     await Spawn(msg, context);
                     break;
                 case MemberJoinedEvent msg:
-                    await MemberJoinedAsync(msg);
+                    await MemberJoinedAsync(msg, context);
                     break;
                 case MemberRejoinedEvent msg:
                     MemberRejoined(msg);
@@ -106,7 +106,7 @@ namespace Proto.Cluster
                     MemberUnavailable(msg);
                     break;
                 case TakeOwnership msg:
-                    TakeOwnership(msg);
+                    TakeOwnership(msg, context);
                     break;
                 case Terminated msg:
                     Terminated(msg);
@@ -124,9 +124,10 @@ namespace Proto.Cluster
             }
         }
 
-        private void TakeOwnership(TakeOwnership msg)
+        private void TakeOwnership(TakeOwnership msg, IContext context)
         {
             _partition[msg.Name] = msg.Pid;
+            context.Watch(msg.Pid);
         }
 
         private void MemberUnavailable(MemberUnavailableEvent msg)
@@ -164,7 +165,7 @@ namespace Proto.Cluster
             }
         }
 
-        private async Task MemberJoinedAsync(MemberJoinedEvent msg)
+        private async Task MemberJoinedAsync(MemberJoinedEvent msg, IContext context)
         {
             _logger.LogInformation("Member Joined {0}", msg.Address);
             //TODO: right now we transfer ownership on a per actor basis.
@@ -176,12 +177,12 @@ namespace Proto.Cluster
 
                 if (address != ProcessRegistry.Instance.Address)
                 {
-                    TransferOwnership(actorId, address);
+                    TransferOwnership(actorId, address, context);
                 }
             }
         }
 
-        private void TransferOwnership(string actorId, string address)
+        private void TransferOwnership(string actorId, string address, IContext context)
         {
             var pid = _partition[actorId];
             var owner = Partition.PartitionForKind(address, _kind);
@@ -191,6 +192,7 @@ namespace Proto.Cluster
                            Pid = pid
                        });
             _partition.Remove(actorId);
+            context.Unwatch(pid);
         }
 
         private async Task Spawn(ActorPidRequest msg, IContext context)

--- a/src/Proto.Cluster/PidCache.cs
+++ b/src/Proto.Cluster/PidCache.cs
@@ -26,6 +26,11 @@ namespace Proto.Cluster
             var props = Actor.FromProducer(() => new PidCachePartitionActor());
             Pid = Actor.SpawnNamed(props, "pidcache");
         }
+
+        internal static void Stop()
+        {
+            Pid.Stop();
+        }
     }
 
     internal class PidCacheRequest : IHashable

--- a/src/Proto.Cluster/Rendezvous.cs
+++ b/src/Proto.Cluster/Rendezvous.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Proto.Cluster
+{
+	/// <summary>
+	/// A dotnet port of rendezvous.go
+	/// </summary>
+	public class Rendezvous
+	{
+		private static readonly HashAlgorithm HashAlgorithm = FNV1A32.Create();
+
+		private class NodeScore
+		{
+			public byte[] node;
+			public uint score;
+		}
+
+		private NodeScore[] nodes;
+
+		public Rendezvous(string[] nodes)
+		{
+			this.nodes = new NodeScore[nodes.Length];
+			for (int i = 0; i < nodes.Length; i++)
+			{
+				this.nodes[i] = new NodeScore()
+				{
+					node = Encoding.UTF8.GetBytes(nodes[i]),
+					score = 0
+				};
+			}
+		}
+
+		public string GetNode(string key)
+		{
+			var keyBytes = Encoding.UTF8.GetBytes(key);
+
+			uint maxScore = 0;
+			byte[] maxNode = new byte[0];
+			uint score = 0;
+
+			for (int i = 0; i < this.nodes.Length; i++)
+			{
+				score = RdvHash(nodes[i].node, keyBytes);
+				if (score > maxScore)
+				{
+					maxScore = score;
+					maxNode = nodes[i].node;
+				}
+			}
+
+			return Encoding.UTF8.GetString(maxNode);
+		}
+
+		public string[] GetN(int n, string key)
+		{
+			if (this.nodes.Length == 0 || n == 0)
+			{
+				return new string[0];
+			}
+
+			if (n > this.nodes.Length)
+			{
+				n = this.nodes.Length;
+			}
+
+			var keyBytes = Encoding.UTF8.GetBytes(key);
+			for (int i = 0; i < this.nodes.Length; i++)
+			{
+				var ns = this.nodes[i];
+				ns.score = RdvHash(ns.node, keyBytes);
+			}
+
+			Array.Sort<NodeScore>(this.nodes, (n1, n2) => n2.score.CompareTo(n1.score));
+
+			var nodes = new string[n];
+			for (int i = 0; i < n; i++)
+			{
+				nodes[i] = Encoding.UTF8.GetString(this.nodes[i].node);
+			}
+			return nodes;
+		}
+
+		private uint RdvHash(byte[] node, byte[] key)
+		{
+			var hashBytes = MergeBytes(key, node);
+			var digest = HashAlgorithm.ComputeHash(hashBytes);
+			var hash = BitConverter.ToUInt32(digest, 0);
+			return hash;
+		}
+
+		private byte[] MergeBytes(byte[] front, byte[] back)
+		{
+			byte[] combined = new byte[front.Length + back.Length];
+			Array.Copy(front, combined, front.Length);
+			Array.Copy(back, 0, combined, front.Length, back.Length);
+			return combined;
+		}
+	}
+}

--- a/src/Proto.Cluster/Rendezvous.cs
+++ b/src/Proto.Cluster/Rendezvous.cs
@@ -13,8 +13,8 @@ namespace Proto.Cluster
 
 		private class NodeScore
 		{
-			public byte[] node;
-			public uint score;
+			public byte[] Node;
+			public uint Score;
 		}
 
 		private NodeScore[] nodes;
@@ -26,8 +26,8 @@ namespace Proto.Cluster
 			{
 				this.nodes[i] = new NodeScore()
 				{
-					node = Encoding.UTF8.GetBytes(nodes[i]),
-					score = 0
+					Node = Encoding.UTF8.GetBytes(nodes[i]),
+					Score = 0
 				};
 			}
 		}
@@ -42,11 +42,11 @@ namespace Proto.Cluster
 
 			for (int i = 0; i < this.nodes.Length; i++)
 			{
-				score = RdvHash(nodes[i].node, keyBytes);
+				score = RdvHash(nodes[i].Node, keyBytes);
 				if (score > maxScore)
 				{
 					maxScore = score;
-					maxNode = nodes[i].node;
+					maxNode = nodes[i].Node;
 				}
 			}
 
@@ -69,15 +69,15 @@ namespace Proto.Cluster
 			for (int i = 0; i < this.nodes.Length; i++)
 			{
 				var ns = this.nodes[i];
-				ns.score = RdvHash(ns.node, keyBytes);
+				ns.Score = RdvHash(ns.Node, keyBytes);
 			}
 
-			Array.Sort<NodeScore>(this.nodes, (n1, n2) => n2.score.CompareTo(n1.score));
+			Array.Sort<NodeScore>(this.nodes, (n1, n2) => n2.Score.CompareTo(n1.Score));
 
 			var nodes = new string[n];
 			for (int i = 0; i < n; i++)
 			{
-				nodes[i] = Encoding.UTF8.GetString(this.nodes[i].node);
+				nodes[i] = Encoding.UTF8.GetString(this.nodes[i].Node);
 			}
 			return nodes;
 		}

--- a/src/Proto.Remote/EndpointManager.cs
+++ b/src/Proto.Remote/EndpointManager.cs
@@ -44,6 +44,11 @@ namespace Proto.Remote
                         _logger.LogDebug("Started EndpointManager");
                         return Actor.Done;
                     }
+                case Stopped _:
+                    {
+                        _logger.LogDebug("Stopped EndpointManager");
+                        return Actor.Done;
+                    }
                 case EndpointTerminatedEvent msg:
                     {
                         var endpoint = EnsureConnected(msg.Address, context);

--- a/src/Proto.Remote/EndpointManager.cs
+++ b/src/Proto.Remote/EndpointManager.cs
@@ -25,6 +25,7 @@ namespace Proto.Remote
 
     public class EndpointManager : IActor, ISupervisorStrategy
     {
+        private readonly Behavior _behavior;
         private readonly RemoteConfig _config;
         private readonly Dictionary<string, Endpoint> _connections = new Dictionary<string, Endpoint>();
 
@@ -33,9 +34,15 @@ namespace Proto.Remote
         public EndpointManager(RemoteConfig config)
         {
             _config = config;
+            _behavior = new Behavior(ActiveAsync);
         }
 
         public Task ReceiveAsync(IContext context)
+        {
+            return _behavior.ReceiveAsync(context);
+        }
+
+        public Task ActiveAsync(IContext context)
         {
             switch (context.Message)
             {
@@ -44,8 +51,15 @@ namespace Proto.Remote
                         _logger.LogDebug("Started EndpointManager");
                         return Actor.Done;
                     }
-                case Stopped _:
+                case StopEndpointManager _:
                     {
+                        foreach(var endpoint in _connections.Values)
+                        {
+                            endpoint.Watcher.Stop();
+                            endpoint.Writer.Stop();
+                        }
+                        _connections.Clear();
+                        _behavior.Become(TerminatedAsync);
                         _logger.LogDebug("Stopped EndpointManager");
                         return Actor.Done;
                     }
@@ -90,6 +104,11 @@ namespace Proto.Remote
             }
         }
 
+        public Task TerminatedAsync(IContext context)
+        {
+            return Actor.Done;
+        }
+        
         public void HandleFailure(ISupervisor supervisor, PID child, RestartStatistics rs, Exception cause)
         {
             supervisor.RestartChildren(cause, child);

--- a/src/Proto.Remote/EndpointReader.cs
+++ b/src/Proto.Remote/EndpointReader.cs
@@ -14,7 +14,7 @@ namespace Proto.Remote
 {
     public class EndpointReader : Remoting.RemotingBase
     {
-        private bool suspended;
+        private bool _suspended;
         
         public override Task<ConnectResponse> Connect(ConnectRequest request, ServerCallContext context)
         {
@@ -29,7 +29,7 @@ namespace Proto.Remote
         {
             await requestStream.ForEachAsync(batch =>
             {
-                if (suspended)
+                if (_suspended)
                     return Actor.Done;
                 
                 var targetNames = new List<string>(batch.TargetNames);
@@ -67,7 +67,7 @@ namespace Proto.Remote
 
         public void Suspend(bool suspended)
         {
-            this.suspended = suspended;
+            this._suspended = suspended;
         }
     }
 }

--- a/src/Proto.Remote/EndpointReader.cs
+++ b/src/Proto.Remote/EndpointReader.cs
@@ -14,6 +14,8 @@ namespace Proto.Remote
 {
     public class EndpointReader : Remoting.RemotingBase
     {
+        private bool suspended;
+        
         public override Task<ConnectResponse> Connect(ConnectRequest request, ServerCallContext context)
         {
             return Task.FromResult(new ConnectResponse()
@@ -27,11 +29,13 @@ namespace Proto.Remote
         {
             await requestStream.ForEachAsync(batch =>
             {
+                if (suspended)
+                    return Actor.Done;
+                
                 var targetNames = new List<string>(batch.TargetNames);
                 var typeNames = new List<string>(batch.TypeNames);
                 foreach (var envelope in batch.Envelopes)
                 {
-                    
                     var targetName = targetNames[envelope.Target];
                     var target = new PID(ProcessRegistry.Instance.Address, targetName);
                   
@@ -59,6 +63,11 @@ namespace Proto.Remote
 
                 return Actor.Done;
             });
+        }
+
+        public void Suspend(bool suspended)
+        {
+            this.suspended = suspended;
         }
     }
 }

--- a/src/Proto.Remote/EndpointWatcher.cs
+++ b/src/Proto.Remote/EndpointWatcher.cs
@@ -6,13 +6,15 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Proto.Remote
 {
     public class EndpointWatcher : IActor
     {
         private readonly Behavior _behavior;
-        private readonly Dictionary<string, PID> _watched = new Dictionary<string, PID>();
+        private readonly Dictionary<string, FastSet<PID>> _watched = new Dictionary<string, FastSet<PID>>();
+        private readonly ILogger _logger = Log.CreateLogger<EndpointWatcher>();
         private string _address; //for logging
 
         public EndpointWatcher(string address)
@@ -32,7 +34,15 @@ namespace Proto.Remote
             {
                 case RemoteTerminate msg:
                 {
-                    _watched.Remove(msg.Watcher.Id);
+                    if (_watched.TryGetValue(msg.Watcher.Id, out var pidSet))
+                    {
+                        pidSet.Remove(msg.Watchee);
+                        if (pidSet.Count == 0)
+                        {
+                            _watched[msg.Watcher.Id] = null;
+                        }
+                    }
+
                     //create a terminated event for the Watched actor
                     var t = new Terminated
                     {
@@ -44,25 +54,43 @@ namespace Proto.Remote
                 }
                 case EndpointTerminatedEvent _:
                 {
-                    foreach (var (id, pid) in _watched)
+                    _logger.LogDebug($"Handle terminated address {_address}");
+
+                    foreach (var (id, pidSet) in _watched)
                     {
-                        //create a terminated event for the Watched actor
-                        var t = new Terminated
+                        var watcherPid = new PID(ProcessRegistry.Instance.Address, id);
+                        var watcherRef = ProcessRegistry.Instance.Get(watcherPid);
+                        if (watcherRef != DeadLetterProcess.Instance)
                         {
-                            Who = pid,
-                            AddressTerminated = true
-                        };
-                            var watcher = new PID(ProcessRegistry.Instance.Address, id);
-                        //send the address Terminated event to the Watcher
-                        watcher.SendSystemMessage(t);
+                            foreach (var pid in pidSet)
+                            {
+                                //create a terminated event for the Watched actor
+                                var t = new Terminated
+                                {
+                                    Who = pid,
+                                    AddressTerminated = true
+                                };
+
+                                //send the address Terminated event to the Watcher
+                                watcherPid.SendSystemMessage(t);
+                            }
+                        }
                     }
 
-                    _behavior.Become(TerminatedAsync); ;
+                    _watched.Clear();
+                    _behavior.Become(TerminatedAsync);
                     break;
                 }
                 case RemoteUnwatch msg:
                 {
-                    _watched[msg.Watcher.Id] = null;
+                    if (_watched.TryGetValue(msg.Watcher.Id, out var pidSet))
+                    {
+                        pidSet.Remove(msg.Watchee);
+                        if (pidSet.Count == 0)
+                        {
+                            _watched[msg.Watcher.Id] = null;
+                        }
+                    }
 
                     var w = new Unwatch(msg.Watcher);
                     Remote.SendMessage(msg.Watchee, w,-1);
@@ -70,10 +98,22 @@ namespace Proto.Remote
                 }
                 case RemoteWatch msg:
                 {
-                    _watched[msg.Watcher.Id] = msg.Watchee;
+                    if (_watched.TryGetValue(msg.Watcher.Id, out var pidSet))
+                    {
+                        pidSet.Add(msg.Watchee);
+                    }
+                    else
+                    {
+                        _watched[msg.Watcher.Id] = new FastSet<PID>{msg.Watchee}; 
+                    }
 
                     var w = new Watch(msg.Watcher);
                     Remote.SendMessage(msg.Watchee, w, -1);
+                    break;
+                }
+                case Stopped _:
+                {
+                    _logger.LogDebug("Stopped EndpointWatcher");
                     break;
                 }
             }
@@ -94,8 +134,11 @@ namespace Proto.Remote
                     break;
                 }
                 case EndpointConnectedEvent _:
+                {
+                    _logger.LogDebug($"Handle restart address {_address}");
                     _behavior.Become(ConnectedAsync);
                     break;
+                }
                 case RemoteUnwatch _:
                 case EndpointTerminatedEvent _:
                 case RemoteTerminate _:

--- a/src/Proto.Remote/Messages.cs
+++ b/src/Proto.Remote/Messages.cs
@@ -8,6 +8,8 @@ using System;
 
 namespace Proto.Remote
 {
+    public sealed class StopEndpointManager { }
+    
     public sealed class EndpointTerminatedEvent
     {
         public string Address { get; set; }

--- a/src/Proto.Remote/Remote.cs
+++ b/src/Proto.Remote/Remote.cs
@@ -79,9 +79,9 @@ namespace Proto.Remote
             {
                 if (gracefull)
                 {
-                    StopActivator();
-                    StopEndPointManager();
                     _endpointReader.Suspend(true);
+                    StopEndPointManager();
+                    StopActivator();
                     _server.ShutdownAsync().Wait(10000);
                     _server.KillAsync().Wait(5000);
                 }
@@ -119,7 +119,7 @@ namespace Proto.Remote
 
         private static void StopEndPointManager()
         {
-            EndpointManagerPid.Stop();
+            EndpointManagerPid.Tell(new StopEndpointManager());
             EventStream.Instance.Unsubscribe(_endpointTermEvnSub.Id);
             EventStream.Instance.Unsubscribe(_endpointConnEvnSub.Id);
         }

--- a/src/Proto.Remote/Remote.cs
+++ b/src/Proto.Remote/Remote.cs
@@ -73,7 +73,7 @@ namespace Proto.Remote
             Logger.LogDebug($"Starting Proto.Actor server on {boundAddr} ({addr})");
         }
 
-        public static void Stop(bool gracefull = true)
+        public static void Shutdown(bool gracefull = true)
         {
             try
             {
@@ -89,13 +89,13 @@ namespace Proto.Remote
                 {
                     _server.KillAsync().Wait(10000);
                 }
+                
+                Logger.LogDebug($"Proto.Actor server stopped on {ProcessRegistry.Instance.Address}. Graceful:{gracefull}");
             }
             catch(Exception ex)
             {
-                Logger.LogError("Proto.Actor server shut down with error:\n" + ex.Message);
+                Logger.LogError($"Proto.Actor server stopped on {ProcessRegistry.Instance.Address} with error:\n{ex.Message}");
             }
-
-            Logger.LogDebug($"Proto.Actor server stopped on {ProcessRegistry.Instance.Address}. Graceful:{gracefull}");
         }
 
         private static void SpawnActivator()


### PR DESCRIPTION
Same as https://github.com/AsynkronIT/protoactor-go/pull/177
This pull request contains multiple changes... not sure how to subdivide it but I will try to make all the changes clear here.

- Rendezvous (already has its own PR) https://github.com/AsynkronIT/protoactor-dotnet/pull/312
- When transferring ownership, the partition with the new ownership will only cache the transferred actor, but not watch it. So if that actor dies, the partition with new ownership will not be notified. This is fixed in f415bab
- PIDCache does not subscribe to membership status event, so if member status changed, PIDCache will not clear the cache of that member accordingly. This is fixed in  fee981c
- Watcher can only watch 1 remote watchee per endpoint, as is mentioned in https://github.com/AsynkronIT/protoactor-go/issues/172 and https://github.com/AsynkronIT/protoactor-go/pull/175. This is fixed in  3cc6663
- A simple implementation of graceful stop (currently works, but should be refined). Got one issue, GRPC does not want to stop and still try to figure out why. Now as a workaround, will kill GRPC server after 10 seconds. This is implemented in  a5691fa 
    - Move Remote.Start to Cluster.Start, this is to follow go version.  95e3cea
    - Using Behaviour mechanism to handle EndpointManager stop (It's a supervisor, so call stop will restart it) 86d744c
    - Update Consul Provider and IClusterProvider to have Shutdown/Deregister methods.  3d3856d