### PR TITLE
Actorsystem in context

### DIFF
--- a/examples/Middleware/Program.cs
+++ b/examples/Middleware/Program.cs
@@ -25,7 +25,7 @@ class Program
         var root = new RootContext(
             system,
             headers,
-            next => async (s, c, target, envelope) =>
+            next => async (c, target, envelope) =>
             {
                 var newEnvelope = envelope
                     .WithHeader("TraceID", c.Headers.GetOrDefault("TraceID"))
@@ -36,7 +36,7 @@ class Program
                 Console.WriteLine(" 1 TraceID: " + newEnvelope.Header.GetOrDefault("TraceID"));
                 Console.WriteLine(" 1 SpanID: " + newEnvelope.Header.GetOrDefault("SpanID"));
                 Console.WriteLine(" 1 ParentSpanID: " + newEnvelope.Header.GetOrDefault("ParentSpanID"));
-                await next(s, c, target, newEnvelope);
+                await next(c, target, newEnvelope);
                 //this line might look confusing at first when reading the console output
                 //it looks like this finishes before the actor receive middleware kicks in
                 //which is exactly what it does, due to the actor mailbox.
@@ -80,7 +80,7 @@ class Program
                 {
                     await next(context, envelope);
                 }
-            }).WithSenderMiddleware(next => async (system, context, target, envelope) =>
+            }).WithSenderMiddleware(next => async (context, target, envelope) =>
             {
                 var newEnvelope = envelope
                     .WithHeader("TraceID", context.Headers.GetOrDefault("TraceID"))
@@ -91,7 +91,7 @@ class Program
                 Console.WriteLine("    4 TraceID: " + newEnvelope.Header.GetOrDefault("TraceID"));
                 Console.WriteLine("    4 SpanID: " + newEnvelope.Header.GetOrDefault("SpanID"));
                 Console.WriteLine("    4 ParentSpanID: " + newEnvelope.Header.GetOrDefault("ParentSpanID"));
-                await next(system, context, target, envelope);
+                await next(context, target, envelope);
                 Console.WriteLine("    4 Exit Actor SenderMiddleware");
             });
         var pid = root.Spawn(actor);

--- a/src/Proto.Actor/ActorContext.cs
+++ b/src/Proto.Actor/ActorContext.cs
@@ -432,7 +432,7 @@ namespace Proto
             if (_props.SenderMiddlewareChain != null)
             {
                 //slow path
-                _props.SenderMiddlewareChain(System, EnsureExtras().Context, target, MessageEnvelope.Wrap(message));
+                _props.SenderMiddlewareChain(EnsureExtras().Context, target, MessageEnvelope.Wrap(message));
             }
             else
             {

--- a/src/Proto.Actor/ActorContext.cs
+++ b/src/Proto.Actor/ActorContext.cs
@@ -76,11 +76,11 @@ namespace Proto
         private object? _messageOrEnvelope;
         private ContextState _state;
 
-        protected readonly ActorSystem System;
+        public ActorSystem System { get; }
 
-        public ActorContext(ActorSystem actorSystem, Props props, PID parent, PID self)
+        public ActorContext(ActorSystem system, Props props, PID parent, PID self)
         {
-            System = actorSystem;
+            System = system;
             _props = props;
 
             //Parents are implicitly watching the child

--- a/src/Proto.Actor/ActorContextDecorator.cs
+++ b/src/Proto.Actor/ActorContextDecorator.cs
@@ -46,6 +46,7 @@ namespace Proto
         public virtual PID? Self => _context.Self;
         public virtual PID? Sender => _context.Sender;
         public virtual IActor? Actor => _context.Actor;
+        public virtual ActorSystem System => _context.System;
         public virtual TimeSpan ReceiveTimeout => _context.ReceiveTimeout;
         public virtual IReadOnlyCollection<PID> Children => _context.Children;
         public virtual void Respond(object message) => _context.Respond(message);

--- a/src/Proto.Actor/Delegates.cs
+++ b/src/Proto.Actor/Delegates.cs
@@ -7,5 +7,5 @@ namespace Proto
     //TODO: IReceiveContext ?
     public delegate Task Receiver(IReceiverContext context, MessageEnvelope envelope);
 
-    public delegate Task Sender(ActorSystem system, ISenderContext context, PID target, MessageEnvelope envelope);
+    public delegate Task Sender(ISenderContext context, PID target, MessageEnvelope envelope);
 }

--- a/src/Proto.Actor/IInfoContext.cs
+++ b/src/Proto.Actor/IInfoContext.cs
@@ -27,5 +27,10 @@ namespace Proto
         ///     Gets the actor associated with this context.
         /// </summary>
         IActor? Actor { get; }
+
+        /// <summary>
+        ///     Gets the actor system this actor was spawned in.
+        /// </summary>
+        ActorSystem System { get; }
     }
 }

