### PR TITLE
Fix for duplicate grain issue upon new nodes joining the cluster

### DIFF
--- a/src/MemberStrategies/WeightedMemberStrategy/WeightedMemberStrategy.cs
+++ b/src/MemberStrategies/WeightedMemberStrategy/WeightedMemberStrategy.cs
@@ -18,7 +18,7 @@ namespace Proto.Cluster.WeightedMemberStrategy
         public WeightedMemberStrategy()
         {
             _members = new List<MemberStatus>();
-            _rdv = new Rendezvous(this);
+            _rdv = new Rendezvous();
             _wrr = new WeightedRoundRobin(this);
         }
 
@@ -28,7 +28,7 @@ namespace Proto.Cluster.WeightedMemberStrategy
         {
             _members.Add(member);
             _wrr.UpdateRR();
-            _rdv.UpdateRdv();
+            _rdv.UpdateMembers(_members);
         }
 
         public void UpdateMember(MemberStatus member)
@@ -52,7 +52,7 @@ namespace Proto.Cluster.WeightedMemberStrategy
                 {
                     _members.RemoveAt(i);
                     _wrr.UpdateRR();
-                    _rdv.UpdateRdv();
+                    _rdv.UpdateMembers(_members);
                     return;
                 }
             }

--- a/src/Proto.Cluster/MemberList.cs
+++ b/src/Proto.Cluster/MemberList.cs
@@ -121,12 +121,20 @@ namespace Proto.Cluster
 
         private void UpdateAndNotify(MemberStatus @new, MemberStatus old)
         {
+            // Make sure that only Alive members are considered valid.
+            // This makes sure that the Members lists onyl contain alive nodes.
+            if (old != null && old.Alive == false)
+                old = null;
+            if (@new != null && @new.Alive == false)
+                @new = null;
+
             if (@new == null && old == null)
             {
                 return; //ignore
             }
-
-            if (@new == null)
+            
+            // Check if a node left.
+            if (@new == null && old != null)
             {
                 //update MemberStrategy
                 foreach (var k in old.Kinds)
@@ -152,7 +160,8 @@ namespace Proto.Cluster
                 return;
             }
 
-            if (old == null)
+            // Check if a new node joined.
+            if (@new != null && old == null)
             {
                 //update MemberStrategy
                 foreach (var k in @new.Kinds)

--- a/src/Proto.Cluster/MemberStrategy.cs
+++ b/src/Proto.Cluster/MemberStrategy.cs
@@ -27,7 +27,7 @@ namespace Proto.Cluster
         public SimpleMemberStrategy()
         {
             _members = new List<MemberStatus>();
-            _rdv = new Rendezvous(this);
+            _rdv = new Rendezvous();
             _rr = new RoundRobin(this);
         }
 
@@ -36,7 +36,7 @@ namespace Proto.Cluster
         public void AddMember(MemberStatus member)
         {
             _members.Add(member);
-            _rdv.UpdateRdv();
+            _rdv.UpdateMembers(_members);
         }
 
         public void UpdateMember(MemberStatus member)
@@ -57,7 +57,7 @@ namespace Proto.Cluster
                 if (_members[i].Address != member.Address) continue;
 
                 _members.RemoveAt(i);
-                _rdv.UpdateRdv();
+                _rdv.UpdateMembers(_members);
                 return;
             }
         }


### PR DESCRIPTION
## Description

This fixes the issue mentioned here https://github.com/AsynkronIT/protoactor-dotnet/issues/518

Approach, I took was to make sure that only Alive nodes are in the members lists. This technically affects the downing time to be shorter, from 30 secs (DeregisterCritical) to 10 secs (ServiceTtl) defaults. This also changes the startup behavior, by making sure that our current node is marked as alive before using it as a partition. This prevents potential issues with cluster startup, however, at the same time this introduces a bit of delay until the first cluster node can start spawning grains. I am thinking of adding a Cluster.WaitUntilAnyAliveAsync() like function for this purpose.