### PR TITLE
Cancellation token in actor context

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -22,9 +22,7 @@ jobs:
 
       - name: Run tests
         run: |
-          docker-compose -f tests/docker-compose.yml up -d
           dotnet test -c Release
-          docker-compose -f tests/docker-compose.yml down
         
   nuget:
     runs-on: windows-latest

--- a/src/Proto.Actor/ActorContext.cs
+++ b/src/Proto.Actor/ActorContext.cs
@@ -43,8 +43,8 @@ namespace Proto
         private static ILogger Logger { get; } = Log.CreateLogger<ActorContext>();
 
         public ActorSystem System { get; }
-        public CancellationTokenSource CancellationTokenSource { get; } = new CancellationTokenSource();
-        public CancellationToken CancellationToken => CancellationTokenSource.Token;
+        public CancellationTokenSource? CancellationTokenSource => _extras?.CancellationTokenSource;
+        public CancellationToken CancellationToken => EnsureExtras().CancellationTokenSource.Token;
         IReadOnlyCollection<PID> IContext.Children => Children;
 
         public IActor? Actor { get; private set; }

--- a/src/Proto.Actor/ActorContext.cs
+++ b/src/Proto.Actor/ActorContext.cs
@@ -43,6 +43,8 @@ namespace Proto
         private static ILogger Logger { get; } = Log.CreateLogger<ActorContext>();
 
         public ActorSystem System { get; }
+        public CancellationTokenSource CancellationTokenSource { get; } = new CancellationTokenSource();
+        public CancellationToken CancellationToken => CancellationTokenSource.Token;
         IReadOnlyCollection<PID> IContext.Children => Children;
 
         public IActor? Actor { get; private set; }
@@ -427,7 +429,7 @@ namespace Proto
         }
 
         private Task HandleUnwatch(Unwatch uw)
