### PR TITLE
Fixed broken RemoteActivate example

### DIFF
--- a/examples/RemoteActivate/Node1/Program.cs
+++ b/examples/RemoteActivate/Node1/Program.cs
@@ -18,7 +18,7 @@ class Program
     {
         Serialization.RegisterFileDescriptor(ProtosReflection.Descriptor);
         Remote.Start("127.0.0.1", 12001);
-        var pid = Remote.SpawnNamedAsync("127.0.0.1:12000", "remote", "hello", TimeSpan.FromSeconds(5)).Result;
+        var pid = Remote.SpawnNamedAsync("127.0.0.1:12000", "remote", "hello", TimeSpan.FromSeconds(5)).Result.Pid;
         var res = pid.RequestAsync<HelloResponse>(new HelloRequest { }).Result;
         Console.WriteLine(res.Message);
         Console.ReadLine();


### PR DESCRIPTION
Using the `Pid` property now, I guess the API changed since this example