### PR TITLE
EndpointWatcher dictionary should use remove instead of set to null.

### DIFF
--- a/src/Proto.Remote/EndpointWatcher.cs
+++ b/src/Proto.Remote/EndpointWatcher.cs
@@ -39,7 +39,7 @@ namespace Proto.Remote
                         pidSet.Remove(msg.Watchee);
                         if (pidSet.Count == 0)
                         {
-                            _watched[msg.Watcher.Id] = null;
+                            _watched.Remove(msg.Watcher.Id);
                         }
                     }
 
@@ -88,7 +88,7 @@ namespace Proto.Remote
                         pidSet.Remove(msg.Watchee);
                         if (pidSet.Count == 0)
                         {
-                            _watched[msg.Watcher.Id] = null;
+                            _watched.Remove(msg.Watcher.Id);
                         }
                     }
 


### PR DESCRIPTION
EndpointWatcher dictionary should use remove instead of set to null.