### PR TITLE
Bundle consul and add auto boot to examples

### DIFF
--- a/examples/ClusterGrainHelloWorld/Node1/Program.cs
+++ b/examples/ClusterGrainHelloWorld/Node1/Program.cs
@@ -16,7 +16,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        ConsulProvider.StartConsulDevMode(@"..\..\..\dependencies\consul");
+        StartConsulDevMode();
         Serialization.RegisterFileDescriptor(ProtosReflection.Descriptor);
         Cluster.Start("MyCluster", "127.0.0.1", 12001, new ConsulProvider(new ConsulProviderOptions()));
 
@@ -28,5 +28,18 @@ class Program
         res = client.SayHello(new HelloRequest()).Result;
         Console.WriteLine(res.Message);
         Console.ReadLine();
+    }
+
+    private static void StartConsulDevMode()
+    {
+        Console.WriteLine("Consul - Starting");
+        ProcessStartInfo psi =
+            new ProcessStartInfo(@"..\..\..\dependencies\consul",
+                "agent -server -bootstrap -data-dir /tmp/consul -bind=127.0.0.1 -ui")
+            {
+                CreateNoWindow = true,
+            };
+        Process.Start(psi);
+        Console.WriteLine("Consul - Started");
     }
 }

--- a/examples/ClusterGrainHelloWorld/Node1/Program.cs
+++ b/examples/ClusterGrainHelloWorld/Node1/Program.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 using Messages;
 using Proto.Cluster;
 using Proto.Cluster.Consul;
@@ -15,6 +16,7 @@ class Program
 {
     static void Main(string[] args)
     {
+        ConsulProvider.StartConsulDevMode(@"..\..\..\dependencies\consul");
         Serialization.RegisterFileDescriptor(ProtosReflection.Descriptor);
         Cluster.Start("MyCluster", "127.0.0.1", 12001, new ConsulProvider(new ConsulProviderOptions()));
 

--- a/examples/ClusterHelloWorld/Node1/Program.cs
+++ b/examples/ClusterHelloWorld/Node1/Program.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using Messages;
 using Proto.Cluster;
@@ -16,12 +17,25 @@ class Program
 {
     static void Main(string[] args)
     {
-        ConsulProvider.StartConsulDevMode(@"..\..\..\dependencies\consul");
+        StartConsulDevMode();
         Serialization.RegisterFileDescriptor(ProtosReflection.Descriptor);
         Cluster.Start("MyCluster", "127.0.0.1", 12001, new ConsulProvider(new ConsulProviderOptions()));
         var (pid, _) = Cluster.GetAsync("TheName", "HelloKind").Result;
         var res = pid.RequestAsync<HelloResponse>(new HelloRequest()).Result;
         Console.WriteLine(res.Message);
         Console.ReadLine();
+    }
+
+    private static void StartConsulDevMode()
+    {
+        Console.WriteLine("Consul - Starting");
+        ProcessStartInfo psi =
+            new ProcessStartInfo(@"..\..\..\dependencies\consul",
+                "agent -server -bootstrap -data-dir /tmp/consul -bind=127.0.0.1 -ui")
+            {
+                CreateNoWindow = true,
+            };
+        Process.Start(psi);
+        Console.WriteLine("Consul - Started");
     }
 }

--- a/examples/ClusterHelloWorld/Node1/Program.cs
+++ b/examples/ClusterHelloWorld/Node1/Program.cs
@@ -16,6 +16,7 @@ class Program
 {
     static void Main(string[] args)
     {
+        ConsulProvider.StartConsulDevMode(@"..\..\..\dependencies\consul");
         Serialization.RegisterFileDescriptor(ProtosReflection.Descriptor);
         Cluster.Start("MyCluster", "127.0.0.1", 12001, new ConsulProvider(new ConsulProviderOptions()));
         var (pid, _) = Cluster.GetAsync("TheName", "HelloKind").Result;

--- a/src/ClusterProviders/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/ClusterProviders/Proto.Cluster.Consul/ConsulProvider.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -41,15 +42,28 @@ namespace Proto.Cluster.Consul
     {
         private readonly ConsulClient _client;
         private string _clusterName;
-        private TimeSpan _serviceTtl;
-        private TimeSpan _blockingWaitTime;
-        private TimeSpan _deregisterCritical;
-        private TimeSpan _refreshTtl;
+        private readonly TimeSpan _serviceTtl;
+        private readonly TimeSpan _blockingWaitTime;
+        private readonly TimeSpan _deregisterCritical;
+        private readonly TimeSpan _refreshTtl;
         private string _id;
         private ulong _index;
         private string _kvKey;
         private bool _shutdown = false;
         private bool _deregistered = false;
+
+        public static void StartConsulDevMode(string path)
+        {
+            Console.WriteLine("Consul - Starting");
+            ProcessStartInfo psi =
+                new ProcessStartInfo(path, "agent -server -bootstrap -data-dir /tmp/consul -bind=127.0.0.1 -ui")
+                {
+                    CreateNoWindow = true,
+
+                };
+            System.Diagnostics.Process.Start(psi);
+            Console.WriteLine("Consul - Started");
+        }
 
         public ConsulProvider(ConsulProviderOptions options) : this(options, config => { })
         {

--- a/src/ClusterProviders/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/ClusterProviders/Proto.Cluster.Consul/ConsulProvider.cs
@@ -52,19 +52,6 @@ namespace Proto.Cluster.Consul
         private bool _shutdown = false;
         private bool _deregistered = false;
 
-        public static void StartConsulDevMode(string path)
-        {
-            Console.WriteLine("Consul - Starting");
-            ProcessStartInfo psi =
-                new ProcessStartInfo(path, "agent -server -bootstrap -data-dir /tmp/consul -bind=127.0.0.1 -ui")
-                {
-                    CreateNoWindow = true,
-
-                };
-            System.Diagnostics.Process.Start(psi);
-            Console.WriteLine("Consul - Started");
-        }
-
         public ConsulProvider(ConsulProviderOptions options) : this(options, config => { })
         {
         }

--- a/src/ClusterProviders/Proto.Cluster.Consul/Proto.Cluster.Consul.csproj
+++ b/src/ClusterProviders/Proto.Cluster.Consul/Proto.Cluster.Consul.csproj
@@ -31,4 +31,9 @@
     <ProjectReference Include="..\..\Proto.Mailbox\Proto.Mailbox.csproj" />
     <ProjectReference Include="..\..\Proto.Persistence\Proto.Persistence.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
+    <PackageReference Include="System.Diagnostics.Process">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR bundles Consul into the example source, it also adds the option to auto boot consul in dev mode.
This makes it a lot easier for newcomers to try our examples.

It would be nice if someone could fetch and verify if this works on their machines too.
Currently, this is Windows only as it bundles the win exe.
Maybe bundle other platforms too?

