### PR TITLE
PartitionPlacementActor-fix

### DIFF
--- a/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
@@ -85,6 +85,7 @@ namespace Proto.Cluster.Partition
             var ownerPid = _partitionManager.RemotePartitionIdentityActor(ownerAddress);
 
             context.Send(ownerPid, activationTerminated);
+            _myActors.Remove(identity);
             return Actor.Done;
         }
 


### PR DESCRIPTION
Actually when a grain is stopped and we ask a new activation, it is redeployed elsewhere. But when it is redeployed on the same node, the PartitionPlacementActor returns the previous address as it is never removed from the _myActors dictionary and never spawn the new actor. When an actor is terminated I remove this pid from _myActors to fix that.