### PR TITLE
Fix MemberList not thread safe bug

### DIFF
--- a/src/Proto.Cluster/MemberList.cs
+++ b/src/Proto.Cluster/MemberList.cs
@@ -16,7 +16,7 @@ namespace Proto.Cluster
     {
         private static readonly ILogger _logger = Log.CreateLogger("MemberList");
 
-		private static readonly ReaderWriterLockSlim _rwLock = new ReaderWriterLockSlim();
+        private static readonly ReaderWriterLockSlim _rwLock = new ReaderWriterLockSlim();
         private static readonly Dictionary<string, MemberStatus> _members = new Dictionary<string, MemberStatus>();
         private static readonly Dictionary<string, IMemberStrategy> _memberStrategyByKind = new Dictionary<string, IMemberStrategy>();
 

--- a/src/Proto.Cluster/MemberList.cs
+++ b/src/Proto.Cluster/MemberList.cs
@@ -4,7 +4,6 @@
 //   </copyright>
 // -----------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -17,7 +16,7 @@ namespace Proto.Cluster
     {
         private static readonly ILogger _logger = Log.CreateLogger("MemberList");
 
-        private static readonly object _lock = new object();
+		private static readonly ReaderWriterLockSlim _rwLock = new ReaderWriterLockSlim();
         private static readonly Dictionary<string, MemberStatus> _members = new Dictionary<string, MemberStatus>();
         private static readonly Dictionary<string, IMemberStrategy> _memberStrategyByKind = new Dictionary<string, IMemberStrategy>();
 
@@ -35,63 +34,103 @@ namespace Proto.Cluster
 
         internal static string[] GetMembers(string kind)
         {
-            return _memberStrategyByKind.TryGetValue(kind, out var memberStrategy)
-                       ? memberStrategy.GetAllMembers().FindAll(m => m.Alive).Select(m => m.Address).ToArray() : new string[0];
+            bool locked = _rwLock.TryEnterReadLock(1000);
+            while (!locked)
+            {
+                _logger.LogDebug("MemberList did not acquire reader lock within 1 seconds, retry");
+                locked = _rwLock.TryEnterReadLock(1000);
+            }
+
+            try
+            {
+                return _memberStrategyByKind.TryGetValue(kind, out var memberStrategy)
+                           ? memberStrategy.GetAllMembers().FindAll(m => m.Alive).Select(m => m.Address).ToArray() : new string[0];
+            }
+            finally
+            {
+                _rwLock.ExitReadLock();
+            }
         }
 
         internal static string GetPartition(string name, string kind)
         {
-            return _memberStrategyByKind.TryGetValue(kind, out var memberStrategy)
-                       ? memberStrategy.GetPartition(name) : "";
+            bool locked = _rwLock.TryEnterReadLock(1000);
+            while (!locked)
+            {
+                _logger.LogDebug("MemberList did not acquire reader lock within 1 seconds, retry");
+                locked = _rwLock.TryEnterReadLock(1000);
+            }
+
+            try
+            {
+                return _memberStrategyByKind.TryGetValue(kind, out var memberStrategy)
+                           ? memberStrategy.GetPartition(name) : "";
+            }
+            finally
+            {
+                _rwLock.ExitReadLock();
+            }
         }
 
         internal static string GetActivator(string kind)
         {
-            return _memberStrategyByKind.TryGetValue(kind, out var memberStrategy)
-                       ? memberStrategy.GetActivator() : "";
+            bool locked = _rwLock.TryEnterReadLock(1000);
+            while (!locked)
+            {
+                _logger.LogDebug("MemberList did not acquire reader lock within 1 seconds, retry");
+                locked = _rwLock.TryEnterReadLock(1000);
+            }
+
+            try
+            {
+                return _memberStrategyByKind.TryGetValue(kind, out var memberStrategy)
+                           ? memberStrategy.GetActivator() : "";
+            }
+            finally
+            {
+                _rwLock.ExitReadLock();
+            }
         }
 
         internal static void UpdateClusterTopology(ClusterTopologyEvent msg)
         {
-            performUpdate:
-            if (Monitor.TryEnter(_lock, TimeSpan.FromSeconds(1)))
+            bool locked = _rwLock.TryEnterWriteLock(1000);
+            while (!locked)
             {
-                try
+                _logger.LogDebug("MemberList did not acquire writer lock within 1 seconds, retry");
+                locked = _rwLock.TryEnterWriteLock(1000);
+            }
+
+            try
+            {
+                //get all new members address sets
+                var newMembersAddress = new HashSet<string>();
+                foreach (var status in msg.Statuses)
                 {
-                    //get all new members address sets
-                    var newMembersAddress = new HashSet<string>();
-                    foreach (var status in msg.Statuses)
-                    {
-                        newMembersAddress.Add(status.Address);
-                    }
+                    newMembersAddress.Add(status.Address);
+                }
 
-                    //remove old ones whose address not exist in new address sets
-                    //_members.ToList() duplicates _members, allow _members to be modified in Notify
-                    foreach (var (address, old) in _members.ToList())
+                //remove old ones whose address not exist in new address sets
+                //_members.ToList() duplicates _members, allow _members to be modified in Notify
+                foreach (var (address, old) in _members.ToList())
+                {
+                    if (!newMembersAddress.Contains(address))
                     {
-                        if (!newMembersAddress.Contains(address))
-                        {
-                            UpdateAndNotify(null, old);
-                        }
-                    }
-
-                    //find all the entries that exist in the new set
-                    foreach (var @new in msg.Statuses)
-                    {
-                        _members.TryGetValue(@new.Address, out var old);
-                        _members[@new.Address] = @new;
-                        UpdateAndNotify(@new, old);
+                        UpdateAndNotify(null, old);
                     }
                 }
-                finally
+
+                //find all the entries that exist in the new set
+                foreach (var @new in msg.Statuses)
                 {
-                    Monitor.Exit(_lock);
+                    _members.TryGetValue(@new.Address, out var old);
+                    _members[@new.Address] = @new;
+                    UpdateAndNotify(@new, old);
                 }
             }
-            else
+            finally
             {
-                _logger.LogDebug("Did not acquire lock within 1 seconds, retry");
-                goto performUpdate;
+                _rwLock.ExitWriteLock();
             }
         }
 
@@ -114,7 +153,7 @@ namespace Proto.Cluster
                             _memberStrategyByKind.Remove(k);
                     }
                 }
