### PR TITLE
PoC logging

### DIFF
--- a/src/Proto.Actor/ActorSystem.cs
+++ b/src/Proto.Actor/ActorSystem.cs
@@ -2,6 +2,7 @@ using System;
 using Google.Protobuf;
 using JetBrains.Annotations;
 using Proto.Extensions;
+using Proto.Logging;
 
 namespace Proto
 {
@@ -28,6 +29,9 @@ namespace Proto
             var eventStreamProcess = new EventStreamProcess(this);
             ProcessRegistry.TryAdd("eventstream", eventStreamProcess);
             Extensions = new ActorSystemExtensions(this);
+            
+            //temp solution. copy whatever value exists in the current static solution, into the plugin
+            Extensions.Register(new LogExtension(Log._loggerFactory));
         }
 
         public string Address { get; private set; } = NoHost;

--- a/src/Proto.Actor/Logging/Log.cs
+++ b/src/Proto.Actor/Logging/Log.cs
@@ -13,7 +13,7 @@ namespace Proto
     [PublicAPI]
     public static class Log
     {
-        private static ILoggerFactory _loggerFactory = new NullLoggerFactory();
+        internal static ILoggerFactory _loggerFactory = new NullLoggerFactory();
 
         public static void SetLoggerFactory(ILoggerFactory loggerFactory)
         {

--- a/src/Proto.Actor/Logging/LogExtension.cs
+++ b/src/Proto.Actor/Logging/LogExtension.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Logging;
+using Proto.Extensions;
+
+namespace Proto.Logging
+{
+    public class LogExtension : IActorSystemExtension<LogExtension>
+    {
+        public LogExtension(ILoggerFactory loggerFactory)
+        {
+            LoggerFactory = loggerFactory;
+        }
+        
+        public ILoggerFactory LoggerFactory { get; }
+    }
+
+    public static class LogExtensionExtensions
+    {
+        public static ILoggerFactory LoggerFactory(this ActorSystem actorSystem) => 
+            actorSystem.Extensions.Get<LogExtension>().LoggerFactory;
+    }
+}

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Proto.Cluster.IdentityLookup;
 using Proto.Cluster.Partition;
 using Proto.Extensions;
+using Proto.Logging;
 
 namespace Proto.Cluster
 {
@@ -89,7 +90,7 @@ namespace Proto.Cluster
             IdentityLookup = Config.IdentityLookup ?? new PartitionIdentityLookup();
             Remote = new Remote.Remote(System, Config.RemoteConfig);
             await Remote.StartAsync();
-            Logger = Log.CreateLogger($"Cluster-{LoggerId}");
+            Logger = System.LoggerFactory().CreateLogger($"Cluster-{LoggerId}");
             Logger.LogInformation("Starting");
             MemberList = new MemberList(this);
             ClusterContext = new DefaultClusterContext(IdentityLookup, PidCache, System.Root, Logger);

--- a/src/Proto.Cluster/Member/MemberList.cs
+++ b/src/Proto.Cluster/Member/MemberList.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using Proto.Cluster.Data;
 using Proto.Cluster.Events;
 using Proto.Cluster.Utils;
+using Proto.Logging;
 using Proto.Remote;
 
 namespace Proto.Cluster
@@ -55,7 +56,7 @@ namespace Proto.Cluster
             _root = _system.Root;
             _eventStream = _system.EventStream;
 
-            _logger = Log.CreateLogger($"MemberList-{_cluster.LoggerId}");
+            _logger = _cluster.System.LoggerFactory().CreateLogger($"MemberList-{_cluster.LoggerId}");
 
             _bannedMembers = new ConcurrentSet<string>();
         }

--- a/src/Proto.Remote/Remote.cs
+++ b/src/Proto.Remote/Remote.cs
@@ -12,13 +12,14 @@ using Grpc.Health.V1;
 using Grpc.HealthCheck;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
+using Proto.Logging;
 
 namespace Proto.Remote
 {
     [PublicAPI]
     public class Remote
     {
-        private static readonly ILogger Logger = Log.CreateLogger<Remote>();
+        private ILogger Logger { get; }
         
         private readonly ActorSystem _system;
         private EndpointManager _endpointManager = null!;
@@ -30,6 +31,7 @@ namespace Proto.Remote
         {
             _system = system;
             Config = config;
+            Logger = system.LoggerFactory().CreateLogger<Remote>();
         }
 
         public RemoteConfig Config { get; private set; }


### PR DESCRIPTION
PoC for logging extension.

It contains a temp hack capturing the current static Log factory and copies that into the new LogExtension.

The LogExtension is then accessible from anywhere you have access to the ActorSystem.

**Some things to consider,** I really don't want to create a new logger per `ActorContext` as that would be very expensive.
Maybe this can be solved with some form of shared ActorContext logger.

There are some examples showing how this new feature is used for Remote, Cluster and MemberList.

Thoughts?

This could all also be done w/o any form of extensions, just having a LoggerFactory prop on the actor system, so maybe this PR overcomplicates things here.