### PR TITLE
Move Parent()/Self()/Sender()/Actor() into InfoContext for shared access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,3 +258,6 @@ tools/
 Cake/
 Addins/
 examples/Persistence/Persistence/states.db
+
+# MacOS file
+.DS_Store

--- a/src/Proto.Actor/IContext.cs
+++ b/src/Proto.Actor/IContext.cs
@@ -10,28 +10,8 @@ using System.Threading.Tasks;
 
 namespace Proto
 {
-    public interface IContext : ISenderContext, IReceiverContext, ISpawnerContext
+    public interface IContext: ISenderContext, IReceiverContext, ISpawnerContext
     {
-        /// <summary>
-        ///     Gets the PID for the parent of the current actor.
-        /// </summary>
-        PID Parent { get; }
-
-        /// <summary>
-        ///     Gets the PID for the current actor.
-        /// </summary>
-        PID Self { get; }
-
-        /// <summary>
-        ///     Gets the PID of the actor that sent the currently processed message.
-        /// </summary>
-        PID Sender { get; }
-
-        /// <summary>
-        ///     Gets the actor associated with this context.
-        /// </summary>
-        IActor Actor { get; }
-
         /// <summary>
         ///     Gets the receive timeout.
         /// </summary>

--- a/src/Proto.Actor/IInfoContext.cs
+++ b/src/Proto.Actor/IInfoContext.cs
@@ -1,0 +1,35 @@
+// -----------------------------------------------------------------------
+//   <copyright file="IContext.cs" company="Asynkron HB">
+//       Copyright (C) 2015-2018 Asynkron HB All rights reserved
+//   </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Proto
+{
+    public interface IInfoContext
+    {
+        /// <summary>
+        ///     Gets the PID for the parent of the current actor.
+        /// </summary>
+        PID Parent { get; }
+
+        /// <summary>
+        ///     Gets the PID for the current actor.
+        /// </summary>
+        PID Self { get; }
+
+        /// <summary>
+        ///     Gets the PID of the actor that sent the currently processed message.
+        /// </summary>
+        PID Sender { get; }
+
+        /// <summary>
+        ///     Gets the actor associated with this context.
+        /// </summary>
+        IActor Actor { get; }
+    }
+}

--- a/src/Proto.Actor/IReceiverContext.cs
+++ b/src/Proto.Actor/IReceiverContext.cs
@@ -2,7 +2,7 @@
 
 namespace Proto
 {
-    public interface IReceiverContext
+    public interface IReceiverContext: IInfoContext
     {
         Task Receive(MessageEnvelope envelope);
     }

--- a/src/Proto.Actor/ISenderContext.cs
+++ b/src/Proto.Actor/ISenderContext.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Proto
 {
-    public interface ISenderContext
+    public interface ISenderContext: IInfoContext
     {
         /// <summary>
         /// Send a message to a given PID target

--- a/src/Proto.Actor/RootContext.cs
+++ b/src/Proto.Actor/RootContext.cs
@@ -14,13 +14,17 @@ namespace Proto
     public interface IRootContext : ISpawnerContext, ISenderContext
     {
     }
-    
+
     public class RootContext : IRootContext
     {
         public static readonly RootContext Empty = new RootContext();
         private Sender SenderMiddleware { get; set; }
         public MessageHeader Headers { get; private set; }
 
+        public PID Parent { get => null; }
+        public PID Self { get => null; }
+        public PID Sender { get => null; }
+        public IActor Actor { get => null; }
 
         public PID Spawn(Props props)
         {
@@ -49,7 +53,7 @@ namespace Proto
         public RootContext(MessageHeader messageHeader, params Func<Sender, Sender>[] middleware)
         {
             SenderMiddleware = middleware.Reverse()
-                .Aggregate((Sender) DefaultSender, (inner, outer) => outer(inner));
+                .Aggregate((Sender)DefaultSender, (inner, outer) => outer(inner));
             Headers = messageHeader;
         }
 
@@ -57,7 +61,7 @@ namespace Proto
         public RootContext WithSenderMiddleware(params Func<Sender, Sender>[] middleware) => Copy(c =>
         {
             SenderMiddleware = middleware.Reverse()
-                .Aggregate((Sender) DefaultSender, (inner, outer) => outer(inner));
+                .Aggregate((Sender)DefaultSender, (inner, outer) => outer(inner));
         });
 
 
@@ -78,7 +82,7 @@ namespace Proto
         private Task DefaultSender(ISenderContext context, PID target, MessageEnvelope message)
         {
             target.SendUserMessage(message);
-            return Actor.Done;
+            return Proto.Actor.Done;
         }
 
         public void Send(PID target, object message)

--- a/src/Proto.Actor/RootContextDecorator.cs
+++ b/src/Proto.Actor/RootContextDecorator.cs
@@ -35,5 +35,10 @@ namespace Proto
 
         public virtual MessageHeader Headers => _context.Headers;
         public virtual object Message => _context.Message;
+
+        public virtual PID Parent { get => null; }
+        public virtual PID Self { get => null; }
+        public virtual PID Sender { get => null; }
+        public virtual IActor Actor { get => null; }
     }
 }


### PR DESCRIPTION
Move Parent()/Self()/Sender()/Actor() into InfoContext for shared access in IContext, ISenderContext and IReceiverContext.