### PR TITLE
TaskCompletionSource complete asynchronously, benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,6 @@ examples/Persistence/Persistence/states.db
 
 # MacOS file
 .DS_Store
+
+# Benchmark artifacts
+BenchmarkDotNet.Artifacts/

--- a/ProtoActor.sln
+++ b/ProtoActor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.202
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{771514F1-12AE-4A26-89CB-2646D3EF7034}"
 EndProject
@@ -202,6 +202,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Patterns", "Patterns", "{3025D606-F487-4A06-A2A3-91AA7503B606}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Saga", "examples\Patterns\Saga\Saga.csproj", "{F6E76800-BF17-4D9B-9AD1-2BD2A3138807}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Proto.Actor.Benchmarks", "tests\Proto.Actor.Benchmarks\Proto.Actor.Benchmarks.csproj", "{690E360D-BC49-42E8-B914-41B022C7093A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1016,6 +1018,18 @@ Global
 		{F6E76800-BF17-4D9B-9AD1-2BD2A3138807}.Release|x64.Build.0 = Release|Any CPU
 		{F6E76800-BF17-4D9B-9AD1-2BD2A3138807}.Release|x86.ActiveCfg = Release|Any CPU
 		{F6E76800-BF17-4D9B-9AD1-2BD2A3138807}.Release|x86.Build.0 = Release|Any CPU
+		{690E360D-BC49-42E8-B914-41B022C7093A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{690E360D-BC49-42E8-B914-41B022C7093A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{690E360D-BC49-42E8-B914-41B022C7093A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{690E360D-BC49-42E8-B914-41B022C7093A}.Debug|x64.Build.0 = Debug|Any CPU
+		{690E360D-BC49-42E8-B914-41B022C7093A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{690E360D-BC49-42E8-B914-41B022C7093A}.Debug|x86.Build.0 = Debug|Any CPU
+		{690E360D-BC49-42E8-B914-41B022C7093A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{690E360D-BC49-42E8-B914-41B022C7093A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{690E360D-BC49-42E8-B914-41B022C7093A}.Release|x64.ActiveCfg = Release|Any CPU
+		{690E360D-BC49-42E8-B914-41B022C7093A}.Release|x64.Build.0 = Release|Any CPU
+		{690E360D-BC49-42E8-B914-41B022C7093A}.Release|x86.ActiveCfg = Release|Any CPU
+		{690E360D-BC49-42E8-B914-41B022C7093A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1116,6 +1130,7 @@ Global
 		{25973551-0EE2-428A-842C-00D5EB8FBF94} = {1F19AC4F-31B5-40DA-B599-3F8F69731339}
 		{3025D606-F487-4A06-A2A3-91AA7503B606} = {59DCCC96-DDAF-469F-9E8E-9BC733285082}
 		{F6E76800-BF17-4D9B-9AD1-2BD2A3138807} = {3025D606-F487-4A06-A2A3-91AA7503B606}
+		{690E360D-BC49-42E8-B914-41B022C7093A} = {9AA2BCF0-19AB-4DD9-8D91-7D188E463806}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD0D1E44-8118-4682-8793-6B20ABFA824C}

--- a/examples/InprocessBenchmark/InprocessBenchmark.csproj
+++ b/examples/InprocessBenchmark/InprocessBenchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="runtimeconfig.template.json" />

--- a/examples/InprocessBenchmark/Program.cs
+++ b/examples/InprocessBenchmark/Program.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Runtime;
 using System.Threading;
@@ -63,8 +64,8 @@ public class Program
             sw.Stop();
             var totalMessages = messageCount * 2 * clientCount;
 
-            var x = (int) (totalMessages / (double) sw.ElapsedMilliseconds * 1000.0d);
-            Console.WriteLine($"{t}\t\t\t{sw.ElapsedMilliseconds}\t\t{x}");
+            var x = ((int) (totalMessages / (double) sw.ElapsedMilliseconds * 1000.0d)).ToString("#,##0,,M", CultureInfo.InvariantCulture);
+            Console.WriteLine($"{t}\t\t\t{sw.ElapsedMilliseconds} ms\t\t{x}");
             Thread.Sleep(2000);
         }
 

--- a/examples/InprocessBenchmark/Program.cs
+++ b/examples/InprocessBenchmark/Program.cs
@@ -21,11 +21,11 @@ public class Program
     {
         var context = new RootContext();
         Console.WriteLine($"Is Server GC {GCSettings.IsServerGC}");
-        const int messageCount = 1000000;
+        const int messageCount = 1_000_000;
         const int batchSize = 100;
 
         Console.WriteLine("Dispatcher\t\tElapsed\t\tMsg/sec");
-        var tps = new[] {300, 400, 500, 600, 700, 800, 900};
+        var tps = new[] {300, 400, 500, 600, 700, 800, 900, 1000, 1500, 3000};
         foreach (var t in tps)
         {
             var d = new ThreadPoolDispatcher {Throughput = t};

--- a/src/Proto.Actor/Proto.Actor.csproj
+++ b/src/Proto.Actor/Proto.Actor.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <DefineConstants>NET452</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>library</OutputType>

--- a/tests/Proto.Actor.Benchmarks/Program.cs
+++ b/tests/Proto.Actor.Benchmarks/Program.cs
@@ -1,0 +1,114 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Proto.Mailbox;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Proto.Actor.Benchmarks
+{
+    public class EchoActor2 : IActor
+    {
+        public Task ReceiveAsync(IContext context)
+        {
+            switch (context.Message)
+            {
+                case string _:
+                    context.Send(context.Sender, "pong");
+                    break;
+            }
+            return Task.CompletedTask;
+        }
+    }
+
+    [MemoryDiagnoser, InProcess]
+    public class ShortBenchmark
+    {
+        private RootContext _context;
+        private Props _echoProps;
+        private PID _echoActor;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _context = new RootContext();
+
+            _echoProps = Props.FromProducer(() => new EchoActor2())
+                .WithMailbox(() => BoundedMailbox.Create(2048));
+            _echoActor = _context.Spawn(_echoProps);
+        }
+
+        [Benchmark]
+        public async Task InProcessPingPong()
+        {
+            var pong = await _context.RequestAsync<string>(_echoActor, "ping", TimeSpan.FromSeconds(5));
+            if (pong != "pong")
+                throw new Exception("Wrong!");
+        }
+    }
+
+    [MemoryDiagnoser, InProcess]
+    public class LongBenchmark
+    {
+        private RootContext _context;
+
+        [Params(300, 400, 500, 600, 700, 800, 900)]
+        public int Tps { get; set; }
+
+        [Params(1000000)]
+        public int MessageCount { get; set; }
+
+        [Params(100)]
+        public int BatchSize { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _context = new RootContext();
+        }
+
+        [Benchmark]
+        public Task InProcessPingPong()
+        {
+            var d = new ThreadPoolDispatcher { Throughput = Tps };
+
+            var clientCount = Environment.ProcessorCount * 1;
+            var clients = new PID[clientCount];
+            var echos = new PID[clientCount];
+            var completions = new TaskCompletionSource<bool>[clientCount];
+
+            var echoProps = Props.FromProducer(() => new EchoActor())
+                .WithDispatcher(d)
+                .WithMailbox(() => BoundedMailbox.Create(2048));
+
+            for (var i = 0; i < clientCount; i++)
+            {
+                var tsc = new TaskCompletionSource<bool>();
+                completions[i] = tsc;
+                var clientProps = Props.FromProducer(() => new PingActor(tsc, MessageCount, BatchSize))
+                    .WithDispatcher(d)
+                    .WithMailbox(() => BoundedMailbox.Create(2048));
+
+                clients[i] = _context.Spawn(clientProps);
+                echos[i] = _context.Spawn(echoProps);
+            }
+            var tasks = completions.Select(tsc => tsc.Task).ToArray();
+            for (var i = 0; i < clientCount; i++)
+            {
+                var client = clients[i];
+                var echo = echos[i];
+
+                _context.Send(client, new Start(echo));
+            }
+            return Task.WhenAll(tasks);
+        }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<ShortBenchmark>();
+        }
+    }
+}

--- a/tests/Proto.Actor.Benchmarks/Program.cs
+++ b/tests/Proto.Actor.Benchmarks/Program.cs
@@ -27,6 +27,7 @@ namespace Proto.Actor.Benchmarks
         private RootContext _context;
         private Props _echoProps;
         private PID _echoActor;
+        private TimeSpan _timeout;
 
         [GlobalSetup]
         public void Setup()
@@ -36,14 +37,13 @@ namespace Proto.Actor.Benchmarks
             _echoProps = Props.FromProducer(() => new EchoActor2())
                 .WithMailbox(() => BoundedMailbox.Create(2048));
             _echoActor = _context.Spawn(_echoProps);
+            _timeout = TimeSpan.FromSeconds(5);
         }
 
         [Benchmark]
-        public async Task InProcessPingPong()
+        public Task InProcessPingPong()
         {
-            var pong = await _context.RequestAsync<string>(_echoActor, "ping", TimeSpan.FromSeconds(5));
-            if (pong != "pong")
-                throw new Exception("Wrong!");
+            return _context.RequestAsync<string>(_echoActor, "ping", _timeout);
         }
     }
 

--- a/tests/Proto.Actor.Benchmarks/Proto.Actor.Benchmarks.csproj
+++ b/tests/Proto.Actor.Benchmarks/Proto.Actor.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Proto.Actor.Benchmarks/Proto.Actor.Benchmarks.csproj
+++ b/tests/Proto.Actor.Benchmarks/Proto.Actor.Benchmarks.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net461</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\examples\InprocessBenchmark\InprocessBenchmark.csproj" />
+    <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj" />
+    <ProjectReference Include="..\..\src\Proto.Mailbox\Proto.Mailbox.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Been taking a look at this library for future projects. Saw this issue: https://github.com/AsynkronIT/protoactor-dotnet/issues/432

This PR instantiates `TaskCompletionSource` with the `TaskCreationOptions.RunContinuationsAsynchronously` for targets other than `net452`. In those cases the `WrapTask` hack isn't needed. Also includes suggested fix for the TODO for the timeout handler.

I've included some benchmarks and added a BenchmarkDotNet project to get some more numbers. Results can be reviewed below. These were run on my laptop. Didn't get much difference from the benchmark in the examples folder, but my runs with BenchmarkDotNet shows some difference in both latency and allocations.

#### InProcessBenchmark from examples folder

##### Before change

net452:
Is Server GC False
Dispatcher              Elapsed         Msg/sec
300                     334 ms          48M
400                     306 ms          52M
500                     280 ms          57M
600                     291 ms          55M
700                     296 ms          54M
800                     284 ms          56M
900                     277 ms          58M

netcoreapp2.1:
Is Server GC True
Dispatcher              Elapsed         Msg/sec
300                     264 ms          61M
400                     233 ms          69M
500                     248 ms          65M
600                     256 ms          63M
700                     229 ms          70M
800                     229 ms          70M
900                     238 ms          67M

##### After change

net452:

Is Server GC False
Dispatcher              Elapsed         Msg/sec
300                     332 ms          48M
400                     311 ms          51M
500                     298 ms          54M
600                     325 ms          49M
700                     285 ms          56M
800                     309 ms          52M
900                     284 ms          56M

netcoreapp2.1:

Is Server GC True
Dispatcher              Elapsed         Msg/sec
300                     268 ms          60M
400                     239 ms          67M
500                     232 ms          69M
600                     236 ms          68M
700                     223 ms          72M
800                     229 ms          70M
900                     230 ms          70M

#### New BenchmarkDotNet benchmarks

##### Before change

netcoreapp2.1:

// * Summary *

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17134.706 (1803/April2018Update/Redstone4)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-preview4-011223
  [Host] : .NET Core 2.1.9 (CoreCLR 4.6.27414.06, CoreFX 4.6.27415.01), 64bit RyuJIT

Job=InProcess  Toolchain=InProcessEmitToolchain

|            Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |---------:|----------:|----------:|-------:|------:|------:|----------:|
| InProcessPingPong | 5.161 us | 0.1082 us | 0.1867 us | 0.4654 |     - |     - |   1.35 KB |

##### After change

netcoreapp2.1:

// * Summary *

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17134.706 (1803/April2018Update/Redstone4)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-preview4-011223
  [Host] : .NET Core 2.1.9 (CoreCLR 4.6.27414.06, CoreFX 4.6.27415.01), 64bit RyuJIT

Job=InProcess  Toolchain=InProcessEmitToolchain

|            Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |---------:|----------:|----------:|-------:|------:|------:|----------:|
| InProcessPingPong | 3.334 us | 0.0665 us | 0.1093 us | 0.3357 |     - |     - |    1000 B |