### PR TITLE
Ordered RequestAsync for MongoIdentityLookup

### DIFF
--- a/benchmarks/ClusterBenchmark/Program.cs
+++ b/benchmarks/ClusterBenchmark/Program.cs
@@ -143,25 +143,33 @@ namespace ClusterExperiment1
         
         private static IClusterProvider ClusterProvider()
         {
-            Console.WriteLine("Running with InClusterConfig");
-            // var namespaceFile = Path.Combine(
-            //     $"{Path.DirectorySeparatorChar}var",
-            //     "run",
-            //     "secrets",
-            //     "kubernetes.io",
-            //     "serviceaccount",
-            //     "namespace"
-            // );
-            // Console.WriteLine(namespaceFile);
-            //
-            // KubernetesClientConfiguration.InClusterConfig();
-            //
-            // var cachedNamespace = File.ReadAllText(namespaceFile);
-            
-            var kubernetesConfig = KubernetesClientConfiguration.InClusterConfig(); //   KubernetesClientConfiguration.BuildConfigFromConfigFile(cachedNamespace);
-            var kubernetes = new Kubernetes(kubernetesConfig);
-            return new KubernetesProvider(kubernetes);
-          //  return new ConsulProvider(new ConsulProviderOptions());
+            try
+            {
+                Console.WriteLine("Running with InClusterConfig");
+                // var namespaceFile = Path.Combine(
+                //     $"{Path.DirectorySeparatorChar}var",
+                //     "run",
+                //     "secrets",
+                //     "kubernetes.io",
+                //     "serviceaccount",
+                //     "namespace"
+                // );
+                // Console.WriteLine(namespaceFile);
+                //
+                // KubernetesClientConfiguration.InClusterConfig();
+                //
+                // var cachedNamespace = File.ReadAllText(namespaceFile);
+
+                var kubernetesConfig =
+                    KubernetesClientConfiguration
+                        .InClusterConfig(); //   KubernetesClientConfiguration.BuildConfigFromConfigFile(cachedNamespace);
+                var kubernetes = new Kubernetes(kubernetesConfig);
+                return new KubernetesProvider(kubernetes);
+            }
+            catch
+            {
+                return new ConsulProvider(new ConsulProviderOptions());
+            }
         }
 
         private static MongoIdentityLookup GetIdentityLookup()

--- a/src/Proto.Cluster.MongoIdentityLookup/GetPid.cs
+++ b/src/Proto.Cluster.MongoIdentityLookup/GetPid.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+using Proto.Router;
+
+namespace Proto.Cluster.MongoIdentityLookup
+{
+    public class GetPid : IHashable
+    {
+        public string Key { get; set; }
+        public string Identity { get; set; }
+        public string Kind { get; set; }
+        public CancellationToken CancellationToken { get; set; }
+        public string HashBy() => Key;
+    }
+}

--- a/src/Proto.Cluster.MongoIdentityLookup/GetPid.cs
+++ b/src/Proto.Cluster.MongoIdentityLookup/GetPid.cs
@@ -11,4 +11,9 @@ namespace Proto.Cluster.MongoIdentityLookup
         public CancellationToken CancellationToken { get; set; }
         public string HashBy() => Key;
     }
+
+    public class PidResult
+    {
+        public PID Pid { get; set; }
+    }
 }

--- a/src/Proto.Cluster.MongoIdentityLookup/MongoIdentityLookup.cs
+++ b/src/Proto.Cluster.MongoIdentityLookup/MongoIdentityLookup.cs
@@ -1,8 +1,7 @@
-﻿using System.Linq;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using MongoDB.Bson;
 using MongoDB.Driver;
 using Proto.Cluster.IdentityLookup;
 using Proto.Router;
@@ -57,7 +56,7 @@ namespace Proto.Cluster.MongoIdentityLookup
             
             var workerProps = Props.FromProducer(() => new MongoIdentityWorker(this));
             //TODO: should pool size be configurable?
-            var routerProps = _system.Root.NewConsistentHashPool(workerProps, 1000);
+            var routerProps = _system.Root.NewConsistentHashPool(workerProps, 50);
             _router = _system.Root.Spawn(routerProps);
 
             //hook up events

--- a/src/Proto.Cluster.MongoIdentityLookup/MongoIdentityWorker.cs
+++ b/src/Proto.Cluster.MongoIdentityLookup/MongoIdentityWorker.cs
@@ -49,7 +49,7 @@ namespace Proto.Cluster.MongoIdentityLookup
                 var memberExists = _memberList.ContainsMemberId(pidLookup.MemberId);
                 if (memberExists) return pid;
                 
-                _logger.LogInformation("Found placement lookup for {Identity} {Kind}, but Member {MemberId} is not part of cluster",identity,kind,pidLookup.MemberId);
+                _logger.LogDebug("Found placement lookup for {Identity} {Kind}, but Member {MemberId} is not part of cluster",identity,kind,pidLookup.MemberId);
                 //if not, spawn a new actor and replace entry
             }
 
@@ -76,7 +76,7 @@ namespace Proto.Cluster.MongoIdentityLookup
             
             //TODO: create the impl :)
             
-            _logger.LogInformation("Storing placement lookup for {Identity} {Kind}",identity,kind);
+            _logger.LogDebug("Storing placement lookup for {Identity} {Kind}",identity,kind);
             
             var remotePid = _lookup.RemotePlacementActor(activator.Address);
             var req = new ActivationRequest

--- a/src/Proto.Cluster.MongoIdentityLookup/MongoIdentityWorker.cs
+++ b/src/Proto.Cluster.MongoIdentityLookup/MongoIdentityWorker.cs
@@ -23,14 +23,16 @@ namespace Proto.Cluster.MongoIdentityLookup
             _lookup = lookup;
         }
         
