### PR TITLE
Get Mailbox to support canceled tasks gracefully.

### DIFF
--- a/src/Proto.Actor/Mailbox/Mailbox.cs
+++ b/src/Proto.Actor/Mailbox/Mailbox.cs
@@ -141,6 +141,11 @@ namespace Proto.Mailbox
                             _invoker.EscalateFailure(t.Exception, msg);
                             continue;
                         }
+                        else if (t.IsCanceled)
+                        {
+                            _invoker.EscalateFailure(new TaskCanceledException(), msg);
+                            continue;
+                        }
                         if (!t.IsCompleted)
                         {
                             // if task didn't complete immediately, halt processing and reschedule a new run when task completes
@@ -163,6 +168,11 @@ namespace Proto.Mailbox
                         if (t.IsFaulted)
                         {
                             _invoker.EscalateFailure(t.Exception, msg);
+                            continue;
+                        }
+                        else if (t.IsCanceled)
+                        {
+                            _invoker.EscalateFailure(new TaskCanceledException(), msg);
                             continue;
                         }
                         if (!t.IsCompleted)
@@ -194,6 +204,10 @@ namespace Proto.Mailbox
             if (task.IsFaulted)
             {
                 _invoker.EscalateFailure(task.Exception, message);
+            }
+            else if (task.IsCanceled)
+            {
+                _invoker.EscalateFailure(new TaskCanceledException(), message);
             }
             else
             {

--- a/tests/Proto.Actor.Tests/Mailbox/EscalateFailureTests.cs
+++ b/tests/Proto.Actor.Tests/Mailbox/EscalateFailureTests.cs
@@ -84,5 +84,77 @@ namespace Proto.Mailbox.Tests
             var e = Assert.IsType<AggregateException>(mailboxHandler.EscalatedFailures[0]);
             Assert.Equal(taskException, e.InnerException);
         }
+
+        [Fact]
+        public void GivenCompletedUserMessageTaskGotCancelled_ShouldEscalateFailure()
+        {
+            var mailboxHandler = new TestMailboxHandler();
+            var mailbox = UnboundedMailbox.Create();
+            mailbox.RegisterHandlers(mailboxHandler, mailboxHandler);
+
+            var msg1 = new TestMessage();
+            var taskException = new Exception();
+            msg1.TaskCompletionSource.SetCanceled();
+
+            mailbox.PostUserMessage(msg1);
+
+            Assert.Single(mailboxHandler.EscalatedFailures);
+            Assert.IsType<TaskCanceledException>(mailboxHandler.EscalatedFailures[0]);
+        }
+
+        [Fact]
+        public void GivenCompletedSystemMessageTaskGotCancelled_ShouldEscalateFailure()
+        {
+            var mailboxHandler = new TestMailboxHandler();
+            var mailbox = UnboundedMailbox.Create();
+            mailbox.RegisterHandlers(mailboxHandler, mailboxHandler);
+
+            var msg1 = new TestMessage();
+            var taskException = new Exception();
+            msg1.TaskCompletionSource.SetCanceled();
+
+            mailbox.PostSystemMessage(msg1);
+
+            Assert.Single(mailboxHandler.EscalatedFailures);
+            Assert.IsType<TaskCanceledException>(mailboxHandler.EscalatedFailures[0]);
+        }
+
+        [Fact]
+        public async Task GivenNonCompletedUserMessageTaskGotCancelled_ShouldEscalateFailure()
+        {
+            var mailboxHandler = new TestMailboxHandler();
+            var mailbox = UnboundedMailbox.Create();
+            mailbox.RegisterHandlers(mailboxHandler, mailboxHandler);
+
+            var msg1 = new TestMessage();
+
+            mailbox.PostUserMessage(msg1);
+
+            Action resumeMailboxTrigger = () => msg1.TaskCompletionSource.SetCanceled();
+            await mailboxHandler.ResumeMailboxProcessingAndWaitAsync(resumeMailboxTrigger)
+                .ConfigureAwait(false);
+
+            Assert.Single(mailboxHandler.EscalatedFailures);
+            Assert.IsType<TaskCanceledException>(mailboxHandler.EscalatedFailures[0]);
+        }
+
+        [Fact]
+        public async Task GivenNonCompletedSystemMessageTaskGotCancelled_ShouldEscalateFailure()
+        {
+            var mailboxHandler = new TestMailboxHandler();
+            var mailbox = UnboundedMailbox.Create();
+            mailbox.RegisterHandlers(mailboxHandler, mailboxHandler);
+
+            var msg1 = new TestMessage();
+
+            mailbox.PostSystemMessage(msg1);
+
+            Action resumeMailboxTrigger = () => msg1.TaskCompletionSource.SetCanceled();
+            await mailboxHandler.ResumeMailboxProcessingAndWaitAsync(resumeMailboxTrigger)
+                .ConfigureAwait(false);
+
+            Assert.Single(mailboxHandler.EscalatedFailures);
+            Assert.IsType<TaskCanceledException>(mailboxHandler.EscalatedFailures[0]);
+        }
     }
 }


### PR DESCRIPTION
## Description

Without this when CancellationTokens were in use or the OperationCancelledException was explicitly thrown by an actor, it was causing that actor's Mailbox to freeze forever and never continue processing the new messages.

This technically fixes issues inside the consul cluster provider as well, because of the consuldotnet library using HttpClient and that throwing TaskCancelledException in certain cases, such as Consul agent being restarted.

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
