### PR TITLE
In EscalateFailure, "who" should be used instead of "Self"

### DIFF
--- a/src/Proto.Actor/ActorContext.cs
+++ b/src/Proto.Actor/ActorContext.cs
@@ -236,10 +236,9 @@ namespace Proto
             target.ContinueWith(t => { Self.SendSystemMessage(cont); });
         }
 
-
         public void EscalateFailure(Exception reason, PID who)
         {
-            var failure = new Failure(Self, reason, EnsureExtras().RestartStatistics);
+            var failure = new Failure(who, reason, EnsureExtras().RestartStatistics);
             Self.SendSystemMessage(SuspendMailbox.Instance);
             if (Parent == null)
             {

--- a/src/Proto.Actor/ActorContext.cs
+++ b/src/Proto.Actor/ActorContext.cs
@@ -236,6 +236,8 @@ namespace Proto
             target.ContinueWith(t => { Self.SendSystemMessage(cont); });
         }
 
+        public void EscalateFailure(Exception reason, object message) => EscalateFailure(reason, Self);
+
         public void EscalateFailure(Exception reason, PID who)
         {
             var failure = new Failure(who, reason, EnsureExtras().RestartStatistics);
@@ -332,8 +334,6 @@ namespace Proto
             }
             return res;
         }
-
-        public void EscalateFailure(Exception reason, object message) => EscalateFailure(reason, Self);
 
         public Task Receive(MessageEnvelope envelope)
         {


### PR DESCRIPTION
In EscalateFailure, "who" should be used instead of "Self"