-        public Task ReceiveAsync(IContext context)
+        public async Task ReceiveAsync(IContext context)
         {
             if (context.Message is GetPid msg)
             {
-                return GetPid(msg);
+                var pid = await GetPid(msg);
+                context.Respond(new PidResult
+                {
+                    Pid = pid
+                });
             }
-            
-            return Task.CompletedTask;
         }
 
         private async Task<PID> GetPid(GetPid msg)

--- a/src/Proto.Cluster.MongoIdentityLookup/MongoIdentityWorker.cs
+++ b/src/Proto.Cluster.MongoIdentityLookup/MongoIdentityWorker.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+
+namespace Proto.Cluster.MongoIdentityLookup
+{
+    public class MongoIdentityWorker : IActor
+    {
+        private readonly MongoIdentityLookup _lookup;
+        private readonly ILogger _logger = Log.CreateLogger<MongoIdentityWorker>();
+        private readonly MemberList _memberList;
+        private readonly IMongoCollection<PidLookupEntity> _pids;
+        private readonly Cluster _cluster;
+
+
+        public MongoIdentityWorker(MongoIdentityLookup lookup)
+        {
+            _cluster = lookup.Cluster;
+            _pids = lookup.Pids;
+            _memberList = lookup.MemberList;
+            _lookup = lookup;
+        }
+        
+        public Task ReceiveAsync(IContext context)
+        {
+            if (context.Message is GetPid msg)
+            {
+                return GetPid(msg);
+            }
+            
+            return Task.CompletedTask;
+        }
+
+        private async Task<PID> GetPid(GetPid msg)
+        {
+            var key = msg.Key;
+            var ct = msg.CancellationToken;
+            var identity = msg.Identity;
+            var kind = msg.Kind;
+            
+            var pidLookup = await _pids.Find(x => x.Key == key).Limit(1).SingleOrDefaultAsync(ct);
+            if (pidLookup != null)
+            {
+                var pid = new PID(pidLookup.Address, pidLookup.UniqueIdentity);
+                var memberExists = _memberList.ContainsMemberId(pidLookup.MemberId);
+                if (memberExists) return pid;
+                
+                _logger.LogInformation("Found placement lookup for {Identity} {Kind}, but Member {MemberId} is not part of cluster",identity,kind,pidLookup.MemberId);
+                //if not, spawn a new actor and replace entry
+            }
+
+            var activator = _memberList.GetActivator(kind);
+            if (activator == null)
+            {
+                return null;
+            }
+            
+            //TODO: acquire global lock here.
+
+            var requestId = Guid.NewGuid();
+            var lockEntity = new PidLookupEntity
+            {
+                Address = null,
+                Identity = identity,
+                Key = key,
+                Kind = kind,
+                LockedBy = requestId
+            };
+            //write to mongo, use filter for if lockedby is null
+            //if no suck document was found, go into spinwait
+            //if updated, we now own the lock
+            
+            //TODO: create the impl :)
+            
+            _logger.LogInformation("Storing placement lookup for {Identity} {Kind}",identity,kind);
+            
+            var remotePid = _lookup.RemotePlacementActor(activator.Address);
+            var req = new ActivationRequest
+            {
+                Kind = kind,
+                Identity = identity
+            };
+
+            try
+            {
+                var resp = ct == CancellationToken.None
+                    ? await _cluster.System.Root.RequestAsync<ActivationResponse>(remotePid, req,
+                        _cluster.Config!.TimeoutTimespan
+                    )
+                    : await _cluster.System.Root.RequestAsync<ActivationResponse>(remotePid, req, ct);
+
+                var entry = new PidLookupEntity
+                {
+                    Address = activator.Address,
+                    Identity = identity,
+                    UniqueIdentity = resp.Pid.Id,
+                    Key = key,
+                    Kind = kind,
+                    MemberId = activator.Id
+                };
+
+                await _pids.ReplaceOneAsync(
+                    s => s.Key == key,
+                    entry, new ReplaceOptions
+                    {
+                        IsUpsert = true
+                    }, CancellationToken.None
+                );
+
+                return resp.Pid;
+            }
+            //TODO: decide if we throw or return null
+            catch (TimeoutException)
+            {
+                _logger.LogDebug("Remote PID request timeout {@Request}", req);
+                return null;
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error occured requesting remote PID {@Request}", req);
+                return null;
+            }
+        }
+    }
+}

--- a/src/Proto.Cluster.MongoIdentityLookup/MongoPlacementActor.cs
+++ b/src/Proto.Cluster.MongoIdentityLookup/MongoPlacementActor.cs
@@ -24,7 +24,7 @@ namespace Proto.Cluster.MongoIdentityLookup
             new Dictionary<string, (PID pid, string kind)>();
 
         private readonly Remote.Remote _remote;
-        private MongoIdentityLookup _mongoIdentityLookup;
+        private readonly MongoIdentityLookup _mongoIdentityLookup;
 
         public MongoPlacementActor(Cluster cluster, MongoIdentityLookup mongoIdentityLookup)
         {

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -148,9 +148,6 @@ namespace Proto.Cluster
             catch
             {
                 //YOLO
-            }
-            finally
-            {
                 _pidCache.TryRemove(key,out _);
             }
 


### PR DESCRIPTION
Added `MongoIdentityWorker` actor
this actor does the same work as the `MongoIdentityLookup` did before, but we can now partition so that all work for the same identity is handled in sequence.

`MongoIdentityLookup` now has a consistent hash router pool of 1000 actors.
the request message `GetPid`, is hashed on `Key`