### PR TITLE
actorfactory can create instance from interface as well

### DIFF
--- a/src/Proto.Actor.Extensions/ActorFactory.cs
+++ b/src/Proto.Actor.Extensions/ActorFactory.cs
@@ -30,7 +30,7 @@ namespace Proto
             where T : IActor
         {
             id = id ?? typeof(T).FullName;
-            return GetActor(id, address, parent, () => CreateActor<T>(id, parent, () => new Props().WithProducer(() => ActivatorUtilities.CreateInstance<T>(serviceProvider))));
+            return GetActor(id, address, parent, () => CreateActor<T>(id, parent, () => new Props().WithProducer(() => (T)serviceProvider.GetService(typeof(T)))));
         }
 
         public PID GetActor(string id, string address, IContext parent, Func<PID> create)


### PR DESCRIPTION
So that actorfactory is able to create actors from interfaces registered in serviceprovider. Previously only concrete types could be instantiated.