### PR TITLE
Copy GuardianStrategy when copy Props.

### DIFF
--- a/src/Proto.Actor/Props.cs
+++ b/src/Proto.Actor/Props.cs
@@ -115,6 +115,7 @@ namespace Proto
                 SenderMiddlewareChain = SenderMiddlewareChain,
                 Spawner = Spawner,
                 SupervisorStrategy = SupervisorStrategy,
+                GuardianStrategy = GuardianStrategy,
                 ContextDecorator = ContextDecorator,
                 ContextDecoratorChain = ContextDecoratorChain,
             };


### PR DESCRIPTION
This pr fixes https://github.com/AsynkronIT/protoactor-dotnet/issues/420