### PR TITLE
add exponential backoff described in AsynkronIT#463

### DIFF
--- a/src/Proto.Actor/DeadLetter.cs
+++ b/src/Proto.Actor/DeadLetter.cs
@@ -7,7 +7,7 @@ namespace Proto
 {
     public class DeadLetterEvent
     {
-        internal DeadLetterEvent(PID pid, object message, PID sender)
+        public DeadLetterEvent(PID pid, object message, PID sender)
         {
             Pid = pid;
             Message = message;

--- a/src/Proto.Remote/EndpointWriter.cs
+++ b/src/Proto.Remote/EndpointWriter.cs
@@ -6,25 +6,30 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Authentication.ExtendedProtection;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Core.Utils;
 using Microsoft.Extensions.Logging;
+using Proto.Mailbox;
+
 
 namespace Proto.Remote
 {
     public class EndpointWriter : IActor
     {
+        private static readonly ILogger _logger = Log.CreateLogger<EndpointWriter>();
         private int _serializerId;
         private readonly string _address;
         private readonly CallOptions _callOptions;
         private readonly ChannelCredentials _channelCredentials;
         private readonly IEnumerable<ChannelOption> _channelOptions;
-        private readonly ILogger _logger = Log.CreateLogger<EndpointWriter>();
+        
         private Channel _channel;
         private Remoting.RemotingClient _client;
         private AsyncDuplexStreamingCall<MessageBatch, Unit> _stream;
         private IClientStreamWriter<MessageBatch> _streamWriter;
+        
 
         public EndpointWriter(string address, IEnumerable<ChannelOption> channelOptions, CallOptions callOptions, ChannelCredentials channelCredentials)
         {
@@ -32,14 +37,18 @@ namespace Proto.Remote
             _channelOptions = channelOptions;
             _callOptions = callOptions;
             _channelCredentials = channelCredentials;
+            
+           
         }
 
         public async Task ReceiveAsync(IContext context)
         {
+            
             switch (context.Message)
             {
                 case Started _:
-                    await StartedAsync();
+                    _logger.LogDebug("Starting Endpoint Writer");
+                    await StartedAsync(context);
                     break;
                 case Stopped _:
                     await StoppedAsync();
@@ -52,12 +61,13 @@ namespace Proto.Remote
                     context.Stop(context.Self);
                     break;
                 case IEnumerable<RemoteDeliver> m:
+                    
                     var envelopes = new List<MessageEnvelope>();
-                    var typeNames = new Dictionary<string, int>();
-                    var targetNames = new Dictionary<string, int>();
+                    var typeNames = new Dictionary<string,int>();
+                    var targetNames = new Dictionary<string,int>();
                     var typeNameList = new List<string>();
                     var targetNameList = new List<string>();
-                    foreach (var rd in m)
+                    foreach(var rd in m)
                     {
                         var targetName = rd.Target.Id;
                         var serializerId = rd.SerializerId == -1 ? _serializerId : rd.SerializerId;
@@ -95,12 +105,12 @@ namespace Proto.Remote
 
                         envelopes.Add(envelope);
                     }
-
+                    
                     var batch = new MessageBatch();
                     batch.TargetNames.AddRange(targetNameList);
                     batch.TypeNames.AddRange(typeNameList);
                     batch.Envelopes.AddRange(envelopes);
-
+                    _logger.LogDebug($"EndpointWriter sending {envelopes.Count} Envelopes for {_address} while channel status is {_channel?.State}");        
                     await SendEnvelopesAsync(batch, context);
                     break;
             }
@@ -108,8 +118,15 @@ namespace Proto.Remote
 
         private async Task SendEnvelopesAsync(MessageBatch batch, IContext context)
         {
+            if (_streamWriter == null)
+            {
+                
+                _logger.LogError($"gRPC Failed to send to address {_address}, reason No Connection available");
+                return;
+            }
             try
             {
+                _logger.LogDebug($"Writing batch to {_address}");
                 await _streamWriter.WriteAsync(batch);
             }
             catch (Exception x)
@@ -121,34 +138,40 @@ namespace Proto.Remote
         }
 
         //shutdown channel before restarting
-        private Task RestartingAsync() => _channel.ShutdownAsync();
-
+        private Task RestartingAsync() => ShutDownChannel();
+       
         //shutdown channel before stopping
-        private Task StoppedAsync() => _channel.ShutdownAsync();
+        private Task StoppedAsync() => ShutDownChannel();
+        
+        private Task ShutDownChannel() 
+        {
+            if (_channel != null && _channel.State != ChannelState.Shutdown)
+            {
+                return _channel.ShutdownAsync();
+            }
 
-        private async Task StartedAsync()
+            return Actor.Done;
+        }
+
+        private async Task StartedAsync(IContext ctx)
         {
             _logger.LogDebug($"Connecting to address {_address}");
+            
+            
             _channel = new Channel(_address, _channelCredentials, _channelOptions);
             _client = new Remoting.RemotingClient(_channel);
+            
+            _logger.LogDebug($"created channel and client for address {_address}");
 
-            try
-            {
-                var res = await _client.ConnectAsync(new ConnectRequest());
-                _serializerId = res.DefaultSerializerId;
-                _stream = _client.Receive(_callOptions);
-                _streamWriter = _stream.RequestStream;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError($"GRPC Failed to connect to address {_address}\n{ex}");
-                //Wait for 2 seconds to restart and retry
-                //Replace with Exponential Backoff
-                await Task.Delay(2000);
-                throw;
-            }
-
-            var _ = Task.Factory.StartNew(async () =>
+            var res = await _client.ConnectAsync(new ConnectRequest());
+            _serializerId = res.DefaultSerializerId;
+            _stream = _client.Receive(_callOptions);
+            _streamWriter = _stream.RequestStream;
+            
+            _logger.LogDebug($"Connected client for address {_address}");
+           
+            
+            var _ = Task.Run(async () =>
             {
                 try
                 {
@@ -164,6 +187,8 @@ namespace Proto.Remote
                     Actor.EventStream.Publish(terminated);
                 }
             });
+            
+            _logger.LogDebug($"created reader for address {_address}");
 
             var connected = new EndpointConnectedEvent
             {

--- a/src/Proto.Remote/RemoteConfig.cs
+++ b/src/Proto.Remote/RemoteConfig.cs
@@ -4,6 +4,7 @@
 //   </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using Grpc.Core;
 
@@ -11,11 +12,12 @@ namespace Proto.Remote
 {
     public class RemoteConfig
     {
-        /// <summary>
-        /// Gets or sets the batch size for the endpoint writer. The default value is 1000.
-        /// The endpoint writer will send up to this number of messages in a batch.
-        /// </summary>
-        public int EndpointWriterBatchSize { get; set; } = 1000;
+       
+        [Obsolete("Use EndpointWriterOptions.EndpointWriterBatchSize instead")]
+        public int EndpointWriterBatchSize { 
+            get { return EndpointWriterOptions.EndpointWriterBatchSize; }
+            set { EndpointWriterOptions.EndpointWriterBatchSize = value; }
+        }
 
         /// <summary>
         /// Gets or sets the ChannelOptions for the gRPC channel.
@@ -50,5 +52,27 @@ namespace Proto.Remote
         /// the external port in order for other systems to be able to connect to it.
         /// </summary>
         public int? AdvertisedPort { get; set; }
+
+        public EndpointWriterOptions EndpointWriterOptions { get; set;} = new EndpointWriterOptions();
+    }
+
+    public class EndpointWriterOptions
+    {
+        /// <summary>
+        /// Gets or sets the batch size for the endpoint writer. The default value is 1000.
+        /// The endpoint writer will send up to this number of messages in a batch.
+        /// </summary>
+        public int EndpointWriterBatchSize { get; set; } = 1000;
+        
+        /// <summary>
+        /// the number of times to retry the connection within the RetryTimeSpan
+        /// </summary>
+        public int MaxRetries {get; set; } = 10;
+        public TimeSpan RetryTimeSpan { get; set; } = TimeSpan.FromMinutes(10);
+
+        /// <summary>
+        /// each retry backs off by an exponential ratio of this amount
+        /// </summary>
+        public int RetryBackOffms { get; set; } = 250;
     }
 }

--- a/src/Proto.Remote/RemoteConfig.cs
+++ b/src/Proto.Remote/RemoteConfig.cs
@@ -67,12 +67,12 @@ namespace Proto.Remote
         /// <summary>
         /// the number of times to retry the connection within the RetryTimeSpan
         /// </summary>
-        public int MaxRetries {get; set; } = 10;
-        public TimeSpan RetryTimeSpan { get; set; } = TimeSpan.FromMinutes(10);
+        public int MaxRetries {get; set; } = 8;
+        public TimeSpan RetryTimeSpan { get; set; } = TimeSpan.FromMinutes(3);
 
         /// <summary>
         /// each retry backs off by an exponential ratio of this amount
         /// </summary>
-        public int RetryBackOffms { get; set; } = 250;
+        public int RetryBackOffms { get; set; } = 10;
     }
 }

--- a/src/Proto.Remote/RemoteConfig.cs
+++ b/src/Proto.Remote/RemoteConfig.cs
@@ -73,6 +73,6 @@ namespace Proto.Remote
         /// <summary>
         /// each retry backs off by an exponential ratio of this amount
         /// </summary>
-        public int RetryBackOffms { get; set; } = 10;
+        public int RetryBackOffms { get; set; } = 100;
     }
 }

--- a/tests/Proto.Remote.Tests/ConnectionFailTests.cs
+++ b/tests/Proto.Remote.Tests/ConnectionFailTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Divergic.Logging.Xunit;
+using Microsoft.Extensions.Logging;
+using Proto.Remote.Tests.Messages;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Proto.Remote.Tests
+{
+    public class ConnectionFailTests
+    {
+        public ConnectionFailTests(ITestOutputHelper testOutputHelper){
+            var factory = LogFactory.Create(testOutputHelper);
+            Log.SetLoggerFactory(factory);
+
+            
+
+        }
+        //[Fact, DisplayTestMethodName]
+        public async Task CanRecoverFromConnectionFailureAsync()
+        {
+
+            var logger = Log.CreateLogger("ConnectionFail");
+            
+            var remoteActor = new PID("127.0.0.1:12000", "EchoActorInstance");
+            var ct = new CancellationTokenSource(30000);
+            var tcs = new TaskCompletionSource<bool>();
+            var receivedTerminationTCS = new TaskCompletionSource<bool>();
+            ct.Token.Register(() =>
+            {
+                tcs.TrySetCanceled();
+                receivedTerminationTCS.TrySetCanceled();
+            });
+            var endpointTermEvnSub = EventStream.Instance.Subscribe<EndpointTerminatedEvent>(termEvent => {
+                receivedTerminationTCS.TrySetResult(true);
+            });
+
+            Remote.Start("127.0.0.1", 12001);
+
+            var localActor = RootContext.Empty.Spawn(Props.FromFunc(ctx =>
+            {
+                
+                if (ctx.Message is Pong)
+                {
+                    tcs.SetResult(true);
+                    ctx.Stop(ctx.Self);
+                }
+
+                return Actor.Done;
+            }));
+            
+            var json = new JsonMessage("remote_test_messages.Ping", "{ \"message\":\"Hello\"}");
+            var envelope = new Proto.MessageEnvelope(json, localActor, Proto.MessageHeader.Empty);
+            Remote.SendMessage(remoteActor, envelope, 1);
+            logger.LogDebug("sent message");
+            // await Task.Delay(3000);
+            logger.LogDebug("starting remote manager");
+            using(var remoteService = new RemoteManager(false)){
+                logger.LogDebug("awaiting completion");
+                await tcs.Task;
+            }
+            
+            Remote.Shutdown(true);
+            await receivedTerminationTCS.Task;
+        }
+
+
+       
+
+        //[Fact, DisplayTestMethodName]
+        public async Task MessagesGoToDeadLetterAfterConnectionFail()
+        {
+
+            var logger = Log.CreateLogger("ConnectionFail");
+            
+            var remoteActor = new PID("127.0.0.1:12000", "EchoActorInstance");
+            var ct = new CancellationTokenSource(30000);
+            var receivedPong = new TaskCompletionSource<bool>();
+            var receivedDeadLetterEventTCS = new TaskCompletionSource<bool>();
+            ct.Token.Register(() =>
+            {
+                receivedPong.TrySetCanceled();
+                receivedDeadLetterEventTCS.TrySetCanceled();
+            });
+            var deadLetterEvnSub = EventStream.Instance.Subscribe<DeadLetterEvent>(deadLetterEvt => {
+                if(deadLetterEvt.Message is JsonMessage){
+                    receivedDeadLetterEventTCS.TrySetResult(true);
+                }
+                
+            });
+            var config = new RemoteConfig{
+                EndpointWriterOptions = new EndpointWriterOptions {
+                    MaxRetries = 2,
+                    RetryBackOffms = 10,
+                    RetryTimeSpan = TimeSpan.FromSeconds(120)
+                }
+            };
+
+            Remote.Start("127.0.0.1", 12001, config);
+
+            var localActor = RootContext.Empty.Spawn(Props.FromFunc(ctx =>
+            {
+                
+                if (ctx.Message is Pong)
+                {
+                    receivedPong.SetResult(true);
+                    ctx.Stop(ctx.Self);
+                }
+
+                return Actor.Done;
+            }));
+            
+            var json = new JsonMessage("remote_test_messages.Ping", "{ \"message\":\"Hello\"}");
+            var envelope = new Proto.MessageEnvelope(json, localActor, Proto.MessageHeader.Empty);
+            logger.LogDebug("sending messge while offline");
+            Remote.SendMessage(remoteActor, envelope, 1);
+            
+            
+            logger.LogDebug("waiting for connection to fail after retries and fire a terminated event");
+            await receivedDeadLetterEventTCS.Task;
+            
+            logger.LogDebug("Starting Remote service");
+            //Should reconnect if we send a new message
+            using(var remoteService = new RemoteManager(false)){
+                await Task.Delay(2000);
+                logger.LogDebug("Sending new message now that remote is up");
+                Remote.SendMessage(remoteActor, envelope, 1);
+                logger.LogDebug("Waiting for response to message");
+                await receivedPong.Task;
+            }
+            
+            Remote.Shutdown(true);
+            
+        }
+
+        
+
+        
+    }
+}

--- a/tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj
+++ b/tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Divergic.Logging.Xunit" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tests/Proto.Remote.Tests/RemoteManager.cs
+++ b/tests/Proto.Remote.Tests/RemoteManager.cs
@@ -13,11 +13,18 @@ namespace Proto.Remote.Tests
 
         public (string Address, System.Diagnostics.Process Process) DefaultNode => (DefaultNodeAddress, Nodes[DefaultNodeAddress]);
 
-        public RemoteManager()
+        public RemoteManager() : this(true) {
+
+        }
+        
+        public RemoteManager(bool startLocalRemote = false)
         {
             Serialization.RegisterFileDescriptor(Messages.ProtosReflection.Descriptor);
             ProvisionNode("127.0.0.1", 12000);
-            Remote.Start("127.0.0.1", 12001);
+            if(startLocalRemote){
+                 Remote.Start("127.0.0.1", 12001);
+            }
+           
             
             Thread.Sleep(3000);
         }


### PR DESCRIPTION
While adding this feature I discovered that in the current codebase, once a connection fails, it does not get reconnected. This PR fixes that bug plus implements a new exponential backoff for the connection.

I wrote some tests to help prove that it is all working (ConnectionFailTests.cs) but these are disabled because they take a little while to run and I wasn't confident they would play nice with the other tests in the suite due to the fact that they switch the remote server on and off.