### PR TITLE
Removed race condition on ReceiveTimeoutCallback. Could try to cancel disposed timer

### DIFF
--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -564,7 +564,6 @@ namespace Proto.Context
         {
             if (_extras?.ReceiveTimeoutTimer is null) return;
 
-            CancelReceiveTimeout();
             Send(Self, Proto.ReceiveTimeout.Instance);
         }
     }


### PR DESCRIPTION

## Description

Fixes race condition where CancelReceiveTimeout would be called in callback outside the actor context. This could get the timer in a disposed state..

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
