### PR TITLE
No need to count messages

### DIFF
--- a/src/Proto.Mailbox/NonBlockingBoundedMailbox.cs
+++ b/src/Proto.Mailbox/NonBlockingBoundedMailbox.cs
@@ -43,6 +43,6 @@ namespace Proto.Mailbox
             return _messages.TryDequeue(out message) ? message : null;
         }
 
-        public bool HasMessages => _messages.Count > 0;
+        public bool HasMessages => !_messages.IsEmpty;
     }
 }


### PR DESCRIPTION
This PR changes the way the mailbox is determined whether it has messages or not. `IsEmpty` is a faster alternative than counting messages.