### PR TITLE
Masstransit counters PoC

### DIFF
--- a/src/Proto.Actor/Monitoring/Performance/BasePerformanceCounters.cs
+++ b/src/Proto.Actor/Monitoring/Performance/BasePerformanceCounters.cs
@@ -1,0 +1,36 @@
+namespace MassTransit.Monitoring.Performance
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+
+    public abstract class BasePerformanceCounters
+    {
+        readonly Lazy<CounterData[]> _counterCreationData;
+
+        protected BasePerformanceCounters()
+        {
+            _counterCreationData = new Lazy<CounterData[]>(() => GetCounterData().ToArray());
+            Initialize();
+        }
+
+        protected CounterData[] Data => _counterCreationData.Value;
+
+        void Initialize()
+        {
+        }
+
+        protected abstract IEnumerable<CounterData> GetCounterData();
+
+        protected CounterData Convert(Counter counter, CounterType type)
+        {
+            return new CounterData
+            {
+                CounterName = counter.Name,
+                CounterDescription = counter.Help,
+                CounterType = type
+            };
+        }
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/BasePerformanceCounters.cs
+++ b/src/Proto.Actor/Monitoring/Performance/BasePerformanceCounters.cs
@@ -1,10 +1,9 @@
-namespace MassTransit.Monitoring.Performance
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Proto.Monitoring.Performance
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
-
     public abstract class BasePerformanceCounters
     {
         readonly Lazy<CounterData[]> _counterCreationData;

--- a/src/Proto.Actor/Monitoring/Performance/BuiltInCounters.cs
+++ b/src/Proto.Actor/Monitoring/Performance/BuiltInCounters.cs
@@ -1,0 +1,79 @@
+﻿namespace MassTransit.Monitoring.Performance
+{
+    public static class BuiltInCounters
+    {
+        public static class Consumers
+        {
+            public static readonly CounterCategory Category = new CounterCategory("MassTransit Consumers", "Consumers built using MassTransit");
+
+
+            public static class Counters
+            {
+                public static readonly Counter MessagesPerSecond = new Counter("Message/s", "Number of messages consumed per second");
+                public static readonly Counter TotalMessages = new Counter("Total Messages", "Total number of messages consumed");
+                public static readonly Counter AverageDuration = new Counter("Average Duration", "The average time spent consuming a message");
+                public static readonly Counter AverageDurationBase = new Counter("Average Duration Base", "The average time spent consuming a message");
+                public static readonly Counter TotalFaults = new Counter("Total Faults", "Total number of consumer faults generated");
+                public static readonly Counter FaultPercent = new Counter("Fault %", "The percentage of consumers generating faults");
+                public static readonly Counter FaultPercentBase = new Counter("Fault % Base", "The percentage of consumers generating faults");
+            }
+        }
+
+
+        public static class Messages
+        {
+            public static readonly CounterCategory Category = new CounterCategory("MassTransit Messages", "Messages handled by MassTransit");
+
+
+            public static class Counters
+            {
+                public static readonly Counter ConsumedPerSecond = new Counter("Consumed/s", "Number of messages consumed per second");
+                public static readonly Counter TotalConsumed = new Counter("Consumed", "Total number of messages consumed");
+                public static readonly Counter AverageConsumeDuration = new Counter("Average Consume Duration", "The average time spent consuming a message");
+
+                public static readonly Counter AverageConusmeDurationBase =
+                    new Counter("Average Consume Duration Base", "The average time spent consuming a message");
+
+                public static readonly Counter TotalConsumeFaults = new Counter("Consume Faults", "Total number of consume faults");
+                public static readonly Counter ConsumeFaultPercent = new Counter("Consume Fault %", "The percentage of consumes faulted");
+                public static readonly Counter ConsumeFaultPercentBase = new Counter("Consume Fault % Base", "The percentage of consumes faulted");
+                public static readonly Counter SentPerSecond = new Counter("Sent/s", "Number of messages sent per second");
+                public static readonly Counter TotalSent = new Counter("Sent", "Total number of messages sent");
+                public static readonly Counter TotalSendFaults = new Counter("Send Faults", "Total number of send faults");
+                public static readonly Counter SendFaultPercent = new Counter("Send Fault %", "The percentage of sends faulted");
+                public static readonly Counter SendFaultPercentBase = new Counter("Send Fault % Base", "The percentage of sends faulted");
+                public static readonly Counter PublishesPerSecond = new Counter("Published/s", "Number of messages Published per second");
+                public static readonly Counter TotalPublished = new Counter("Published", "Total number of messages Published");
+                public static readonly Counter TotalPublishFaults = new Counter("Publish Faults", "Total number of Publish faults");
+                public static readonly Counter PublishFaultPercent = new Counter("Publish Fault %", "The percentage of Publishes faulted");
+                public static readonly Counter PublishFaultPercentBase = new Counter("Publish Fault % Base", "The percentage of Publishes faulted");
+            }
+        }
+    }
+
+
+    public class CounterCategory
+    {
+        public CounterCategory(string name, string help)
+        {
+            Name = name;
+            Help = help;
+        }
+
+        public string Name { get; }
+        public string Help { get; }
+    }
+
+
+    public class Counter
+    {
+        public Counter(string name, string help)
+        {
+            Name = name;
+            Help = help;
+        }
+
+        public string Name { get; }
+        public string Help { get; }
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/BuiltInCounters.cs
+++ b/src/Proto.Actor/Monitoring/Performance/BuiltInCounters.cs
@@ -1,4 +1,4 @@
-﻿namespace MassTransit.Monitoring.Performance
+﻿namespace Proto.Monitoring.Performance
 {
     public static class BuiltInCounters
     {

--- a/src/Proto.Actor/Monitoring/Performance/ConsumerPerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/ConsumerPerformanceCounter.cs
@@ -1,0 +1,70 @@
+﻿namespace MassTransit.Monitoring.Performance
+{
+    using System;
+
+
+    /// <summary>
+    /// Tracks the consumption and failure of a consumer processing messages. The message types
+    /// in this case are not included in the counter, only the consumer itself.
+    /// </summary>
+    public class ConsumerPerformanceCounter :
+        IDisposable,
+        IConsumerPerformanceCounter
+    {
+        readonly IPerformanceCounter _consumeRate;
+        readonly IPerformanceCounter _duration;
+        readonly IPerformanceCounter _durationBase;
+        readonly IPerformanceCounter _faultPercentage;
+        readonly IPerformanceCounter _faultPercentageBase;
+        readonly IPerformanceCounter _totalFaults;
+        readonly IPerformanceCounter _totalMessages;
+
+        public ConsumerPerformanceCounter(ICounterFactory factory, string consumerType)
+        {
+            if (consumerType.Length > 127)
+                consumerType = consumerType.Substring(consumerType.Length - 127);
+
+            _totalMessages = factory.Create(BuiltInCounters.Consumers.Category, ConsumerPerformanceCounters.TotalMessages.CounterName, consumerType);
+            _consumeRate = factory.Create(BuiltInCounters.Consumers.Category, ConsumerPerformanceCounters.ConsumeRate.CounterName, consumerType);
+            _duration = factory.Create(BuiltInCounters.Consumers.Category, ConsumerPerformanceCounters.Duration.CounterName, consumerType);
+            _durationBase = factory.Create(BuiltInCounters.Consumers.Category, ConsumerPerformanceCounters.DurationBase.CounterName, consumerType);
+            _totalFaults = factory.Create(BuiltInCounters.Consumers.Category, ConsumerPerformanceCounters.TotalFaults.CounterName, consumerType);
+            _faultPercentage = factory.Create(BuiltInCounters.Consumers.Category, ConsumerPerformanceCounters.FaultPercentage.CounterName, consumerType);
+            _faultPercentageBase = factory.Create(BuiltInCounters.Consumers.Category, ConsumerPerformanceCounters.FaultPercentageBase.CounterName,
+                consumerType);
+        }
+
+        public void Consumed(TimeSpan duration)
+        {
+            _totalMessages.Increment();
+            _consumeRate.Increment();
+
+            _duration.IncrementBy((long)duration.TotalMilliseconds);
+            _durationBase.Increment();
+
+            _faultPercentageBase.Increment();
+        }
+
+        public void Faulted()
+        {
+            _totalMessages.Increment();
+            _consumeRate.Increment();
+
+            _totalFaults.Increment();
+
+            _faultPercentage.Increment();
+            _faultPercentageBase.Increment();
+        }
+
+        public void Dispose()
+        {
+            _duration.Dispose();
+            _durationBase.Dispose();
+            _consumeRate.Dispose();
+            _faultPercentage.Dispose();
+            _faultPercentageBase.Dispose();
+            _totalFaults.Dispose();
+            _totalMessages.Dispose();
+        }
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/ConsumerPerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/ConsumerPerformanceCounter.cs
@@ -1,8 +1,7 @@
-﻿namespace MassTransit.Monitoring.Performance
+﻿using System;
+
+namespace Proto.Monitoring.Performance
 {
-    using System;
-
-
     /// <summary>
     /// Tracks the consumption and failure of a consumer processing messages. The message types
     /// in this case are not included in the counter, only the consumer itself.

--- a/src/Proto.Actor/Monitoring/Performance/ConsumerPerformanceCounterCache.cs
+++ b/src/Proto.Actor/Monitoring/Performance/ConsumerPerformanceCounterCache.cs
@@ -1,0 +1,30 @@
+﻿namespace MassTransit.Monitoring.Performance
+{
+    using System;
+    using System.Collections.Concurrent;
+
+
+    public class ConsumerPerformanceCounterCache
+    {
+        readonly ConcurrentDictionary<string, Lazy<ConsumerPerformanceCounter>> _types;
+
+        ConsumerPerformanceCounterCache()
+        {
+            _types = new ConcurrentDictionary<string, Lazy<ConsumerPerformanceCounter>>();
+        }
+
+        public static IConsumerPerformanceCounter GetCounter(ICounterFactory factory, string consumerType)
+        {
+            return Cached.Counter.Value._types
+                .GetOrAdd(consumerType, x => new Lazy<ConsumerPerformanceCounter>(() => new ConsumerPerformanceCounter(factory, x)))
+                .Value;
+        }
+
+
+        static class Cached
+        {
+            public static readonly Lazy<ConsumerPerformanceCounterCache> Counter =
+                new Lazy<ConsumerPerformanceCounterCache>(() => new ConsumerPerformanceCounterCache());
+        }
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/ConsumerPerformanceCounterCache.cs
+++ b/src/Proto.Actor/Monitoring/Performance/ConsumerPerformanceCounterCache.cs
@@ -1,9 +1,8 @@
-﻿namespace MassTransit.Monitoring.Performance
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace Proto.Monitoring.Performance
 {
-    using System;
-    using System.Collections.Concurrent;
-
-
     public class ConsumerPerformanceCounterCache
     {
         readonly ConcurrentDictionary<string, Lazy<ConsumerPerformanceCounter>> _types;

--- a/src/Proto.Actor/Monitoring/Performance/ConsumerPerformanceCounters.cs
+++ b/src/Proto.Actor/Monitoring/Performance/ConsumerPerformanceCounters.cs
@@ -1,0 +1,41 @@
+﻿namespace MassTransit.Monitoring.Performance
+{
+    using System;
+    using System.Collections.Generic;
+
+
+    public class ConsumerPerformanceCounters :
+        BasePerformanceCounters
+    {
+        public static CounterData ConsumeRate => Cached.Instance.Value.Data[0];
+        public static CounterData TotalMessages => Cached.Instance.Value.Data[1];
+        public static CounterData Duration => Cached.Instance.Value.Data[2];
+        public static CounterData DurationBase => Cached.Instance.Value.Data[3];
+        public static CounterData TotalFaults => Cached.Instance.Value.Data[4];
+        public static CounterData FaultPercentage => Cached.Instance.Value.Data[5];
+        public static CounterData FaultPercentageBase => Cached.Instance.Value.Data[6];
+
+        public static void Install()
+        {
+            _ = Cached.Instance.Value;
+        }
+
+        protected override IEnumerable<CounterData> GetCounterData()
+        {
+            yield return Convert(BuiltInCounters.Consumers.Counters.MessagesPerSecond, CounterType.RateOfCountsPerSecond32);
+            yield return Convert(BuiltInCounters.Consumers.Counters.TotalMessages, CounterType.NumberOfItems64);
+            yield return Convert(BuiltInCounters.Consumers.Counters.AverageDuration, CounterType.AverageCount64);
+            yield return Convert(BuiltInCounters.Consumers.Counters.AverageDurationBase, CounterType.AverageBase);
+            yield return Convert(BuiltInCounters.Consumers.Counters.TotalFaults, CounterType.NumberOfItems64);
+            yield return Convert(BuiltInCounters.Consumers.Counters.FaultPercent, CounterType.AverageCount64);
+            yield return Convert(BuiltInCounters.Consumers.Counters.FaultPercentBase, CounterType.AverageBase);
+        }
+
+
+        static class Cached
+        {
+            internal static readonly Lazy<ConsumerPerformanceCounters> Instance =
+                new Lazy<ConsumerPerformanceCounters>(() => new ConsumerPerformanceCounters());
+        }
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/ConsumerPerformanceCounters.cs
+++ b/src/Proto.Actor/Monitoring/Performance/ConsumerPerformanceCounters.cs
@@ -1,9 +1,8 @@
-﻿namespace MassTransit.Monitoring.Performance
+﻿using System;
+using System.Collections.Generic;
+
+namespace Proto.Monitoring.Performance
 {
-    using System;
-    using System.Collections.Generic;
-
-
     public class ConsumerPerformanceCounters :
         BasePerformanceCounters
     {

--- a/src/Proto.Actor/Monitoring/Performance/CounterData.cs
+++ b/src/Proto.Actor/Monitoring/Performance/CounterData.cs
@@ -1,0 +1,82 @@
+﻿namespace MassTransit.Monitoring.Performance
+{
+    public class CounterData
+    {
+        //
+        // Summary:
+        //     Gets or sets the name of the custom counter.
+        //
+        // Returns:
+        //     A name for the counter, which is unique in its category.
+        //
+        // Exceptions:
+        //   T:System.ArgumentNullException:
+        //     The specified value is null.
+        //
+        //   T:System.ArgumentException:
+        //     The specified value is not between 1 and 80 characters long or contains double
+        //     quotes, control characters or leading or trailing spaces.
+        public string CounterName { get; set; }
+
+        //
+        // Summary:
+        //     Gets or sets the custom counter's description.
+        //
+        // Returns:
+        //     The text that describes the counter's behavior.
+        //
+        // Exceptions:
+        //   T:System.ArgumentNullException:
+        //     The specified value is null.
+        public string CounterDescription { get; set; }
+
+        //
+        // Summary:
+        //     Gets or sets the performance counter type of the custom counter.
+        //
+        // Returns:
+        //     A System.Diagnostics.PerformanceCounterType that defines the behavior of the
+        //     performance counter.
+        //
+        // Exceptions:
+        //   T:System.ComponentModel.InvalidEnumArgumentException:
+        //     You have specified a type that is not a member of the System.Diagnostics.PerformanceCounterType
+        //     enumeration.
+        public CounterType CounterType { get; set; }
+    }
+
+
+    public enum CounterType
+    {
+        //
+        // Summary:
+        //     An instantaneous counter that shows the most recently observed value. Used, for
+        //     example, to maintain a simple count of a very large number of items or operations.
+        //     It is the same as NumberOfItems32 except that it uses larger fields to accommodate
+        //     larger values.
+        NumberOfItems64 = 65792,
+
+        //
+        // Summary:
+        //     A difference counter that shows the average number of operations completed during
+        //     each second of the sample interval. Counters of this type measure time in ticks
+        //     of the system clock.
+        RateOfCountsPerSecond32 = 272696320,
+
+        //
+        // Summary:
+        //     An average counter that shows how many items are processed, on average, during
+        //     an operation. Counters of this type display a ratio of the items processed to
+        //     the number of operations completed. The ratio is calculated by comparing the
+        //     number of items processed during the last interval to the number of operations
+        //     completed during the last interval.
+        AverageCount64 = 1073874176,
+
+        //
+        // Summary:
+        //     A base counter that is used in the calculation of time or count averages, such
+        //     as AverageTimer32 and AverageCount64. Stores the denominator for calculating
+        //     a counter to present "time per operation" or "count per operation".
+        AverageBase = 1073939458
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/CounterData.cs
+++ b/src/Proto.Actor/Monitoring/Performance/CounterData.cs
@@ -1,4 +1,4 @@
-﻿namespace MassTransit.Monitoring.Performance
+﻿namespace Proto.Monitoring.Performance
 {
     public class CounterData
     {

--- a/src/Proto.Actor/Monitoring/Performance/CreateCounterDelegate.cs
+++ b/src/Proto.Actor/Monitoring/Performance/CreateCounterDelegate.cs
@@ -1,0 +1,4 @@
+namespace MassTransit.Monitoring.Performance
+{
+    public delegate IPerformanceCounter CreateCounterDelegate(string name, string instanceName);
+}

--- a/src/Proto.Actor/Monitoring/Performance/CreateCounterDelegate.cs
+++ b/src/Proto.Actor/Monitoring/Performance/CreateCounterDelegate.cs
@@ -1,4 +1,4 @@
-namespace MassTransit.Monitoring.Performance
+namespace Proto.Monitoring.Performance
 {
     public delegate IPerformanceCounter CreateCounterDelegate(string name, string instanceName);
 }

--- a/src/Proto.Actor/Monitoring/Performance/IConsumerPerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/IConsumerPerformanceCounter.cs
@@ -1,0 +1,11 @@
+﻿namespace MassTransit.Monitoring.Performance
+{
+    using System;
+
+
+    public interface IConsumerPerformanceCounter
+    {
+        void Consumed(TimeSpan duration);
+        void Faulted();
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/IConsumerPerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/IConsumerPerformanceCounter.cs
@@ -1,8 +1,7 @@
-﻿namespace MassTransit.Monitoring.Performance
+﻿using System;
+
+namespace Proto.Monitoring.Performance
 {
-    using System;
-
-
     public interface IConsumerPerformanceCounter
     {
         void Consumed(TimeSpan duration);

--- a/src/Proto.Actor/Monitoring/Performance/ICounterFactory.cs
+++ b/src/Proto.Actor/Monitoring/Performance/ICounterFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace MassTransit.Monitoring.Performance
+{
+    public interface ICounterFactory
+    {
+        IPerformanceCounter Create(CounterCategory category, string counterName, string instanceName);
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/ICounterFactory.cs
+++ b/src/Proto.Actor/Monitoring/Performance/ICounterFactory.cs
@@ -1,4 +1,4 @@
-﻿namespace MassTransit.Monitoring.Performance
+﻿namespace Proto.Monitoring.Performance
 {
     public interface ICounterFactory
     {

--- a/src/Proto.Actor/Monitoring/Performance/IMessagePerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/IMessagePerformanceCounter.cs
@@ -1,0 +1,40 @@
+﻿namespace MassTransit.Monitoring.Performance
+{
+    using System;
+
+
+    public interface IMessagePerformanceCounter
+    {
+        /// <summary>
+        /// A message was consumed, including the consume duration
+        /// </summary>
+        /// <param name="duration"></param>
+        void Consumed(TimeSpan duration);
+
+        /// <summary>
+        /// A message faulted while being consumed
+        /// </summary>
+        /// <param name="duration"></param>
+        void ConsumeFaulted(TimeSpan duration);
+
+        /// <summary>
+        /// A message was sent
+        /// </summary>
+        void Sent();
+
+        /// <summary>
+        /// A message was published
+        /// </summary>
+        void Published();
+
+        /// <summary>
+        /// A publish faulted
+        /// </summary>
+        void PublishFaulted();
+
+        /// <summary>
+        /// A send faulted
+        /// </summary>
+        void SendFaulted();
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/IMessagePerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/IMessagePerformanceCounter.cs
@@ -1,8 +1,7 @@
-﻿namespace MassTransit.Monitoring.Performance
+﻿using System;
+
+namespace Proto.Monitoring.Performance
 {
-    using System;
-
-
     public interface IMessagePerformanceCounter
     {
         /// <summary>

--- a/src/Proto.Actor/Monitoring/Performance/IPerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/IPerformanceCounter.cs
@@ -1,0 +1,13 @@
+namespace MassTransit.Monitoring.Performance
+{
+    using System;
+
+
+    public interface IPerformanceCounter :
+        IDisposable
+    {
+        void Increment();
+        void IncrementBy(long val);
+        void Set(long val);
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/IPerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/IPerformanceCounter.cs
@@ -1,8 +1,7 @@
-namespace MassTransit.Monitoring.Performance
+using System;
+
+namespace Proto.Monitoring.Performance
 {
-    using System;
-
-
     public interface IPerformanceCounter :
         IDisposable
     {

--- a/src/Proto.Actor/Monitoring/Performance/IPerformanceCounterInstaller.cs
+++ b/src/Proto.Actor/Monitoring/Performance/IPerformanceCounterInstaller.cs
@@ -1,0 +1,7 @@
+﻿namespace MassTransit.Monitoring.Performance
+{
+    public interface IPerformanceCounterInstaller
+    {
+        void Install();
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/IPerformanceCounterInstaller.cs
+++ b/src/Proto.Actor/Monitoring/Performance/IPerformanceCounterInstaller.cs
@@ -1,4 +1,4 @@
-﻿namespace MassTransit.Monitoring.Performance
+﻿namespace Proto.Monitoring.Performance
 {
     public interface IPerformanceCounterInstaller
     {

--- a/src/Proto.Actor/Monitoring/Performance/ISendPerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/ISendPerformanceCounter.cs
@@ -1,0 +1,8 @@
+namespace MassTransit.Monitoring.Performance
+{
+    public interface ISendPerformanceCounter
+    {
+        void Sent();
+        void Faulted();
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/ISendPerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/ISendPerformanceCounter.cs
@@ -1,4 +1,4 @@
-namespace MassTransit.Monitoring.Performance
+namespace Proto.Monitoring.Performance
 {
     public interface ISendPerformanceCounter
     {

--- a/src/Proto.Actor/Monitoring/Performance/MessagePerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/MessagePerformanceCounter.cs
@@ -1,8 +1,7 @@
-﻿namespace MassTransit.Monitoring.Performance
+﻿using System;
+
+namespace Proto.Monitoring.Performance
 {
-    using System;
-
-
     public class MessagePerformanceCounter<TMessage> :
         IDisposable,
         IMessagePerformanceCounter

--- a/src/Proto.Actor/Monitoring/Performance/MessagePerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/MessagePerformanceCounter.cs
@@ -1,0 +1,156 @@
+﻿namespace MassTransit.Monitoring.Performance
+{
+    using System;
+
+
+    public class MessagePerformanceCounter<TMessage> :
+        IDisposable,
+        IMessagePerformanceCounter
+    {
+        readonly IPerformanceCounter _consumedPerSecond;
+        readonly IPerformanceCounter _consumeDuration;
+        readonly IPerformanceCounter _consumeDurationBase;
+        readonly IPerformanceCounter _faulted;
+        readonly IPerformanceCounter _faultPercentage;
+        readonly IPerformanceCounter _faultPercentageBase;
+        readonly IPerformanceCounter _publishedPerSecond;
+        readonly IPerformanceCounter _publishFaulted;
+        readonly IPerformanceCounter _publishFaultPercentage;
+        readonly IPerformanceCounter _publishFaultPercentageBase;
+        readonly IPerformanceCounter _sendFaulted;
+        readonly IPerformanceCounter _sendFaultPercentage;
+        readonly IPerformanceCounter _sendFaultPercentageBase;
+        readonly IPerformanceCounter _sentPerSecond;
+        readonly IPerformanceCounter _totalConsumed;
+        readonly IPerformanceCounter _totalPublished;
+        readonly IPerformanceCounter _totalSent;
+
+        public MessagePerformanceCounter(ICounterFactory factory)
+        {
+            var messageType = TypeMetadataCache<TMessage>.ShortName;
+            if (messageType.Length > 127)
+                messageType = messageType.Substring(messageType.Length - 127);
+
+            _totalConsumed = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.TotalReceived.CounterName, messageType);
+            _consumedPerSecond = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.ConsumedPerSecond.CounterName, messageType);
+            _consumeDuration = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.ConsumeDuration.CounterName, messageType);
+            _consumeDurationBase = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.ConsumeDurationBase.CounterName, messageType);
+            _faulted = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.ConsumeFaulted.CounterName, messageType);
+            _faultPercentage = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.ConsumeFaultPercentage.CounterName, messageType);
+            _faultPercentageBase = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.ConsumeFaultPercentageBase.CounterName, messageType);
+            _totalSent = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.TotalSent.CounterName, messageType);
+            _sentPerSecond = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.SentPerSecond.CounterName, messageType);
+            _sendFaulted = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.SendFaulted.CounterName, messageType);
+            _sendFaultPercentage = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.SendFaultPercentage.CounterName, messageType);
+            _sendFaultPercentageBase = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.SendFaultPercentageBase.CounterName, messageType);
+            _totalPublished = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.TotalPublished.CounterName, messageType);
+            _publishedPerSecond = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.PublishedPerSecond.CounterName, messageType);
+            _publishFaulted = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.PublishFaulted.CounterName, messageType);
+            _publishFaultPercentage = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.PublishFaultPercentage.CounterName, messageType);
+            _publishFaultPercentageBase = factory.Create(BuiltInCounters.Messages.Category,
+                MessagePerformanceCounters.PublishFaultPercentageBase.CounterName, messageType);
+        }
+
+        public void Dispose()
+        {
+            _consumeDuration.Dispose();
+            _consumeDurationBase.Dispose();
+            _consumedPerSecond.Dispose();
+            _faultPercentage.Dispose();
+            _faultPercentageBase.Dispose();
+            _faulted.Dispose();
+            _totalConsumed.Dispose();
+            _totalSent.Dispose();
+            _sentPerSecond.Dispose();
+            _sendFaulted.Dispose();
+            _sendFaultPercentage.Dispose();
+            _sendFaultPercentageBase.Dispose();
+            _totalPublished.Dispose();
+            _publishedPerSecond.Dispose();
+            _publishFaulted.Dispose();
+            _publishFaultPercentage.Dispose();
+            _publishFaultPercentageBase.Dispose();
+        }
+
+        public void Consumed(TimeSpan duration)
+        {
+            _totalConsumed.Increment();
+            _consumedPerSecond.Increment();
+
+            _consumeDuration.IncrementBy((long)duration.TotalMilliseconds);
+            _consumeDurationBase.Increment();
+
+            _faultPercentageBase.Increment();
+        }
+
+        public void ConsumeFaulted(TimeSpan duration)
+        {
+            _totalConsumed.Increment();
+            _consumedPerSecond.Increment();
+
+            _faulted.Increment();
+
+            _faultPercentage.Increment();
+            _faultPercentageBase.Increment();
+        }
+
+        public void Sent()
+        {
+            _totalSent.Increment();
+            _sentPerSecond.Increment();
+
+            _sendFaultPercentageBase.Increment();
+        }
+
+        public void Published()
+        {
+            _totalPublished.Increment();
+            _publishedPerSecond.Increment();
+
+            _publishFaultPercentageBase.Increment();
+        }
+
+        public void PublishFaulted()
+        {
+            _totalPublished.Increment();
+            _publishedPerSecond.Increment();
+
+            _publishFaulted.Increment();
+
+            _publishFaultPercentage.Increment();
+            _publishFaultPercentageBase.Increment();
+        }
+
+        public void SendFaulted()
+        {
+            _totalSent.Increment();
+            _sentPerSecond.Increment();
+
+            _sendFaulted.Increment();
+
+            _sendFaultPercentage.Increment();
+            _sendFaultPercentageBase.Increment();
+        }
+    }
+
+    public class TypeMetadataCache<T>
+    {
+        public static string ShortName { get; set; }
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/MessagePerformanceCounterCache.cs
+++ b/src/Proto.Actor/Monitoring/Performance/MessagePerformanceCounterCache.cs
@@ -1,0 +1,17 @@
+﻿namespace MassTransit.Monitoring.Performance
+{
+    using System;
+
+
+    public static class MessagePerformanceCounterCache<T>
+    {
+        static Lazy<MessagePerformanceCounter<T>> _cache;
+
+        public static IMessagePerformanceCounter Counter(ICounterFactory factory)
+        {
+            if (_cache == null)
+                _cache = new Lazy<MessagePerformanceCounter<T>>(() => new MessagePerformanceCounter<T>(factory));
+            return _cache.Value;
+        }
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/MessagePerformanceCounterCache.cs
+++ b/src/Proto.Actor/Monitoring/Performance/MessagePerformanceCounterCache.cs
@@ -1,8 +1,7 @@
-﻿namespace MassTransit.Monitoring.Performance
+﻿using System;
+
+namespace Proto.Monitoring.Performance
 {
-    using System;
-
-
     public static class MessagePerformanceCounterCache<T>
     {
         static Lazy<MessagePerformanceCounter<T>> _cache;

--- a/src/Proto.Actor/Monitoring/Performance/MessagePerformanceCounters.cs
+++ b/src/Proto.Actor/Monitoring/Performance/MessagePerformanceCounters.cs
@@ -1,0 +1,62 @@
+namespace MassTransit.Monitoring.Performance
+{
+    using System;
+    using System.Collections.Generic;
+
+
+    public class MessagePerformanceCounters :
+        BasePerformanceCounters
+    {
+        public static CounterData ConsumedPerSecond => Cached.Instance.Value.Data[0];
+        public static CounterData TotalReceived => Cached.Instance.Value.Data[1];
+        public static CounterData ConsumeDuration => Cached.Instance.Value.Data[2];
+        public static CounterData ConsumeDurationBase => Cached.Instance.Value.Data[3];
+        public static CounterData ConsumeFaulted => Cached.Instance.Value.Data[4];
+        public static CounterData ConsumeFaultPercentage => Cached.Instance.Value.Data[5];
+        public static CounterData ConsumeFaultPercentageBase => Cached.Instance.Value.Data[6];
+        public static CounterData SentPerSecond => Cached.Instance.Value.Data[7];
+        public static CounterData TotalSent => Cached.Instance.Value.Data[8];
+        public static CounterData SendFaulted => Cached.Instance.Value.Data[9];
+        public static CounterData SendFaultPercentage => Cached.Instance.Value.Data[10];
+        public static CounterData SendFaultPercentageBase => Cached.Instance.Value.Data[11];
+        public static CounterData PublishedPerSecond => Cached.Instance.Value.Data[12];
+        public static CounterData TotalPublished => Cached.Instance.Value.Data[13];
+        public static CounterData PublishFaulted => Cached.Instance.Value.Data[14];
+        public static CounterData PublishFaultPercentage => Cached.Instance.Value.Data[15];
+        public static CounterData PublishFaultPercentageBase => Cached.Instance.Value.Data[16];
+
+        protected override IEnumerable<CounterData> GetCounterData()
+        {
+            yield return Convert(BuiltInCounters.Messages.Counters.ConsumedPerSecond, CounterType.RateOfCountsPerSecond32);
+            yield return Convert(BuiltInCounters.Messages.Counters.TotalConsumed, CounterType.NumberOfItems64);
+            yield return Convert(BuiltInCounters.Messages.Counters.AverageConsumeDuration, CounterType.AverageCount64);
+            yield return Convert(BuiltInCounters.Messages.Counters.AverageConusmeDurationBase, CounterType.AverageBase);
+            yield return Convert(BuiltInCounters.Messages.Counters.TotalConsumeFaults, CounterType.NumberOfItems64);
+            yield return Convert(BuiltInCounters.Messages.Counters.ConsumeFaultPercent, CounterType.AverageCount64);
+            yield return Convert(BuiltInCounters.Messages.Counters.ConsumeFaultPercentBase, CounterType.AverageBase);
+
+            yield return Convert(BuiltInCounters.Messages.Counters.SentPerSecond, CounterType.RateOfCountsPerSecond32);
+            yield return Convert(BuiltInCounters.Messages.Counters.TotalSent, CounterType.NumberOfItems64);
+            yield return Convert(BuiltInCounters.Messages.Counters.TotalSendFaults, CounterType.NumberOfItems64);
+            yield return Convert(BuiltInCounters.Messages.Counters.SendFaultPercent, CounterType.AverageCount64);
+            yield return Convert(BuiltInCounters.Messages.Counters.SendFaultPercentBase, CounterType.AverageBase);
+
+            yield return Convert(BuiltInCounters.Messages.Counters.PublishesPerSecond, CounterType.RateOfCountsPerSecond32);
+            yield return Convert(BuiltInCounters.Messages.Counters.TotalPublished, CounterType.NumberOfItems64);
+            yield return Convert(BuiltInCounters.Messages.Counters.TotalPublishFaults, CounterType.NumberOfItems64);
+            yield return Convert(BuiltInCounters.Messages.Counters.PublishFaultPercent, CounterType.AverageCount64);
+            yield return Convert(BuiltInCounters.Messages.Counters.PublishFaultPercentBase, CounterType.AverageBase);
+        }
+
+        public static void Install()
+        {
+            _ = Cached.Instance.Value;
+        }
+
+
+        static class Cached
+        {
+            internal static readonly Lazy<MessagePerformanceCounters> Instance = new Lazy<MessagePerformanceCounters>(() => new MessagePerformanceCounters());
+        }
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/MessagePerformanceCounters.cs
+++ b/src/Proto.Actor/Monitoring/Performance/MessagePerformanceCounters.cs
@@ -1,9 +1,8 @@
-namespace MassTransit.Monitoring.Performance
+using System;
+using System.Collections.Generic;
+
+namespace Proto.Monitoring.Performance
 {
-    using System;
-    using System.Collections.Generic;
-
-
     public class MessagePerformanceCounters :
         BasePerformanceCounters
     {

--- a/src/Proto.Actor/Monitoring/Performance/Null/NullCounterFactory.cs
+++ b/src/Proto.Actor/Monitoring/Performance/Null/NullCounterFactory.cs
@@ -1,0 +1,10 @@
+﻿namespace MassTransit.Monitoring.Performance.Null
+{
+    public class NullCounterFactory : ICounterFactory
+    {
+        public IPerformanceCounter Create(CounterCategory category, string counterName, string instanceName)
+        {
+            return new NullPerformanceCounter();
+        }
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/Null/NullCounterFactory.cs
+++ b/src/Proto.Actor/Monitoring/Performance/Null/NullCounterFactory.cs
@@ -1,4 +1,4 @@
-﻿namespace MassTransit.Monitoring.Performance.Null
+﻿namespace Proto.Monitoring.Performance.Null
 {
     public class NullCounterFactory : ICounterFactory
     {

--- a/src/Proto.Actor/Monitoring/Performance/Null/NullPerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/Null/NullPerformanceCounter.cs
@@ -1,0 +1,22 @@
+namespace MassTransit.Monitoring.Performance.Null
+{
+    public class NullPerformanceCounter :
+        IPerformanceCounter
+    {
+        public void Increment()
+        {
+        }
+
+        public void IncrementBy(long val)
+        {
+        }
+
+        public void Set(long val)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/Null/NullPerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/Null/NullPerformanceCounter.cs
@@ -1,4 +1,4 @@
-namespace MassTransit.Monitoring.Performance.Null
+namespace Proto.Monitoring.Performance.Null
 {
     public class NullPerformanceCounter :
         IPerformanceCounter

--- a/src/Proto.Actor/Monitoring/Performance/PerformanceCounterBusObserver.cs
+++ b/src/Proto.Actor/Monitoring/Performance/PerformanceCounterBusObserver.cs
@@ -1,0 +1,62 @@
+// namespace MassTransit.Monitoring.Performance
+// {
+//     using System;
+//     using System.Threading.Tasks;
+//     using Util;
+//
+//
+//     public class PerformanceCounterBusObserver :
+//         IBusObserver
+//     {
+//         readonly ICounterFactory _factory;
+//
+//         public PerformanceCounterBusObserver(ICounterFactory factory)
+//         {
+//             _factory = factory;
+//         }
+//
+//         public Task PostCreate(IBus bus)
+//         {
+//             bus.ConnectPublishObserver(new PerformanceCounterPublishObserver(_factory));
+//             bus.ConnectSendObserver(new PerformanceCounterSendObserver(_factory));
+//             bus.ConnectReceiveObserver(new PerformanceCounterReceiveObserver(_factory));
+//
+//             return Task.Completed;
+//         }
+//
+//         public Task CreateFaulted(Exception exception)
+//         {
+//             return Task.Completed;
+//         }
+//
+//         public Task PreStart(IBus bus)
+//         {
+//             return Task.Completed;
+//         }
+//
+//         public Task PostStart(IBus bus, Task<BusReady> busReady)
+//         {
+//             return Task.Completed;
+//         }
+//
+//         public Task StartFaulted(IBus bus, Exception exception)
+//         {
+//             return Task.Completed;
+//         }
+//
+//         public Task PreStop(IBus bus)
+//         {
+//             return Task.Completed;
+//         }
+//
+//         public Task PostStop(IBus bus)
+//         {
+//             return Task.Completed;
+//         }
+//
+//         public Task StopFaulted(IBus bus, Exception exception)
+//         {
+//             return TaskUtil.Completed;
+//         }
+//     }
+// }

--- a/src/Proto.Actor/Monitoring/Performance/PerformanceCounterPublishObserver.cs
+++ b/src/Proto.Actor/Monitoring/Performance/PerformanceCounterPublishObserver.cs
@@ -1,0 +1,41 @@
+﻿// namespace MassTransit.Monitoring.Performance
+// {
+//     using System;
+//     using System.Threading.Tasks;
+//     using Util;
+//
+//
+//     /// <summary>
+//     /// An observer that updates the performance counters using the bus events
+//     /// generated.
+//     /// </summary>
+//     public class PerformanceCounterPublishObserver :
+//         IPublishObserver
+//     {
+//         readonly ICounterFactory _factory;
+//
+//         public PerformanceCounterPublishObserver(ICounterFactory factory)
+//         {
+//             _factory = factory;
+//         }
+//
+//         Task IPublishObserver.PrePublish<T>(PublishContext<T> context)
+//         {
+//             return TaskUtil.Completed;
+//         }
+//
+//         Task IPublishObserver.PostPublish<T>(PublishContext<T> context)
+//         {
+//             MessagePerformanceCounterCache<T>.Counter(_factory).Published();
+//
+//             return TaskUtil.Completed;
+//         }
+//
+//         Task IPublishObserver.PublishFault<T>(PublishContext<T> context, Exception exception)
+//         {
+//             MessagePerformanceCounterCache<T>.Counter(_factory).PublishFaulted();
+//
+//             return TaskUtil.Completed;
+//         }
+//     }
+// }

--- a/src/Proto.Actor/Monitoring/Performance/PerformanceCounterReceiveObserver.cs
+++ b/src/Proto.Actor/Monitoring/Performance/PerformanceCounterReceiveObserver.cs
@@ -1,0 +1,51 @@
+﻿// namespace MassTransit.Monitoring.Performance
+// {
+//     using System;
+//     using System.Threading.Tasks;
+//     using Util;
+//
+//
+//     /// <summary>
+//     /// An observer that updates the performance counters using the bus events
+//     /// generated.
+//     /// </summary>
+//     public class PerformanceCounterReceiveObserver :
+//         IReceiveObserver
+//     {
+//         readonly ICounterFactory _factory;
+//
+//         public PerformanceCounterReceiveObserver(ICounterFactory factory)
+//         {
+//             _factory = factory;
+//         }
+//
+//         Task IReceiveObserver.PreReceive(ReceiveContext context)
+//         {
+//             return TaskUtil.Completed;
+//         }
+//
+//         Task IReceiveObserver.PostReceive(ReceiveContext context)
+//         {
+//             return TaskUtil.Completed;
+//         }
+//
+//         Task IReceiveObserver.PostConsume<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType)
+//         {
+//             ConsumerPerformanceCounterCache.GetCounter(_factory, consumerType).Consumed(duration);
+//             MessagePerformanceCounterCache<T>.Counter(_factory).Consumed(duration);
+//             return TaskUtil.Completed;
+//         }
+//
+//         Task IReceiveObserver.ConsumeFault<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType, Exception exception)
+//         {
+//             ConsumerPerformanceCounterCache.GetCounter(_factory, consumerType).Faulted();
+//             MessagePerformanceCounterCache<T>.Counter(_factory).ConsumeFaulted(duration);
+//             return TaskUtil.Completed;
+//         }
+//
+//         Task IReceiveObserver.ReceiveFault(ReceiveContext context, Exception exception)
+//         {
+//             return TaskUtil.Completed;
+//         }
+//     }
+// }

--- a/src/Proto.Actor/Monitoring/Performance/PerformanceCounterSendObserver.cs
+++ b/src/Proto.Actor/Monitoring/Performance/PerformanceCounterSendObserver.cs
@@ -1,0 +1,41 @@
+﻿// namespace MassTransit.Monitoring.Performance
+// {
+//     using System;
+//     using System.Threading.Tasks;
+//     using Util;
+//
+//
+//     /// <summary>
+//     /// An observer that updates the performance counters using the bus events
+//     /// generated.
+//     /// </summary>
+//     public class PerformanceCounterSendObserver :
+//         ISendObserver
+//     {
+//         readonly ICounterFactory _factory;
+//
+//         public PerformanceCounterSendObserver(ICounterFactory factory)
+//         {
+//             _factory = factory;
+//         }
+//
+//         Task ISendObserver.PreSend<T>(SendContext<T> context)
+//         {
+//             return Task.Completed;
+//         }
+//
+//         Task ISendObserver.PostSend<T>(SendContext<T> context)
+//         {
+//             MessagePerformanceCounterCache<T>.Counter(_factory).Sent();
+//
+//             return Task.Completed;
+//         }
+//
+//         Task ISendObserver.SendFault<T>(SendContext<T> context, Exception exception)
+//         {
+//             MessagePerformanceCounterCache<T>.Counter(_factory).SendFaulted();
+//
+//             return Task.Completed;
+//         }
+//     }
+// }

--- a/src/Proto.Actor/Monitoring/Performance/StatsD/StatsDConfiguration.cs
+++ b/src/Proto.Actor/Monitoring/Performance/StatsD/StatsDConfiguration.cs
@@ -1,0 +1,19 @@
+namespace MassTransit.Monitoring.Performance.StatsD
+{
+    public class StatsDConfiguration
+    {
+        public StatsDConfiguration(string hostname, int port)
+        {
+            Hostname = hostname;
+            Port = port;
+        }
+
+        public string Hostname { get; set; }
+        public int Port { get; set; }
+
+        public static StatsDConfiguration Defaults()
+        {
+            return new StatsDConfiguration("localhost", 8125);
+        }
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/StatsD/StatsDConfiguration.cs
+++ b/src/Proto.Actor/Monitoring/Performance/StatsD/StatsDConfiguration.cs
@@ -1,4 +1,4 @@
-namespace MassTransit.Monitoring.Performance.StatsD
+namespace Proto.Monitoring.Performance.StatsD
 {
     public class StatsDConfiguration
     {

--- a/src/Proto.Actor/Monitoring/Performance/StatsD/StatsDCounterFactory.cs
+++ b/src/Proto.Actor/Monitoring/Performance/StatsD/StatsDCounterFactory.cs
@@ -1,0 +1,17 @@
+﻿namespace MassTransit.Monitoring.Performance.StatsD
+{
+    public class StatsDCounterFactory : ICounterFactory
+    {
+        readonly StatsDConfiguration _config;
+
+        public StatsDCounterFactory(StatsDConfiguration config)
+        {
+            _config = config;
+        }
+
+        public IPerformanceCounter Create(CounterCategory category, string counterName, string instanceName)
+        {
+            return new StatsDPerformanceCounter(_config, category.Name, counterName, instanceName);
+        }
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/StatsD/StatsDCounterFactory.cs
+++ b/src/Proto.Actor/Monitoring/Performance/StatsD/StatsDCounterFactory.cs
@@ -1,4 +1,4 @@
-﻿namespace MassTransit.Monitoring.Performance.StatsD
+﻿namespace Proto.Monitoring.Performance.StatsD
 {
     public class StatsDCounterFactory : ICounterFactory
     {

--- a/src/Proto.Actor/Monitoring/Performance/StatsD/StatsDPerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/StatsD/StatsDPerformanceCounter.cs
@@ -1,0 +1,47 @@
+﻿namespace MassTransit.Monitoring.Performance.StatsD
+{
+    using System.Net.Sockets;
+    using System.Text;
+    using System.Threading.Tasks;
+
+
+    public class StatsDPerformanceCounter :
+        IPerformanceCounter
+    {
+        readonly UdpClient _client;
+        readonly string _fullName;
+        readonly byte[] _incrementPayload;
+
+        public StatsDPerformanceCounter(StatsDConfiguration cfg, string category, string name, string instance)
+        {
+            _fullName = $"{category}.{name}.{instance}";
+            var increment = $"{_fullName}:1|c";
+            _incrementPayload = Encoding.UTF8.GetBytes(increment);
+            _client = new UdpClient(cfg.Hostname, cfg.Port);
+        }
+
+        public void Increment()
+        {
+            Task<int> t = _client.SendAsync(_incrementPayload, _incrementPayload.Length);
+        }
+
+        public void IncrementBy(long val)
+        {
+            var payload = $"{_fullName}:{val}|c";
+            byte[] datagram = Encoding.UTF8.GetBytes(payload);
+            Task<int> t = _client.SendAsync(datagram, datagram.Length);
+        }
+
+        public void Set(long val)
+        {
+            var payload = $"{_fullName}:{val}|g";
+            byte[] datagram = Encoding.UTF8.GetBytes(payload);
+            Task<int> t = _client.SendAsync(datagram, datagram.Length);
+        }
+
+        public void Dispose()
+        {
+            _client?.Close();
+        }
+    }
+}

--- a/src/Proto.Actor/Monitoring/Performance/StatsD/StatsDPerformanceCounter.cs
+++ b/src/Proto.Actor/Monitoring/Performance/StatsD/StatsDPerformanceCounter.cs
@@ -1,10 +1,9 @@
-﻿namespace MassTransit.Monitoring.Performance.StatsD
+﻿using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Proto.Monitoring.Performance.StatsD
 {
-    using System.Net.Sockets;
-    using System.Text;
-    using System.Threading.Tasks;
-
-
     public class StatsDPerformanceCounter :
         IPerformanceCounter
     {


### PR DESCRIPTION
PoC stealing the Performance Counter abstraction from @MassTransit.
Nothing implemented yet, just copy paste on counter infra code.

cc @alexeyzimarev @mhelleborg do you think this is something we can work on? adapting it to the PA infrastructure?

Some special cases, we have core, remote and cluster, (and persistence?) that could benefit from this.
each module would need its own counters.

cc @phatboyg for transparency