### PR TITLE
Update Actor code example to match latest code

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ internal class HelloActor : IActor
 Spawn it and send a message to it:
 
 ```csharp
-var props = Actor.FromProducer(() => new HelloActor());
-var pid = Actor.Spawn(props);
-pid.Tell(new Hello
+var context = new RootContext();
+var props = Props.FromProducer(() => new HelloActor());
+var pid = context.Spawn(props);
+
+context.Send(pid, new Hello
 {
     Who = "Alex"
 });


### PR DESCRIPTION
Code example in the readme is out of date and references older API's.

This is a simple change which updates the readme code example to use the `RootContext` object for spawning actors.