### PR TITLE
Revise MessageHeader.

### DIFF
--- a/src/Proto.Actor/MessageEnvelope.cs
+++ b/src/Proto.Actor/MessageEnvelope.cs
@@ -66,14 +66,7 @@ namespace Proto
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static MessageHeader UnwrapHeader(object message)
-        {
-            if (message is MessageEnvelope messageEnvelope && messageEnvelope.Header != null)
-            {
-                return messageEnvelope.Header;
-            }
-            return MessageHeader.Empty;
-        }
+        public static MessageHeader UnwrapHeader(object message) => (message as MessageEnvelope)?.Header;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static object UnwrapMessage(object message) => message is MessageEnvelope r ? r.Message : message;

--- a/src/Proto.Actor/MessageHeader.cs
+++ b/src/Proto.Actor/MessageHeader.cs
@@ -12,9 +12,8 @@ namespace Proto
 {
     public class MessageHeader : IReadOnlyDictionary<string, string>
     {
-        
         private readonly ImmutableDictionary<string, string> _inner;
-        public static MessageHeader Empty => new MessageHeader();
+        public readonly static MessageHeader Empty = new MessageHeader();
 
         public IDictionary<string, string> ToDictionary() => _inner;
 


### PR DESCRIPTION
- It's not necessary to regenerate Empty message header every time.
Since MessageHeader.With already generate a new header object.

- UnwrapHeader should follow Unwrap, return null instead of MessageHeader.Empty for consistency?