-        { 
+        {
             _extras?.Unwatch(uw.Watcher);
             return Done;
         }

--- a/src/Proto.Actor/ActorContextDecorator.cs
+++ b/src/Proto.Actor/ActorContextDecorator.cs
@@ -41,6 +41,7 @@ namespace Proto
         public virtual ActorSystem System => _context.System;
         public virtual TimeSpan ReceiveTimeout => _context.ReceiveTimeout;
         public virtual IReadOnlyCollection<PID> Children => _context.Children;
+        public CancellationToken CancellationToken => _context.CancellationToken;
 
         public virtual void Respond(object message) => _context.Respond(message);
 

--- a/src/Proto.Actor/ActorContextExtras.cs
+++ b/src/Proto.Actor/ActorContextExtras.cs
@@ -24,6 +24,8 @@ namespace Proto
         public Stack<object> Stash { get; } = new Stack<object>();
         public ImmutableHashSet<PID> Watchers { get; private set; } = ImmutableHashSet<PID>.Empty;
         public IContext Context { get; }
+        public CancellationTokenSource CancellationTokenSource { get; } = new CancellationTokenSource();
+        public CancellationToken CancellationToken => CancellationTokenSource.Token;
 
         public void InitReceiveTimeoutTimer(Timer timer) => ReceiveTimeoutTimer = timer;
 

--- a/src/Proto.Actor/IContext.cs
+++ b/src/Proto.Actor/IContext.cs
@@ -14,7 +14,7 @@ namespace Proto
     public interface IContext : ISenderContext, IReceiverContext, ISpawnerContext, IStopperContext
     {
         /// <summary>
-        ///     Gets the CancellationToken. Pass this token in long running task to stop them when the actor is about to stop
+        ///     Gets the CancellationToken. Pass this token in long running tasks to stop them when the actor is about to stop
         /// </summary>
         CancellationToken CancellationToken { get; }
         /// <summary>

--- a/src/Proto.Actor/IContext.cs
+++ b/src/Proto.Actor/IContext.cs
@@ -6,12 +6,17 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Proto
 {
     public interface IContext : ISenderContext, IReceiverContext, ISpawnerContext, IStopperContext
     {
+        /// <summary>
+        ///     Gets the CancellationToken. Pass this token in long running task to stop them when the actor is about to stop
+        /// </summary>
+        CancellationToken CancellationToken { get; }
         /// <summary>
         ///     Gets the receive timeout.
         /// </summary>

--- a/src/Proto.Actor/Mailbox/Dispatcher.cs
+++ b/src/Proto.Actor/Mailbox/Dispatcher.cs
@@ -14,7 +14,7 @@ namespace Proto.Mailbox
     {
         Task InvokeSystemMessageAsync(object msg);
         Task InvokeUserMessageAsync(object msg);
-        CancellationTokenSource CancellationTokenSource { get; }
+        CancellationTokenSource? CancellationTokenSource { get; }
         void EscalateFailure(Exception reason, object? message);
     }
 

--- a/src/Proto.Actor/Mailbox/Dispatcher.cs
+++ b/src/Proto.Actor/Mailbox/Dispatcher.cs
@@ -14,6 +14,7 @@ namespace Proto.Mailbox
     {
         Task InvokeSystemMessageAsync(object msg);
         Task InvokeUserMessageAsync(object msg);
+        CancellationTokenSource CancellationTokenSource { get; }
         void EscalateFailure(Exception reason, object? message);
     }
 
@@ -88,6 +89,9 @@ namespace Proto.Mailbox
     internal class NoopInvoker : IMessageInvoker
     {
         internal static readonly IMessageInvoker Instance = new NoopInvoker();
+
+        public CancellationTokenSource CancellationTokenSource => throw new NotImplementedException();
+
         public Task InvokeSystemMessageAsync(object msg) => throw new NotImplementedException();
 
         public Task InvokeUserMessageAsync(object msg) => throw new NotImplementedException();

--- a/src/Proto.Actor/Mailbox/Mailbox.cs
+++ b/src/Proto.Actor/Mailbox/Mailbox.cs
@@ -75,6 +75,8 @@ namespace Proto.Mailbox
         public void PostSystemMessage(object msg)
         {
             _systemMessages.Push(msg);
+            if(msg is Stop)
+                _invoker.CancellationTokenSource.Cancel();
             Interlocked.Increment(ref _systemMessageCount);
             foreach (var t in _stats)
             {

--- a/src/Proto.Actor/Mailbox/Mailbox.cs
+++ b/src/Proto.Actor/Mailbox/Mailbox.cs
@@ -76,7 +76,7 @@ namespace Proto.Mailbox
         {
             _systemMessages.Push(msg);
             if(msg is Stop)
-                _invoker.CancellationTokenSource.Cancel();
+                _invoker?.CancellationTokenSource?.Cancel();
             Interlocked.Increment(ref _systemMessageCount);
             foreach (var t in _stats)
             {

--- a/tests/Proto.Remote.Tests/RemoteManager.cs
+++ b/tests/Proto.Remote.Tests/RemoteManager.cs
@@ -6,7 +6,7 @@ namespace Proto.Remote.Tests
 {
     public class RemoteManager
     {
-        public const string RemoteAddress = "0.0.0.0:12000";
+        public const string RemoteAddress = "localhost:12000";
         static RemoteManager()
         {
             system = new ActorSystem();
@@ -34,7 +34,7 @@ namespace Proto.Remote.Tests
                 }
             };
             
-            var service = new ProtoService(12000,"0.0.0.0");
+            var service = new ProtoService(12000,"localhost");
             service.StartAsync().Wait();
             
             remote.Start(GetLocalIp(), 12001, config);

--- a/tests/Proto.TestFixtures/TestMailbox.cs
+++ b/tests/Proto.TestFixtures/TestMailbox.cs
@@ -24,7 +24,7 @@ namespace Proto.TestFixtures
         public void PostSystemMessage(object msg)
         {
             if (msg is Stop)
-                _invoker.CancellationTokenSource.Cancel();
+                _invoker?.CancellationTokenSource?.Cancel();
             SystemMessages.Add(msg);
             _invoker?.InvokeSystemMessageAsync(msg).Wait();
         }

--- a/tests/Proto.TestFixtures/TestMailbox.cs
+++ b/tests/Proto.TestFixtures/TestMailbox.cs
@@ -23,6 +23,8 @@ namespace Proto.TestFixtures
 
         public void PostSystemMessage(object msg)
         {
+            if (msg is Stop)
+                _invoker.CancellationTokenSource.Cancel();
             SystemMessages.Add(msg);
             _invoker?.InvokeSystemMessageAsync(msg).Wait();
         }

--- a/tests/Proto.TestFixtures/TestMailboxHandler.cs
+++ b/tests/Proto.TestFixtures/TestMailboxHandler.cs
@@ -31,6 +31,8 @@ namespace Proto.TestFixtures
 
         public int Throughput { get; } = 10;
 
+        public CancellationTokenSource CancellationTokenSource { get; } = new CancellationTokenSource();
+        
         public void Schedule(Func<Task> runner)
         {
             var waitingTaskExists = _taskCompletionQueue.TryDequeue(out TaskCompletionSource<int> onScheduleCompleted);


### PR DESCRIPTION
## Description

It would be nice to be able to stop an actor right away even if it is processing a long running task. Today we need to wait that the actor finishes processing the current message.
This PR enables it by passing a CancellationToken to the actor's context.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