-                
+
                 //notify left
                 var left = new MemberLeftEvent(old.Host, old.Port, old.Kinds);
                 Actor.EventStream.Publish(left);

--- a/src/Proto.Cluster/Rendezvous.cs
+++ b/src/Proto.Cluster/Rendezvous.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -14,7 +13,7 @@ namespace Proto.Cluster
         private static readonly HashAlgorithm HashAlgorithm = FNV1A32.Create();
 
         private IMemberStrategy _m;
-        private List<byte[]> _memberHashes;
+        private byte[][] _memberHashes;
 
         public Rendezvous(IMemberStrategy m)
         {
@@ -25,7 +24,7 @@ namespace Proto.Cluster
         public string GetNode(string key)
         {
             var members = _m.GetAllMembers();
-            
+
             if (members == null || members.Count == 0)
                 return "";
 
@@ -58,7 +57,7 @@ namespace Proto.Cluster
 
         public void UpdateRdv()
         {
-            this._memberHashes = this._m.GetAllMembers().Select(mb => Encoding.UTF8.GetBytes(mb.Address)).ToList();
+            this._memberHashes = this._m.GetAllMembers().Select(mb => Encoding.UTF8.GetBytes(mb.Address)).ToArray();
         }
 
         private static uint RdvHash(byte[] node, byte[] key)


### PR DESCRIPTION
In my previous PR https://github.com/AsynkronIT/protoactor-dotnet/pull/344, I only lock the MemberList during its updating.
This is definitely not enough and will make MemberList not thread safe. This PR addresses this.