### PR TITLE
Several revisions

### DIFF
--- a/examples/DependencyInjection/Startup.cs
+++ b/examples/DependencyInjection/Startup.cs
@@ -15,7 +15,7 @@ namespace DependencyInjection
             services.AddProtoActor(props =>
             {
                 //attached console tracing
-                props.RegisterProps<DIActor>(p => p.WithReceiveMiddleware(next => async (c,env) =>
+                props.RegisterProps<DIActor>(p => p.WithReceiverMiddleware(next => async (c,env) =>
                 {
                     Console.WriteLine($"enter {env.Message.GetType().FullName}");
                     await next(c, env);

--- a/examples/Middleware/Program.cs
+++ b/examples/Middleware/Program.cs
@@ -59,7 +59,7 @@ class Program
 
                     return Actor.Done;
                 })
-            .WithReceiveMiddleware(next => async (context, envelope) =>
+            .WithReceiverMiddleware(next => async (context, envelope) =>
             {
                 if (envelope.Message is string)
                 {

--- a/src/Proto.Actor/ActorContext.cs
+++ b/src/Proto.Actor/ActorContext.cs
@@ -236,10 +236,9 @@ namespace Proto
             target.ContinueWith(t => { Self.SendSystemMessage(cont); });
         }
 
-
-        public void EscalateFailure(Exception reason, PID who)
+        public void EscalateFailure(Exception reason, object message)
         {
-            var failure = new Failure(Self, reason, EnsureExtras().RestartStatistics);
+            var failure = new Failure(Self, reason, EnsureExtras().RestartStatistics, message);
             Self.SendSystemMessage(SuspendMailbox.Instance);
             if (Parent == null)
             {
@@ -333,8 +332,6 @@ namespace Proto
             }
             return res;
         }
-
-        public void EscalateFailure(Exception reason, object message) => EscalateFailure(reason, Self);
 
         public Task Receive(MessageEnvelope envelope)
         {
@@ -431,10 +428,10 @@ namespace Proto
             switch (Actor)
             {
                 case ISupervisorStrategy supervisor:
-                    supervisor.HandleFailure(this, msg.Who, msg.RestartStatistics, msg.Reason);
+                    supervisor.HandleFailure(this, msg.Who, msg.RestartStatistics, msg.Reason, msg.Message);
                     break;
                 default:
-                    _props.SupervisorStrategy.HandleFailure(this, msg.Who, msg.RestartStatistics, msg.Reason);
+                    _props.SupervisorStrategy.HandleFailure(this, msg.Who, msg.RestartStatistics, msg.Reason, msg.Message);
                     break;
             }
         }
@@ -451,7 +448,7 @@ namespace Proto
 
         private void HandleRootFailure(Failure failure)
         {
-            Supervision.DefaultStrategy.HandleFailure(this, failure.Who, failure.RestartStatistics, failure.Reason);
+            Supervision.DefaultStrategy.HandleFailure(this, failure.Who, failure.RestartStatistics, failure.Reason, failure.Message);
         }
 
         //Initiate stopping, not final

--- a/src/Proto.Actor/ActorContext.cs
+++ b/src/Proto.Actor/ActorContext.cs
@@ -482,6 +482,8 @@ namespace Proto
                 return Done;
             }
 
+            CancelReceiveTimeout();
+
             switch (_state)
             {
                 case ContextState.Restarting:

--- a/src/Proto.Actor/ActorContext.cs
+++ b/src/Proto.Actor/ActorContext.cs
@@ -76,7 +76,6 @@ namespace Proto
         private object _messageOrEnvelope;
         private ContextState _state;
 
-
         private ActorContextExtras EnsureExtras()
         {
             if (_extras == null)
@@ -102,6 +101,7 @@ namespace Proto
         private static ILogger Logger { get; } = Log.CreateLogger<ActorContext>();
 
         public IImmutableSet<PID> Children => _extras?.Children ?? EmptyChildren;
+        IReadOnlyCollection<PID> IContext.Children => Children;
 
         public IActor Actor { get; private set; }
         public PID Parent { get; }
@@ -114,7 +114,6 @@ namespace Proto
         public MessageHeader Headers => MessageEnvelope.UnwrapHeader(_messageOrEnvelope);
 
         public TimeSpan ReceiveTimeout { get; private set; }
-        IReadOnlyCollection<PID> IContext.Children => Children;
 
         public void Stash() => EnsureExtras().Stash.Push(Message);
 

--- a/src/Proto.Actor/ActorContext.cs
+++ b/src/Proto.Actor/ActorContext.cs
@@ -361,9 +361,9 @@ namespace Proto
         private Task ProcessMessageAsync(object msg)
         {
             //slow path, there is middleware, message must be wrapped in an envelop
-            if (_props.ReceiveMiddlewareChain != null)
+            if (_props.ReceiverMiddlewareChain != null)
             {
-                return _props.ReceiveMiddlewareChain(EnsureExtras().Context, MessageEnvelope.Wrap(msg));
+                return _props.ReceiverMiddlewareChain(EnsureExtras().Context, MessageEnvelope.Wrap(msg));
             }
             if (_props.ContextDecoratorChain != null)
             {

--- a/src/Proto.Actor/Guardians.cs
+++ b/src/Proto.Actor/Guardians.cs
@@ -48,7 +48,7 @@ namespace Proto
         public IImmutableSet<PID> Children =>
             throw new MemberAccessException("Guardian does not hold its children PIDs.");
 
-        public void EscalateFailure(Exception reason, PID who)
+        public void EscalateFailure(Exception reason, object message)
         {
             throw new InvalidOperationException("Guardian cannot escalate failure.");
         }
@@ -69,7 +69,7 @@ namespace Proto
         {
             if (message is Failure msg)
             {
-                _supervisorStrategy.HandleFailure(this, msg.Who, msg.RestartStatistics, msg.Reason);
+                _supervisorStrategy.HandleFailure(this, msg.Who, msg.RestartStatistics, msg.Reason, msg.Message);
             }
         }
     }

--- a/src/Proto.Actor/Messages.cs
+++ b/src/Proto.Actor/Messages.cs
@@ -27,16 +27,18 @@ namespace Proto
 
     public class Failure : SystemMessage
     {
-        public Failure(PID who, Exception reason, RestartStatistics crs)
+        public Failure(PID who, Exception reason, RestartStatistics crs, object message)
         {
             Who = who;
             Reason = reason;
             RestartStatistics = crs;
+            Message = message;
         }
 
         public Exception Reason { get; }
         public PID Who { get; }
         public RestartStatistics RestartStatistics { get; }
+        public object Message { get; }
     }
 
     public sealed partial class Watch : SystemMessage

--- a/src/Proto.Actor/Props.cs
+++ b/src/Proto.Actor/Props.cs
@@ -33,9 +33,9 @@ namespace Proto
         public ISupervisorStrategy GuardianStrategy { get; private set; }
         public ISupervisorStrategy SupervisorStrategy { get; private set; } = Supervision.DefaultStrategy;
         public IDispatcher Dispatcher { get; private set; } = Dispatchers.DefaultDispatcher;
-        public IList<Func<Receiver, Receiver>> ReceiveMiddleware { get; private set; } = new List<Func<Receiver, Receiver>>();
+        public IList<Func<Receiver, Receiver>> ReceiverMiddleware { get; private set; } = new List<Func<Receiver, Receiver>>();
         public IList<Func<Sender, Sender>> SenderMiddleware { get; private set; } = new List<Func<Sender, Sender>>();
-        public Receiver ReceiveMiddlewareChain { get; private set; }
+        public Receiver ReceiverMiddlewareChain { get; private set; }
         public Sender SenderMiddlewareChain { get; private set; }
         public IList<Func<IContext, IContext>> ContextDecorator { get; private set; } = new List<Func<IContext, IContext>>();
         public Func<IContext, IContext> ContextDecoratorChain { get; private set; } = DefaultContextDecorator;
@@ -86,10 +86,10 @@ namespace Proto
 
         public Props WithChildSupervisorStrategy(ISupervisorStrategy supervisorStrategy) => Copy(props => props.SupervisorStrategy = supervisorStrategy);
 
-        public Props WithReceiveMiddleware(params Func<Receiver, Receiver>[] middleware) => Copy(props =>
+        public Props WithReceiverMiddleware(params Func<Receiver, Receiver>[] middleware) => Copy(props =>
         {
-            props.ReceiveMiddleware = ReceiveMiddleware.Concat(middleware).ToList();
-            props.ReceiveMiddlewareChain = props.ReceiveMiddleware.Reverse()
+            props.ReceiverMiddleware = ReceiverMiddleware.Concat(middleware).ToList();
+            props.ReceiverMiddlewareChain = props.ReceiverMiddleware.Reverse()
                                                 .Aggregate((Receiver)Middleware.Receive, (inner, outer) => outer(inner));
         });
 
@@ -109,8 +109,8 @@ namespace Proto
                 Dispatcher = Dispatcher,
                 MailboxProducer = MailboxProducer,
                 Producer = Producer,
-                ReceiveMiddleware = ReceiveMiddleware,
-                ReceiveMiddlewareChain = ReceiveMiddlewareChain,
+                ReceiverMiddleware = ReceiverMiddleware,
+                ReceiverMiddlewareChain = ReceiverMiddlewareChain,
                 SenderMiddleware = SenderMiddleware,
                 SenderMiddlewareChain = SenderMiddlewareChain,
                 Spawner = Spawner,

--- a/src/Proto.Remote/EndpointManager.cs
+++ b/src/Proto.Remote/EndpointManager.cs
@@ -119,7 +119,7 @@ namespace Proto.Remote
             return Actor.Done;
         }
 
-        public void HandleFailure(ISupervisor supervisor, PID child, RestartStatistics rs, Exception cause)
+        public void HandleFailure(ISupervisor supervisor, PID child, RestartStatistics rs, Exception cause, object message)
         {
             supervisor.RestartChildren(cause, child);
         }

--- a/tests/Proto.Actor.Tests/ActorContextTests.cs
+++ b/tests/Proto.Actor.Tests/ActorContextTests.cs
@@ -18,7 +18,7 @@ namespace Proto.Tests
             var props = new Props()
                 .WithProducer(() => null)
                 .WithChildSupervisorStrategy(new DoNothingSupervisorStrategy())
-                .WithReceiveMiddleware(next => (ctx,env) => Actor.Done);
+                .WithReceiverMiddleware(next => (ctx,env) => Actor.Done);
             
             var context = new ActorContext(props, parent);
 

--- a/tests/Proto.Actor.Tests/MiddlewareTests.cs
+++ b/tests/Proto.Actor.Tests/MiddlewareTests.cs
@@ -79,7 +79,7 @@ namespace Proto.Tests
 
 
         [Fact]
-        public void Given_ReceiveMiddleware_and_ContextDecorator_Should_Call_Middleware_and_Decorator_Before_Actor_Receive()
+        public void Given_ReceiverMiddleware_and_ContextDecorator_Should_Call_Middleware_and_Decorator_Before_Actor_Receive()
         {
             var logs = new List<string>();
             var testMailbox = new TestMailbox();
@@ -95,7 +95,7 @@ namespace Proto.Tests
                             return Actor.Done;
                     }
                 })
-                .WithReceiveMiddleware(
+                .WithReceiverMiddleware(
                     next => async (c, env) =>
                     {
                         //only inspect "start" message
@@ -123,7 +123,7 @@ namespace Proto.Tests
         }
 
         [Fact]
-        public void Given_ReceiveMiddleware_Should_Call_Middleware_In_Order_Then_Actor_Receive()
+        public void Given_ReceiverMiddleware_Should_Call_Middleware_In_Order_Then_Actor_Receive()
         {
             var logs = new List<string>();
             var testMailbox = new TestMailbox();
@@ -133,7 +133,7 @@ namespace Proto.Tests
                         logs.Add("actor");
                     return Actor.Done;
                 })
-                .WithReceiveMiddleware(
+                .WithReceiverMiddleware(
                     next => async (c, env) =>
                     {
                         if (env.Message is string)

--- a/tests/Proto.Actor.Tests/PropsTests.cs
+++ b/tests/Proto.Actor.Tests/PropsTests.cs
@@ -20,8 +20,8 @@ namespace Proto.Tests
 
             Assert.NotEqual(props.Dispatcher, props2.Dispatcher);
             Assert.Equal(props.MailboxProducer, props2.MailboxProducer);
-            Assert.Equal(props.ReceiveMiddleware, props2.ReceiveMiddleware);
-            Assert.Equal(props.ReceiveMiddlewareChain, props2.ReceiveMiddlewareChain);
+            Assert.Equal(props.ReceiverMiddleware, props2.ReceiverMiddleware);
+            Assert.Equal(props.ReceiverMiddlewareChain, props2.ReceiverMiddlewareChain);
             Assert.Equal(props.Producer, props2.Producer);
             Assert.Equal(props.Spawner, props2.Spawner);
             Assert.Equal(props.SupervisorStrategy, props2.SupervisorStrategy);
@@ -40,8 +40,8 @@ namespace Proto.Tests
 
             Assert.Equal(props.Dispatcher, props2.Dispatcher);
             Assert.NotEqual(props.MailboxProducer, props2.MailboxProducer);
-            Assert.Equal(props.ReceiveMiddleware, props2.ReceiveMiddleware);
-            Assert.Equal(props.ReceiveMiddlewareChain, props2.ReceiveMiddlewareChain);
+            Assert.Equal(props.ReceiverMiddleware, props2.ReceiverMiddleware);
+            Assert.Equal(props.ReceiverMiddlewareChain, props2.ReceiverMiddlewareChain);
             Assert.Equal(props.Producer, props2.Producer);
             Assert.Equal(props.Spawner, props2.Spawner);
             Assert.Equal(props.SupervisorStrategy, props2.SupervisorStrategy);
@@ -55,17 +55,17 @@ namespace Proto.Tests
             Func<Receiver, Receiver> middleware3 = r => r;
 
             var props = new Props();
-            var props2 = props.WithReceiveMiddleware(middleware, middleware2);
-            var props3 = props2.WithReceiveMiddleware(middleware3);
+            var props2 = props.WithReceiverMiddleware(middleware, middleware2);
+            var props3 = props2.WithReceiverMiddleware(middleware3);
 
             Assert.NotEqual(props, props2);
-            Assert.Equal(props.ReceiveMiddleware.Count + 2, props2.ReceiveMiddleware.Count);
-            Assert.Equal(props.ReceiveMiddleware.Count + 3, props3.ReceiveMiddleware.Count);
+            Assert.Equal(props.ReceiverMiddleware.Count + 2, props2.ReceiverMiddleware.Count);
+            Assert.Equal(props.ReceiverMiddleware.Count + 3, props3.ReceiverMiddleware.Count);
 
             Assert.Equal(props.Dispatcher, props2.Dispatcher);
             Assert.Equal(props.MailboxProducer, props2.MailboxProducer);
-            Assert.NotEqual(props.ReceiveMiddleware, props2.ReceiveMiddleware);
-            Assert.NotEqual(props.ReceiveMiddlewareChain, props2.ReceiveMiddlewareChain);
+            Assert.NotEqual(props.ReceiverMiddleware, props2.ReceiverMiddleware);
+            Assert.NotEqual(props.ReceiverMiddlewareChain, props2.ReceiverMiddlewareChain);
             Assert.Equal(props.Producer, props2.Producer);
             Assert.Equal(props.Spawner, props2.Spawner);
             Assert.Equal(props.SupervisorStrategy, props2.SupervisorStrategy);
@@ -84,8 +84,8 @@ namespace Proto.Tests
 
             Assert.Equal(props.Dispatcher, props2.Dispatcher);
             Assert.Equal(props.MailboxProducer, props2.MailboxProducer);
-            Assert.Equal(props.ReceiveMiddleware, props2.ReceiveMiddleware);
-            Assert.Equal(props.ReceiveMiddlewareChain, props2.ReceiveMiddlewareChain);
+            Assert.Equal(props.ReceiverMiddleware, props2.ReceiverMiddleware);
+            Assert.Equal(props.ReceiverMiddlewareChain, props2.ReceiverMiddlewareChain);
             Assert.NotEqual(props.Producer, props2.Producer);
             Assert.Equal(props.Spawner, props2.Spawner);
             Assert.Equal(props.SupervisorStrategy, props2.SupervisorStrategy);
@@ -104,8 +104,8 @@ namespace Proto.Tests
 
             Assert.Equal(props.Dispatcher, props2.Dispatcher);
             Assert.Equal(props.MailboxProducer, props2.MailboxProducer);
-            Assert.Equal(props.ReceiveMiddleware, props2.ReceiveMiddleware);
-            Assert.Equal(props.ReceiveMiddlewareChain, props2.ReceiveMiddlewareChain);
+            Assert.Equal(props.ReceiverMiddleware, props2.ReceiverMiddleware);
+            Assert.Equal(props.ReceiverMiddlewareChain, props2.ReceiverMiddlewareChain);
             Assert.Equal(props.Producer, props2.Producer);
             Assert.NotEqual(props.Spawner, props2.Spawner);
             Assert.Equal(props.SupervisorStrategy, props2.SupervisorStrategy);
@@ -124,8 +124,8 @@ namespace Proto.Tests
 
             Assert.Equal(props.Dispatcher, props2.Dispatcher);
             Assert.Equal(props.MailboxProducer, props2.MailboxProducer);
-            Assert.Equal(props.ReceiveMiddleware, props2.ReceiveMiddleware);
-            Assert.Equal(props.ReceiveMiddlewareChain, props2.ReceiveMiddlewareChain);
+            Assert.Equal(props.ReceiverMiddleware, props2.ReceiverMiddleware);
+            Assert.Equal(props.ReceiverMiddlewareChain, props2.ReceiverMiddlewareChain);
             Assert.Equal(props.Producer, props2.Producer);
             Assert.Equal(props.Spawner, props2.Spawner);
             Assert.NotEqual(props.SupervisorStrategy, props2.SupervisorStrategy);

--- a/tests/Proto.Actor.Tests/SupervisionTests_ExponentialBackoff.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_ExponentialBackoff.cs
@@ -10,7 +10,7 @@ namespace Proto.Tests
         {
             var rs = new RestartStatistics(10, DateTime.Now.Subtract(TimeSpan.FromSeconds(11)));
             var strategy = new ExponentialBackoffStrategy(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1));
-            strategy.HandleFailure(null, null, rs, null);
+            strategy.HandleFailure(null, null, rs, null, null);
             Assert.Equal(1, rs.FailureCount);
         }
         
@@ -19,9 +19,9 @@ namespace Proto.Tests
         {
             var rs = new RestartStatistics(0, DateTime.Now);
             var strategy = new ExponentialBackoffStrategy(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1));
-            strategy.HandleFailure(null, null, rs, null);
-            strategy.HandleFailure(null, null, rs, null);
-            strategy.HandleFailure(null, null, rs, null);
+            strategy.HandleFailure(null, null, rs, null, null);
+            strategy.HandleFailure(null, null, rs, null, null);
+            strategy.HandleFailure(null, null, rs, null, null);
             Assert.Equal(3, rs.FailureCount);
         }
     }

--- a/tests/Proto.TestFixtures/DoNothingSupervisorStrategy.cs
+++ b/tests/Proto.TestFixtures/DoNothingSupervisorStrategy.cs
@@ -4,6 +4,6 @@ namespace Proto.TestFixtures
 {
     public class DoNothingSupervisorStrategy : ISupervisorStrategy
     {
-        public void HandleFailure(ISupervisor supervisor, PID child, RestartStatistics rs, Exception cause) { }
+        public void HandleFailure(ISupervisor supervisor, PID child, RestartStatistics rs, Exception cause, object message) { }
     }
 }


### PR DESCRIPTION
@rogeralsing 
This PR contains following changes:
- Revise Failure type and EscalateFailure method.  https://github.com/AsynkronIT/protoactor-dotnet/commit/f11c81e53a92e36f367a3895fddcc9b7eb807630
    1.  Follow Go version, add Message Field to Failure message type.
    2. Change EscalateFailure(Exception reason, PID who) to EscalateFailure(Exception reason, object message), since "who" will be ignored anyway.
- Rename **ReceiveMiddleware** to **ReceiverMiddleware**, this is to match SenderMiddleware naming format. https://github.com/AsynkronIT/protoactor-dotnet/commit/55379d3c1f732ab829ec00e8a01ffd0de25831c1
- Move some timer methods to ActorContextExtras. https://github.com/AsynkronIT/protoactor-dotnet/commit/55cf49b5f970bdac239a063b7bde1d10bfc85701
- CancelReceiveTimeout when TryRestartOrStopAsync https://github.com/AsynkronIT/protoactor-dotnet/commit/636129339de936c6f02a0469bb879991cfa8bd5a
    Notice this when compare with Go version. Timer is not cancelled when TryRestartOrStop