### PR TITLE
Make all remaining methods virtual

### DIFF
--- a/src/Proto.Actor/RootContextDecorator.cs
+++ b/src/Proto.Actor/RootContextDecorator.cs
@@ -35,13 +35,13 @@ namespace Proto
 
         public virtual object? Message => _context.Message;
 
-        public void Stop(PID pid) => _context.Stop(pid);
+        public virtual void Stop(PID pid) => _context.Stop(pid);
 
-        public Task StopAsync(PID pid) => _context.StopAsync(pid);
+        public virtual Task StopAsync(PID pid) => _context.StopAsync(pid);
 
-        public void Poison(PID pid) => _context.Poison(pid);
+        public virtual void Poison(PID pid) => _context.Poison(pid);
 
-        public Task PoisonAsync(PID pid) => _context.PoisonAsync(pid);
+        public virtual Task PoisonAsync(PID pid) => _context.PoisonAsync(pid);
 
         public virtual PID? Parent => null;
         public virtual PID? Self => null;


### PR DESCRIPTION
A few members of the `RootContextDecorator` class are not virtual and cannot be overridden to make a new decorator. This PR fixes this and makes all the decorator methods consistently virtual. 