### PR TITLE
Fix stash replay bug - context is now replayed correctly

### DIFF
--- a/src/Proto.Actor/ActorContext.cs
+++ b/src/Proto.Actor/ActorContext.cs
@@ -115,7 +115,7 @@ namespace Proto
 
         public TimeSpan ReceiveTimeout { get; private set; }
 
-        public void Stash() => EnsureExtras().Stash.Push(Message);
+        public void Stash() => EnsureExtras().Stash.Push(_messageOrEnvelope);
 
         public void Respond(object message) => Send(Sender, message);
 

--- a/src/Proto.Actor/ActorContext.cs
+++ b/src/Proto.Actor/ActorContext.cs
@@ -526,9 +526,12 @@ namespace Proto
             await InvokeUserMessageAsync(Started.Instance);
             if (_extras?.Stash != null)
             {
-                while (_extras.Stash.Any())
+                
+                var currentStash = new Stack<Object>(_extras.Stash);
+                _extras.Stash.Clear();
+                while (currentStash.Any())
                 {
-                    var msg = _extras.Stash.Pop();
+                    var msg = currentStash.Pop();
                     await InvokeUserMessageAsync(msg);
                 }
             }

--- a/tests/Proto.Actor.Tests/ActorContextTests.cs
+++ b/tests/Proto.Actor.Tests/ActorContextTests.cs
@@ -30,6 +30,7 @@ namespace Proto.Tests
             Assert.Null(context.Actor);
             Assert.NotNull(context.Children);
             Assert.NotNull(context.Children);
+            
 
             Assert.Equal(TimeSpan.Zero, context.ReceiveTimeout);
         }
@@ -83,5 +84,31 @@ namespace Proto.Tests
             Assert.Equal("bar", two);
             Assert.Equal("baz", three);
         }
+        [Fact]
+        public async Task Stash_Should_Replay_Context()
+        {
+            var receiverFirstMessage = true;
+
+        
+            var receiver = SpawnActorFromFunc(ctx => {
+                
+                if(ctx.Message is string strMsg){
+                    if(receiverFirstMessage){
+                        ctx.Stash();
+                        receiverFirstMessage = false;
+                        throw new ApplicationException("First run error");
+                    }
+                    ctx.Respond(ctx.Sender);
+                }
+                return Actor.Done;
+            });
+
+
+            var ctxSender = await Context.RequestAsync<PID>(receiver, "firstmessage");
+
+            Assert.NotNull(ctxSender);
+        }
     }
+
+    
 }

--- a/tests/Proto.Actor.Tests/ActorContextTests.cs
+++ b/tests/Proto.Actor.Tests/ActorContextTests.cs
@@ -104,7 +104,7 @@ namespace Proto.Tests
             });
 
 
-            var ctxSender = await Context.RequestAsync<PID>(receiver, "firstmessage");
+            var ctxSender = await Context.RequestAsync<PID>(receiver, "firstmessage", TimeSpan.FromSeconds(10));
 
             Assert.NotNull(ctxSender);
         }


### PR DESCRIPTION
Upon replay of stash values like context.Sender were not preserved this PR resolves that.