--- a/src/Proto.Actor/Middleware.cs
+++ b/src/Proto.Actor/Middleware.cs
@@ -6,9 +6,9 @@ namespace Proto
     {
         internal static Task Receive(IReceiverContext context, MessageEnvelope envelope) => context.Receive(envelope);
 
-        internal static Task Sender(ActorSystem system, ISenderContext context, PID target, MessageEnvelope envelope)
+        internal static Task Sender(ISenderContext context, PID target, MessageEnvelope envelope)
         {
-            target.SendUserMessage(system, envelope);
+            target.SendUserMessage(context.System, envelope);
             return Actor.Done;
         }
     }

--- a/src/Proto.Actor/RootContext.cs
+++ b/src/Proto.Actor/RootContext.cs
@@ -133,9 +133,9 @@ namespace Proto
         }
 
 
-        private Task DefaultSender(ActorSystem system, ISenderContext context, PID target, MessageEnvelope message)
+        private Task DefaultSender(ISenderContext context, PID target, MessageEnvelope message)
         {
-            target.SendUserMessage(system, message);
+            target.SendUserMessage(context.System, message);
             return Proto.Actor.Done;
         }
 
@@ -152,7 +152,7 @@ namespace Proto
             if (SenderMiddleware != null)
             {
                 //slow path
-                SenderMiddleware(System, this, target, MessageEnvelope.Wrap(message));
+                SenderMiddleware(this, target, MessageEnvelope.Wrap(message));
             }
             else
             {

--- a/src/Proto.Actor/RootContext.cs
+++ b/src/Proto.Actor/RootContext.cs
@@ -17,18 +17,18 @@ namespace Proto
 
     public class RootContext : IRootContext
     {
-        private readonly ActorSystem _system;
+        public ActorSystem System { get; }
 
         public RootContext(ActorSystem system)
         {
-            _system = system;
+            System = system;
             SenderMiddleware = null;
             Headers = MessageHeader.Empty;
         }
 
         public RootContext(ActorSystem system, MessageHeader messageHeader, params Func<Sender, Sender>[] middleware)
         {
-            _system = system;
+            System = system;
             SenderMiddleware = middleware.Reverse()
                 .Aggregate((Sender)DefaultSender, (inner, outer) => outer(inner));
             Headers = messageHeader;
@@ -44,19 +44,19 @@ namespace Proto
 
         public PID Spawn(Props props)
         {
-            var name = _system.ProcessRegistry.NextId();
+            var name = System.ProcessRegistry.NextId();
             return SpawnNamed(props, name);
         }
 
         public PID SpawnNamed(Props props, string name)
         {
-            var parent = props.GuardianStrategy != null ? _system.Guardians.GetGuardianPID(props.GuardianStrategy) : null;
-            return props.Spawn(_system, name, parent);
+            var parent = props.GuardianStrategy != null ? System.Guardians.GetGuardianPID(props.GuardianStrategy) : null;
+            return props.Spawn(System, name, parent);
         }
 
         public PID SpawnPrefix(Props props, string prefix)
         {
-            var name = prefix + _system.ProcessRegistry.NextId();
+            var name = prefix + System.ProcessRegistry.NextId();
             return SpawnNamed(props, name);
         }
 
@@ -75,37 +75,37 @@ namespace Proto
         }
 
         public Task<T> RequestAsync<T>(PID target, object message, TimeSpan timeout)
-            => RequestAsync(target, message, new FutureProcess<T>(_system, timeout));
+            => RequestAsync(target, message, new FutureProcess<T>(System, timeout));
 
         public Task<T> RequestAsync<T>(PID target, object message, CancellationToken cancellationToken)
-            => RequestAsync(target, message, new FutureProcess<T>(_system, cancellationToken));
+            => RequestAsync(target, message, new FutureProcess<T>(System, cancellationToken));
 
         public Task<T> RequestAsync<T>(PID target, object message)
-            => RequestAsync(target, message, new FutureProcess<T>(_system));
+            => RequestAsync(target, message, new FutureProcess<T>(System));
 
         public void Stop(PID pid)
         {
-            var reff = _system.ProcessRegistry.Get(pid);
+            var reff = System.ProcessRegistry.Get(pid);
             reff.Stop(pid);
         }
 
         public Task StopAsync(PID pid)
         {
-            var future = new FutureProcess<object>(_system);
+            var future = new FutureProcess<object>(System);
 
-            pid.SendSystemMessage(_system, new Watch(future.Pid));
+            pid.SendSystemMessage(System, new Watch(future.Pid));
             Stop(pid);
 
             return future.Task;
         }
 
-        public void Poison(PID pid) => pid.SendUserMessage(_system, new PoisonPill());
+        public void Poison(PID pid) => pid.SendUserMessage(System, new PoisonPill());
 
         public Task PoisonAsync(PID pid)
         {
-            var future = new FutureProcess<object>(_system);
+            var future = new FutureProcess<object>(System);
 
-            pid.SendSystemMessage(_system, new Watch(future.Pid));
+            pid.SendSystemMessage(System, new Watch(future.Pid));
             Poison(pid);
 
             return future.Task;
@@ -123,7 +123,7 @@ namespace Proto
 
         private RootContext Copy(Action<RootContext> mutator)
         {
-            var copy = new RootContext(_system)
+            var copy = new RootContext(System)
             {
                 SenderMiddleware = SenderMiddleware,
                 Headers = Headers
@@ -152,12 +152,12 @@ namespace Proto
             if (SenderMiddleware != null)
             {
                 //slow path
-                SenderMiddleware(_system, this, target, MessageEnvelope.Wrap(message));
+                SenderMiddleware(System, this, target, MessageEnvelope.Wrap(message));
             }
             else
             {
                 //fast path, 0 alloc
-                target.SendUserMessage(_system, message);
+                target.SendUserMessage(System, message);
             }
         }
     }

--- a/src/Proto.Actor/RootContextDecorator.cs
+++ b/src/Proto.Actor/RootContextDecorator.cs
@@ -50,5 +50,6 @@ namespace Proto
         public virtual PID? Self => null;
         public virtual PID? Sender => null;
         public virtual IActor? Actor => null;
+        public virtual ActorSystem System => null;
     }
 }

--- a/src/Tracing/Proto.OpenTracing/OpenTracingExtensions.cs
+++ b/src/Tracing/Proto.OpenTracing/OpenTracingExtensions.cs
@@ -39,13 +39,13 @@ namespace Proto.OpenTracing
         /// Only responsible to tweak the envelop in order to send SpanContext informations.
         /// </summary>
         public static Func<Sender, Sender> OpenTracingSenderMiddleware(ITracer tracer = null)
-            => next => async (system, context, target, envelope) =>
+            => next => async (context, target, envelope) =>
             {
                 tracer ??= GlobalTracer.Instance;
 
                 var span = tracer.ActiveSpan;
 
-                Task SimpleNext() => next(system, context, target, envelope); // to forget nothing
+                Task SimpleNext() => next(context, target, envelope); // to forget nothing
 
                 if (span == null)
                 {

--- a/tests/Proto.Actor.Tests/MiddlewareTests.cs
+++ b/tests/Proto.Actor.Tests/MiddlewareTests.cs
@@ -170,17 +170,17 @@ namespace Proto.Tests
                     return Actor.Done;
                 })
                 .WithSenderMiddleware(
-                    next => (s, c, t, e) =>
+                    next => (c, t, e) =>
                     {
                         if (c.Message is string)
                             logs.Add("middleware 1");
-                        return next(s, c, t, e);
+                        return next(c, t, e);
                     },
-                    next => (s, c, t, e) =>
+                    next => (c, t, e) =>
                     {
                         if (c.Message is string)
                             logs.Add("middleware 2");
-                        return next(s, c, t, e);
+                        return next(c, t, e);
                     })
                 .WithMailbox(() => new TestMailbox());
             var pid2 = Context.Spawn(props);


### PR DESCRIPTION
As discussed in #497 this PR adds the actor system to the context, so it does not need to be passed to the sender middlewares.