### PR TITLE
WIP: initial example of cluster routers - do not merge

### DIFF
--- a/ProtoActor.sln
+++ b/ProtoActor.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.10
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{771514F1-12AE-4A26-89CB-2646D3EF7034}"
 EndProject
@@ -166,7 +166,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Proto.Persistence.DynamoDB"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EscalateSupervision", "examples\EscalateSupervision\EscalateSupervision.csproj", "{837CDD41-BEA3-4C7D-957F-3B4AFE3B14DB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Proto.Cluster.Tests", "tests\Proto.Cluster.Tests\Proto.Cluster.Tests.csproj", "{9DE48E83-DF4E-4C5F-9BC8-CB05C646FC43}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Proto.Cluster.Tests", "tests\Proto.Cluster.Tests\Proto.Cluster.Tests.csproj", "{9DE48E83-DF4E-4C5F-9BC8-CB05C646FC43}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Proto.Cluster.Router", "src\Proto.Cluster.Router\Proto.Cluster.Router.csproj", "{4E96B65E-D3A0-4A35-96E6-B61D5B5CEBB8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -849,7 +851,6 @@ Global
 		{837CDD41-BEA3-4C7D-957F-3B4AFE3B14DB}.Release|x64.Build.0 = Release|Any CPU
 		{837CDD41-BEA3-4C7D-957F-3B4AFE3B14DB}.Release|x86.ActiveCfg = Release|Any CPU
 		{837CDD41-BEA3-4C7D-957F-3B4AFE3B14DB}.Release|x86.Build.0 = Release|Any CPU
-
 		{9DE48E83-DF4E-4C5F-9BC8-CB05C646FC43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9DE48E83-DF4E-4C5F-9BC8-CB05C646FC43}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9DE48E83-DF4E-4C5F-9BC8-CB05C646FC43}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -862,7 +863,18 @@ Global
 		{9DE48E83-DF4E-4C5F-9BC8-CB05C646FC43}.Release|x64.Build.0 = Release|Any CPU
 		{9DE48E83-DF4E-4C5F-9BC8-CB05C646FC43}.Release|x86.ActiveCfg = Release|Any CPU
 		{9DE48E83-DF4E-4C5F-9BC8-CB05C646FC43}.Release|x86.Build.0 = Release|Any CPU
-
+		{4E96B65E-D3A0-4A35-96E6-B61D5B5CEBB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E96B65E-D3A0-4A35-96E6-B61D5B5CEBB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E96B65E-D3A0-4A35-96E6-B61D5B5CEBB8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4E96B65E-D3A0-4A35-96E6-B61D5B5CEBB8}.Debug|x64.Build.0 = Debug|Any CPU
+		{4E96B65E-D3A0-4A35-96E6-B61D5B5CEBB8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4E96B65E-D3A0-4A35-96E6-B61D5B5CEBB8}.Debug|x86.Build.0 = Debug|Any CPU
+		{4E96B65E-D3A0-4A35-96E6-B61D5B5CEBB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E96B65E-D3A0-4A35-96E6-B61D5B5CEBB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E96B65E-D3A0-4A35-96E6-B61D5B5CEBB8}.Release|x64.ActiveCfg = Release|Any CPU
+		{4E96B65E-D3A0-4A35-96E6-B61D5B5CEBB8}.Release|x64.Build.0 = Release|Any CPU
+		{4E96B65E-D3A0-4A35-96E6-B61D5B5CEBB8}.Release|x86.ActiveCfg = Release|Any CPU
+		{4E96B65E-D3A0-4A35-96E6-B61D5B5CEBB8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -947,7 +959,7 @@ Global
 		{4234384F-5DA4-4EEF-A727-08C67BDB7651} = {7AF64900-EA34-4A93-9514-FEBC4648E39E}
 		{837CDD41-BEA3-4C7D-957F-3B4AFE3B14DB} = {660167A8-008A-45D1-B489-AF49907895ED}
 		{9DE48E83-DF4E-4C5F-9BC8-CB05C646FC43} = {9AA2BCF0-19AB-4DD9-8D91-7D188E463806}
-
+		{4E96B65E-D3A0-4A35-96E6-B61D5B5CEBB8} = {771514F1-12AE-4A26-89CB-2646D3EF7034}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD0D1E44-8118-4682-8793-6B20ABFA824C}

--- a/src/Proto.Cluster.Router/ClusterRouter.cs
+++ b/src/Proto.Cluster.Router/ClusterRouter.cs
@@ -1,0 +1,62 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Proto.Mailbox;
+
+namespace Proto.Cluster.Router
+{
+    public class ClusterRouter
+    {
+        public static PID NewClusterBroadcastPool(string name, int poolSize, string kind)
+        {
+            var props = Actor.FromProducer(() => new ClusterBroadcastPool(name, poolSize, kind));
+            var pid = Actor.Spawn(props);
+            return pid;
+        }
+    }
+
+    //TODO: There are two approaches that could be viable for cluster routers
+    //this approach generates a name per routee and simply use Cluster.GetAsync on each
+    //This works, but, this is not guaranteed to place routees evenly on different nodes.
+    //
+    //another approach could be to subscribe to cluster members and place actors on each of those
+    //IMO, both are correct in their own ways
+    public class ClusterBroadcastPool : IActor
+    {
+        private readonly string[] _routees;
+        private readonly string _kind;
+
+        public ClusterBroadcastPool(string name,int poolSize, string kind)
+        {
+            _kind = kind;
+            _routees = Enumerable
+                .Range(0, poolSize)
+                .Select(i => name + i) //TODO: How should routees be named?
+                .ToArray();
+        }
+
+        public Task ReceiveAsync(IContext context)
+        {
+            switch (context.Message)
+            {
+                case AutoReceiveMessage _:
+                case SystemMessage _:
+                    break;
+                default:
+                    var m = context.Message;
+                    foreach (var routee in _routees)
+                    {
+#pragma warning disable 4014
+                        Cluster.GetAsync(routee, _kind).ContinueWith(t =>
+#pragma warning restore 4014
+                        {
+                            var pid = t.Result.Item1;
+                            pid?.Tell(m);
+                            //TODO: what to do if pid is null? (unavailable) 
+                        });
+                    }
+                    break;
+            }
+            return Actor.Done;
+        }
+    }
+}

--- a/src/Proto.Cluster.Router/Proto.Cluster.Router.csproj
+++ b/src/Proto.Cluster.Router/Proto.Cluster.Router.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Proto.Cluster\Proto.Cluster.csproj" />
+    <ProjectReference Include="..\Proto.Router\Proto.Router.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This PR contains a first sketch on how cluster routers could be designed.

The reason this does not build on existing router code is that the cluster infrastructure is async, we need to resolve routees and members  async.
Messages are also going to be sent over network, so there is not the same need to avoid the actor mailbox overhead as this is minimal in this case.

 