### PR TITLE
Reset timer when receiving timeout callback.

### DIFF
--- a/src/Proto.Actor/LocalContext.cs
+++ b/src/Proto.Actor/LocalContext.cs
@@ -559,6 +559,11 @@ namespace Proto
 
         private void ReceiveTimeoutCallback(object state)
         {
+            if (_receiveTimeoutTimer == null)
+            {
+                return;
+            }
+            CancelReceiveTimeout();
             Self.Request(Proto.ReceiveTimeout.Instance, null);
         }
     }


### PR DESCRIPTION
During my stress test, ReceiveTimeoutCallback can be called twice in some cases due to task scheduling problem. This can be fixed by resetting timer when receiving the callback.