### PR TITLE
Index creation added to MongoDBProvider to avoid problems on sorting …

### DIFF
--- a/src/PersistenceProviders/Proto.Persistence.MongoDB/MongoDBProvider.cs
+++ b/src/PersistenceProviders/Proto.Persistence.MongoDB/MongoDBProvider.cs
@@ -18,6 +18,17 @@ namespace Proto.Persistence.MongoDB
         public MongoDBProvider(IMongoDatabase mongoDB)
         {
             _mongoDB = mongoDB;
+            SetupIndexes();
+        }
+
+        private async void SetupIndexes()
+        {
+            await EventCollection.Indexes.CreateOneAsync(Builders<Event>.IndexKeys
+                .Ascending(_ => _.ActorName)
+                .Ascending(_ => _.EventIndex));
+            await SnapshotCollection.Indexes.CreateOneAsync(Builders<Snapshot>.IndexKeys
+                .Ascending(_ => _.ActorName)
+                .Descending(_ => _.SnapshotIndex));
         }
         
         public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)


### PR DESCRIPTION
…when collection grows. They are not created in the background to be optimized. 

I used SetupIndexes method in the constructor like in RavenDB provider.