### PR TITLE
implement stopping when max number of restarts exceeds allowed number…

### DIFF
--- a/src/Proto.Actor/RestartStatistics.cs
+++ b/src/Proto.Actor/RestartStatistics.cs
@@ -5,30 +5,32 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Proto
 {
     public class RestartStatistics
     {
+        private readonly List<DateTime> _failureTimes = new List<DateTime>();
+        
+        public int FailureCount => _failureTimes.Count;
+
         public RestartStatistics(int failureCount, DateTime? lastFailuretime)
         {
-            FailureCount = failureCount;
-            LastFailureTime = lastFailuretime;
+            for (int i = 0; i < failureCount; i++)
+            {
+                _failureTimes.Add(lastFailuretime ?? DateTime.Now);
+            }
         }
 
-        public int FailureCount { get; private set; }
-        public DateTime? LastFailureTime { get; private set; }
+        public void Fail() => _failureTimes.Add(DateTime.Now);
 
-        public void Fail()
+        public void Reset() => _failureTimes.Clear();
+
+        public int NumberOfFailures(TimeSpan? within)
         {
-            FailureCount++;
-            LastFailureTime = DateTime.Now;
+            return within.HasValue ? _failureTimes.Count(a => DateTime.Now - a < within) : _failureTimes.Count;
         }
-
-        public void Reset() => FailureCount = 0;
-
-        public void Restart() => LastFailureTime = DateTime.Now;
-
-        public bool IsWithinDuration(TimeSpan within) => DateTime.Now - LastFailureTime < within;
     }
 }

--- a/tests/Proto.Actor.Tests/SupervisionTests_ExponentialBackoff.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_ExponentialBackoff.cs
@@ -6,21 +6,23 @@ namespace Proto.Tests
     public class SupervisionTests_ExponentialBackoff
     {
         [Fact]
-        public void FailureOutsideWindow_ZeroCount()
+        public void FailureOutsideWindow_ResetsFailureCount()
         {
             var rs = new RestartStatistics(10, DateTime.Now.Subtract(TimeSpan.FromSeconds(11)));
             var strategy = new ExponentialBackoffStrategy(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1));
             strategy.HandleFailure(null, null, rs, null);
-            Assert.Equal(0, rs.FailureCount);
+            Assert.Equal(1, rs.FailureCount);
         }
-
+        
         [Fact]
-        public void FailureInsideWindow_IncrementCount()
+        public void FailureInsideWindow_IncrementsFailureCount()
         {
-            var rs = new RestartStatistics(10, DateTime.Now.Subtract(TimeSpan.FromSeconds(9)));
+            var rs = new RestartStatistics(0, DateTime.Now);
             var strategy = new ExponentialBackoffStrategy(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1));
             strategy.HandleFailure(null, null, rs, null);
-            Assert.Equal(11, rs.FailureCount);
+            strategy.HandleFailure(null, null, rs, null);
+            strategy.HandleFailure(null, null, rs, null);
+            Assert.Equal(3, rs.FailureCount);
         }
     }
 }


### PR DESCRIPTION
… in a period of time

Uses the _withinTimeSpan value properly to fix https://github.com/AsynkronIT/protoactor-dotnet/issues/379
Reversed the control flow in the Restart section as it kept confusing me
Adds tests 

NOTE: ExponentialBackoffStrategy looks wrong to me, we are lacking tests around this as the current two still pass, could do with some input into what this strategies behaviour is supposed to be.