### PR TITLE
Global killswitch

### DIFF
--- a/benchmarks/ClusterBenchmark/Configuration.cs
+++ b/benchmarks/ClusterBenchmark/Configuration.cs
@@ -115,15 +115,11 @@ namespace ClusterExperiment1
         public static void SetupLogger()
         {
             Log.Logger = new LoggerConfiguration()
-               // .WriteTo.Console()
                 .WriteTo.Console(LogEventLevel.Information, "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}")
-                .MinimumLevel.Information()
-                // .Filter.ByExcluding(e => e.Exception != null && e.Level == LogEventLevel.Warning)
-                .CreateLogger();
+               .CreateLogger();
 
             var l = LoggerFactory.Create(l =>
                 l.AddSerilog()
-                    .SetMinimumLevel(LogLevel.Error)
             );
 
             Proto.Log.SetLoggerFactory(l);

--- a/benchmarks/ClusterBenchmark/Configuration.cs
+++ b/benchmarks/ClusterBenchmark/Configuration.cs
@@ -113,8 +113,8 @@ namespace ClusterExperiment1
         public static void SetupLogger()
         {
             Log.Logger = new LoggerConfiguration()
-                .WriteTo.Console()
-               // .WriteTo.Console(LogEventLevel.Information, "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}")
+               // .WriteTo.Console()
+                .WriteTo.Console(LogEventLevel.Information, "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}")
                 .MinimumLevel.Information()
                 // .Filter.ByExcluding(e => e.Exception != null && e.Level == LogEventLevel.Warning)
                 .CreateLogger();

--- a/benchmarks/ClusterBenchmark/Configuration.cs
+++ b/benchmarks/ClusterBenchmark/Configuration.cs
@@ -65,7 +65,7 @@ namespace ClusterExperiment1
         {
             var db = GetMongo();
             var identity = new IdentityStorageLookup(
-                new MongoIdentityStorage("mycluster", db.GetCollection<PidLookupEntity>("pids"))
+                new MongoIdentityStorage("mycluster", db.GetCollection<PidLookupEntity>("pids"),200)
             );
             return identity;
         }

--- a/benchmarks/ClusterBenchmark/Configuration.cs
+++ b/benchmarks/ClusterBenchmark/Configuration.cs
@@ -76,8 +76,10 @@ namespace ClusterExperiment1
                 Environment.GetEnvironmentVariable("MONGO") ?? "mongodb://127.0.0.1:27017/ProtoMongo";
             var url = MongoUrl.Create(connectionString);
             var settings = MongoClientSettings.FromUrl(url);
-            settings.WriteConcern = WriteConcern.Acknowledged;
-            settings.ReadConcern = ReadConcern.Majority;
+            settings.WaitQueueSize = 10000;
+            settings.WaitQueueTimeout = TimeSpan.FromSeconds(10);
+            // settings.WriteConcern = WriteConcern.Acknowledged;
+            // settings.ReadConcern = ReadConcern.Majority;
             var client = new MongoClient(settings);
             var database = client.GetDatabase("ProtoMongo");
             return database;

--- a/benchmarks/ClusterBenchmark/Program.cs
+++ b/benchmarks/ClusterBenchmark/Program.cs
@@ -127,12 +127,13 @@ namespace ClusterExperiment1
                                 var id = "myactor" + rnd.Next(0, 10000);
                                 var request = cluster.RequestAsync<HelloResponse>(id, "hello", new HelloRequest(),
                                     new CancellationTokenSource(TimeSpan.FromSeconds(15)).Token
-                                ).ContinueWith(_ => Console.Write("."));
+                                );
 
                                 requests.Add(request);
                             }
 
                             await Task.WhenAll(requests);
+                            Console.Write(".");
                         }
                         catch (Exception x)
                         {

--- a/benchmarks/ClusterBenchmark/Program.cs
+++ b/benchmarks/ClusterBenchmark/Program.cs
@@ -40,6 +40,20 @@ namespace ClusterExperiment1
             Console.WriteLine("3) Run fire and forget client");
 
             var res2 = Console.ReadLine();
+
+            int batchSize = 0;
+            if (res2 == "2")
+            {
+                Console.WriteLine("Batch size? default is 50");
+                var res = Console.ReadLine();
+
+                if (!int.TryParse(res, out batchSize))
+                {
+                    batchSize = 50;
+                }
+            
+                Console.WriteLine($"Using batch size {batchSize}");
+            }
             
             Console.WriteLine("Number of virtual actors? default 10000");
 
@@ -75,7 +89,7 @@ namespace ClusterExperiment1
                     RunClient();
                     break;
                 case "2":
-                    RunBatchClient();
+                    RunBatchClient(batchSize);
                     break;
                 case "3":
                     RunFireForgetClient();
@@ -120,7 +134,7 @@ namespace ClusterExperiment1
             );
         }
 
-        private static void RunBatchClient()
+        private static void RunBatchClient(int batchSize)
         {
             var logger = Log.CreateLogger(nameof(Program));
             ThreadPoolStats.Run(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500), t => {
@@ -140,11 +154,11 @@ namespace ClusterExperiment1
 
                         try
                         {
-                            for (var i = 0; i < 1000; i++)
+                            for (var i = 0; i < batchSize; i++)
                             {
                                 var id = "myactor" + rnd.Next(0, ActorCount);
                                 var request = cluster.RequestAsync<HelloResponse>(id, "hello", new HelloRequest(),
-                                    new CancellationTokenSource(TimeSpan.FromSeconds(15)).Token
+                                    new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token
                                 );
 
                                 requests.Add(request);

--- a/benchmarks/ClusterBenchmark/Program.cs
+++ b/benchmarks/ClusterBenchmark/Program.cs
@@ -165,7 +165,7 @@ namespace ClusterExperiment1
                         try
                         {
                             var res = await cluster.RequestAsync<HelloResponse>(id, "hello", new HelloRequest(),
-                                new CancellationTokenSource(TimeSpan.FromSeconds(15)).Token
+                                new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token
                             );
 
                             if (res is null)
@@ -186,7 +186,7 @@ namespace ClusterExperiment1
         {
             var followers = new List<IRunMember>();
 
-            for (var i = 0; i < 4; i++)
+            for (var i = 0; i < 8; i++)
             {
                 var p = memberFactory();
                 p.Start();
@@ -196,7 +196,7 @@ namespace ClusterExperiment1
             _ = Task.Run(async () => {
                     foreach (var t in followers)
                     {
-                        await Task.Delay(30000);
+                        await Task.Delay(12000);
                         Console.WriteLine("Stopping node...");
                         _ = t.Kill();
                     }

--- a/benchmarks/ClusterBenchmark/Program.cs
+++ b/benchmarks/ClusterBenchmark/Program.cs
@@ -196,7 +196,7 @@ namespace ClusterExperiment1
             _ = Task.Run(async () => {
                     foreach (var t in followers)
                     {
-                        await Task.Delay(60000);
+                        await Task.Delay(30000);
                         Console.WriteLine("Stopping node...");
                         _ = t.Kill();
                     }

--- a/benchmarks/ClusterBenchmark/Runner.cs
+++ b/benchmarks/ClusterBenchmark/Runner.cs
@@ -23,7 +23,7 @@ namespace ClusterExperiment1
 
         public async Task Start() => _cluster = await Configuration.SpawnMember();
 
-        public async Task Kill() => await _cluster.ShutdownAsync(false);
+        public async Task Kill() => await _cluster.ShutdownAsync(true);
     }
 
     public class RunMemberExternalProc : IRunMember

--- a/benchmarks/ClusterBenchmark/Runner.cs
+++ b/benchmarks/ClusterBenchmark/Runner.cs
@@ -17,13 +17,22 @@ namespace ClusterExperiment1
         Task Kill();
     }
 
-    public class RunMemberInProc : IRunMember
+    public class RunMemberInProcGraceful : IRunMember
     {
         private Cluster _cluster;
 
         public async Task Start() => _cluster = await Configuration.SpawnMember();
 
         public async Task Kill() => await _cluster.ShutdownAsync(true);
+    }
+    
+    public class RunMemberInProc : IRunMember
+    {
+        private Cluster _cluster;
+
+        public async Task Start() => _cluster = await Configuration.SpawnMember();
+
+        public async Task Kill() => await _cluster.ShutdownAsync(false);
     }
 
     public class RunMemberExternalProc : IRunMember

--- a/benchmarks/HostedService/ProtoHost.cs
+++ b/benchmarks/HostedService/ProtoHost.cs
@@ -41,7 +41,7 @@ namespace HostedService
             {
                 var id = rnd.Next(0, 100000);
                 _ = _cluster.RequestAsync<int>($"abc{id}", "kind", 123, _appLifetime.ApplicationStopping);
-              //  await Task.Delay(2);
+             //   await Task.Delay(10);
             }
         }
 

--- a/benchmarks/HostedService/ProtoHost.cs
+++ b/benchmarks/HostedService/ProtoHost.cs
@@ -41,6 +41,7 @@ namespace HostedService
             {
                 var id = rnd.Next(0, 100000);
                 _ = _cluster.RequestAsync<int>($"abc{id}", "kind", 123, _appLifetime.ApplicationStopping);
+                await Task.Delay(10);
             }
         }
 

--- a/benchmarks/HostedService/ProtoHost.cs
+++ b/benchmarks/HostedService/ProtoHost.cs
@@ -25,7 +25,7 @@ namespace HostedService
         {
             _logger.LogInformation("Starting cluster...");
             _appLifetime.ApplicationStarted.Register(() => Task.Run(() => RunRequestLoop(), _appLifetime.ApplicationStopping));
-            _appLifetime.ApplicationStopping.Register(OnStopping);
+          //  _appLifetime.ApplicationStopping.Register(OnStopping);
             return Task.CompletedTask;
 
         }
@@ -45,21 +45,16 @@ namespace HostedService
             }
         }
 
-        private void OnStopping()
+        public async Task StopAsync(CancellationToken cancellationToken)
         {
             _logger.LogWarning("Shutting down cluster...");
             var shutdown = _cluster.ShutdownAsync(true);
             var timeout = Task.Delay(15000);
-            Task.WhenAny(shutdown, timeout).GetAwaiter().GetResult();
+            await Task.WhenAny(shutdown, timeout).GetAwaiter().GetResult();
             if (shutdown.IsCompleted)
                 _logger.LogWarning("Shut down cluster...");
             else
                 _logger.LogError("Shut down cluster timed out...");
-        }
-
-        public Task StopAsync(CancellationToken cancellationToken)
-        {
-            return Task.CompletedTask;
         }
     }
 }

--- a/benchmarks/HostedService/ProtoHost.cs
+++ b/benchmarks/HostedService/ProtoHost.cs
@@ -47,7 +47,7 @@ namespace HostedService
         private void OnStopping()
         {
             _logger.LogWarning("Shutting down cluster...");
-            var shutdown = _cluster.ShutdownAsync(false);
+            var shutdown = _cluster.ShutdownAsync(true);
             var timeout = Task.Delay(15000);
             Task.WhenAny(shutdown, timeout).GetAwaiter().GetResult();
             if (shutdown.IsCompleted)

--- a/benchmarks/HostedService/ProtoHost.cs
+++ b/benchmarks/HostedService/ProtoHost.cs
@@ -41,19 +41,16 @@ namespace HostedService
             {
                 var id = rnd.Next(0, 100000);
                 _ = _cluster.RequestAsync<int>($"abc{id}", "kind", 123, _appLifetime.ApplicationStopping);
-            //    await Task.Delay(5);
+              //  await Task.Delay(2);
             }
         }
 
         private void OnStopping()
         {
-            _logger.LogWarning("Shutting down cluster...");
             var shutdown = _cluster.ShutdownAsync(true);
             var timeout = Task.Delay(15000);
             Task.WhenAny(shutdown, timeout).GetAwaiter().GetResult();
-            if (shutdown.IsCompleted)
-                _logger.LogWarning("Shut down cluster...");
-            else
+            if (timeout.IsCompleted)
                 _logger.LogError("Shut down cluster timed out...");
         }
 

--- a/benchmarks/HostedService/ProtoHost.cs
+++ b/benchmarks/HostedService/ProtoHost.cs
@@ -41,7 +41,7 @@ namespace HostedService
             {
                 var id = rnd.Next(0, 100000);
                 _ = _cluster.RequestAsync<int>($"abc{id}", "kind", 123, _appLifetime.ApplicationStopping);
-                await Task.Delay(5);
+            //    await Task.Delay(5);
             }
         }
 

--- a/benchmarks/HostedService/Startup.cs
+++ b/benchmarks/HostedService/Startup.cs
@@ -40,11 +40,14 @@ namespace HostedService
             
             
             var settings = MongoClientSettings.FromUrl(MongoUrl.Create("mongodb://127.0.0.1:27017"));
+            settings.MinConnectionPoolSize = 10;
+            settings.MaxConnectionPoolSize = 20;
+            
             var mongoClient = new MongoClient(settings);
             var pids = mongoClient.GetDatabase("dummydb").GetCollection<PidLookupEntity>("pids");
 
             var clusterProvider = new ConsulProvider(new ConsulProviderConfig());
-            var identityLookup = new IdentityStorageLookup(new MongoIdentityStorage("foo", pids,50));
+            var identityLookup = new IdentityStorageLookup(new MongoIdentityStorage("foo", pids,10));
             var sys = new ActorSystem(new ActorSystemConfig().WithDeadLetterThrottleCount(3).WithDeadLetterThrottleInterval(TimeSpan.FromSeconds(1)))
                 .WithRemote(GrpcCoreRemoteConfig.BindToLocalhost(9090))
                 .WithCluster(ClusterConfig.Setup("test", clusterProvider, identityLookup)

--- a/benchmarks/HostedService/Startup.cs
+++ b/benchmarks/HostedService/Startup.cs
@@ -41,7 +41,7 @@ namespace HostedService
             
             var settings = MongoClientSettings.FromUrl(MongoUrl.Create("mongodb://127.0.0.1:27017"));
             settings.MinConnectionPoolSize = 10;
-            settings.MaxConnectionPoolSize = 20;
+            settings.MaxConnectionPoolSize = 1000;
             
             var mongoClient = new MongoClient(settings);
             var pids = mongoClient.GetDatabase("dummydb").GetCollection<PidLookupEntity>("pids");

--- a/benchmarks/HostedService/Startup.cs
+++ b/benchmarks/HostedService/Startup.cs
@@ -40,14 +40,16 @@ namespace HostedService
             
             
             var settings = MongoClientSettings.FromUrl(MongoUrl.Create("mongodb://127.0.0.1:27017"));
-            settings.MinConnectionPoolSize = 10;
-            settings.MaxConnectionPoolSize = 1000;
+            // settings.MinConnectionPoolSize = 10;
+            // settings.MaxConnectionPoolSize = 100;
+            settings.WaitQueueTimeout = TimeSpan.FromSeconds(10);
+            settings.WaitQueueSize = 10000;
             
             var mongoClient = new MongoClient(settings);
             var pids = mongoClient.GetDatabase("dummydb").GetCollection<PidLookupEntity>("pids");
 
             var clusterProvider = new ConsulProvider(new ConsulProviderConfig());
-            var identityLookup = new IdentityStorageLookup(new MongoIdentityStorage("foo", pids,10));
+            var identityLookup = new IdentityStorageLookup(new MongoIdentityStorage("foo", pids,50));
             var sys = new ActorSystem(new ActorSystemConfig().WithDeadLetterThrottleCount(3).WithDeadLetterThrottleInterval(TimeSpan.FromSeconds(1)))
                 .WithRemote(GrpcCoreRemoteConfig.BindToLocalhost(9090))
                 .WithCluster(ClusterConfig.Setup("test", clusterProvider, identityLookup)

--- a/benchmarks/HostedService/Startup.cs
+++ b/benchmarks/HostedService/Startup.cs
@@ -44,7 +44,7 @@ namespace HostedService
             var pids = mongoClient.GetDatabase("dummydb").GetCollection<PidLookupEntity>("pids");
 
             var clusterProvider = new ConsulProvider(new ConsulProviderConfig());
-            var identityLookup = new IdentityStorageLookup(new MongoIdentityStorage("foo", pids,10));
+            var identityLookup = new IdentityStorageLookup(new MongoIdentityStorage("foo", pids,50));
             var sys = new ActorSystem(new ActorSystemConfig().WithDeadLetterThrottleCount(3).WithDeadLetterThrottleInterval(TimeSpan.FromSeconds(1)))
                 .WithRemote(GrpcCoreRemoteConfig.BindToLocalhost(9090))
                 .WithCluster(ClusterConfig.Setup("test", clusterProvider, identityLookup)

--- a/benchmarks/HostedService/Startup.cs
+++ b/benchmarks/HostedService/Startup.cs
@@ -46,10 +46,11 @@ namespace HostedService
             settings.WaitQueueSize = 10000;
             
             var mongoClient = new MongoClient(settings);
+            
             var pids = mongoClient.GetDatabase("dummydb").GetCollection<PidLookupEntity>("pids");
 
             var clusterProvider = new ConsulProvider(new ConsulProviderConfig());
-            var identityLookup = new IdentityStorageLookup(new MongoIdentityStorage("foo", pids,50));
+            var identityLookup = new IdentityStorageLookup(new MongoIdentityStorage("foo", pids,150));
             var sys = new ActorSystem(new ActorSystemConfig().WithDeadLetterThrottleCount(3).WithDeadLetterThrottleInterval(TimeSpan.FromSeconds(1)))
                 .WithRemote(GrpcCoreRemoteConfig.BindToLocalhost(9090))
                 .WithCluster(ClusterConfig.Setup("test", clusterProvider, identityLookup)

--- a/src/Proto.Actor/ActorSystem.cs
+++ b/src/Proto.Actor/ActorSystem.cs
@@ -31,7 +31,7 @@ namespace Proto
             Root = new RootContext(this);
             DeadLetter = new DeadLetterProcess(this);
             Guardians = new Guardians(this);
-            EventStream = new EventStream(config.DeadLetterThrottleInterval, config.DeadLetterThrottleCount, Token);
+            EventStream = new EventStream(config.DeadLetterThrottleInterval, config.DeadLetterThrottleCount, Shutdown);
             var eventStreamProcess = new EventStreamProcess(this);
             ProcessRegistry.TryAdd("eventstream", eventStreamProcess);
             Extensions = new ActorSystemExtensions(this);
@@ -53,7 +53,7 @@ namespace Proto
 
         public ActorSystemExtensions Extensions { get; }
 
-        public CancellationToken Token => _cts.Token;
+        public CancellationToken Shutdown => _cts.Token;
 
         public Task ShutdownAsync()
         {

--- a/src/Proto.Actor/ActorSystem.cs
+++ b/src/Proto.Actor/ActorSystem.cs
@@ -31,7 +31,7 @@ namespace Proto
             Root = new RootContext(this);
             DeadLetter = new DeadLetterProcess(this);
             Guardians = new Guardians(this);
-            EventStream = new EventStream(config.DeadLetterThrottleInterval, config.DeadLetterThrottleCount);
+            EventStream = new EventStream(config.DeadLetterThrottleInterval, config.DeadLetterThrottleCount, Token);
             var eventStreamProcess = new EventStreamProcess(this);
             ProcessRegistry.TryAdd("eventstream", eventStreamProcess);
             Extensions = new ActorSystemExtensions(this);

--- a/src/Proto.Actor/ActorSystem.cs
+++ b/src/Proto.Actor/ActorSystem.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Proto.Extensions;
 
@@ -16,6 +18,7 @@ namespace Proto
         internal const string NoHost = "nonhost";
         private string _host = NoHost;
         private int _port;
+        private CancellationTokenSource _cts = new();
 
         public ActorSystem() : this(new ActorSystemConfig())
         {
@@ -49,6 +52,14 @@ namespace Proto
         public EventStream EventStream { get; }
 
         public ActorSystemExtensions Extensions { get; }
+
+        public CancellationToken Toke => _cts.Token;
+
+        public Task ShutdownAsync()
+        {
+            _cts.Cancel();
+            return Task.CompletedTask;
+        }
 
         public void SetAddress(string host, int port)
         {

--- a/src/Proto.Actor/ActorSystem.cs
+++ b/src/Proto.Actor/ActorSystem.cs
@@ -53,7 +53,7 @@ namespace Proto
 
         public ActorSystemExtensions Extensions { get; }
 
-        public CancellationToken Toke => _cts.Token;
+        public CancellationToken Token => _cts.Token;
 
         public Task ShutdownAsync()
         {

--- a/src/Proto.Actor/Future/Futures.cs
+++ b/src/Proto.Actor/Future/Futures.cs
@@ -30,8 +30,6 @@ namespace Proto.Future
 
         private FutureProcess(ActorSystem system, CancellationTokenSource? cts) : base(system)
         {
-            system.Token.ThrowIfCancellationRequested();
-            
             _tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             _cts = cts;
 

--- a/src/Proto.Actor/Future/Futures.cs
+++ b/src/Proto.Actor/Future/Futures.cs
@@ -30,6 +30,8 @@ namespace Proto.Future
 
         private FutureProcess(ActorSystem system, CancellationTokenSource? cts) : base(system)
         {
+            system.Token.ThrowIfCancellationRequested();
+            
             _tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             _cts = cts;
 

--- a/src/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/Proto.Cluster.Consul/ConsulProvider.cs
@@ -110,16 +110,12 @@ namespace Proto.Cluster.Consul
             //flag for shutdown. used in thread loops
             _shutdown = true;
 
-            if (!graceful)
+            if (graceful)
             {
-                _logger.LogInformation("Shut down consul provider");
-                return;
+                await DeregisterServiceAsync();
+                _deregistered = true;
             }
-
-            //DeregisterService
-            await DeregisterServiceAsync();
-
-            _deregistered = true;
+           
             _logger.LogInformation("Shut down consul provider");
         }
 

--- a/src/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/Proto.Cluster.Consul/ConsulProvider.cs
@@ -109,12 +109,18 @@ namespace Proto.Cluster.Consul
             _logger.LogInformation("Shutting down consul provider");
             //flag for shutdown. used in thread loops
             _shutdown = true;
-            if (!graceful) return;
+
+            if (!graceful)
+            {
+                _logger.LogInformation("Shut down consul provider");
+                return;
+            }
 
             //DeregisterService
             await DeregisterServiceAsync();
 
             _deregistered = true;
+            _logger.LogInformation("Shut down consul provider");
         }
 
         //TODO: this is never signalled to rest of cluster

--- a/src/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/Proto.Cluster.Consul/ConsulProvider.cs
@@ -50,7 +50,7 @@ namespace Proto.Cluster.Consul
         private string _consulLeaderKey;
         private string _consulServiceInstanceId; //the specific instance id of this node in consul
         private string _consulServiceName; //name of the custer, in consul this means the name of the service
-        private string _consulSessionId;
+     //   private string _consulSessionId;
         private volatile bool _deregistered;
         private string _host;
 
@@ -91,7 +91,7 @@ namespace Proto.Cluster.Consul
             await RegisterMemberAsync();
             StartUpdateTtlLoop();
             StartMonitorMemberStatusChangesLoop();
-            StartLeaderElectionLoop();
+         //   StartLeaderElectionLoop();
         }
 
         public Task StartClientAsync(Cluster cluster)
@@ -123,15 +123,15 @@ namespace Proto.Cluster.Consul
         //it gets hidden until leader blocking wait ends
         public async Task UpdateClusterState(ClusterState state)
         {
-            var json = JsonConvert.SerializeObject(state.BannedMembers);
-            var kvp = new KVPair($"{_consulServiceName}/banned")
-            {
-                Value = Encoding.UTF8.GetBytes(json)
-            };
-
-            var updated = await _client.KV.Put(kvp);
-
-            if (!updated.Response) _logger.LogError("Failed to update cluster state");
+            // var json = JsonConvert.SerializeObject(state.BannedMembers);
+            // var kvp = new KVPair($"{_consulServiceName}/banned")
+            // {
+            //     Value = Encoding.UTF8.GetBytes(json)
+            // };
+            //
+            // var updated = await _client.KV.Put(kvp);
+            //
+            // if (!updated.Response) _logger.LogError("Failed to update cluster state");
         }
 
         private void SetState(Cluster cluster, string clusterName, string host, int port, string[] kinds,
@@ -152,14 +152,14 @@ namespace Proto.Cluster.Consul
             _ = Task.Run(async () =>
                 {
                     var waitIndex = 0ul;
-                    while (!_shutdown)
+                    while (!_shutdown && !_cluster.System.Shutdown.IsCancellationRequested)
                     {
                         var statuses = await _client.Health.Service(_consulServiceName, null, false, new QueryOptions
                             {
                                 WaitIndex = waitIndex,
                                 WaitTime = _blockingWaitTime
                             }
-                        );
+                        ,_cluster.System.Shutdown);
                         if (_deregistered) break;
 
                         _logger.LogDebug("Got status updates from Consul");
@@ -204,112 +204,115 @@ namespace Proto.Cluster.Consul
                     while (!_shutdown)
                     {
                         await _client.Agent.PassTTL("service:" + _consulServiceInstanceId, "");
-                        await Task.Delay(_refreshTtl);
+                        await Task.Delay(_refreshTtl, _cluster.System.Shutdown);
                     }
 
                     _logger.LogInformation("Exiting TTL loop");
                 }
             );
         }
-
-        private void StartLeaderElectionLoop()
-        {
-            _ = Task.Run(async () =>
-                {
-                    try
-                    {
-                        var leaderKey = $"{_consulServiceName}/leader";
-                        var se = new SessionEntry
-                        {
-                            Behavior = SessionBehavior.Delete,
-                            Name = leaderKey,
-                            TTL = TimeSpan.FromSeconds(10)
-                        };
-                        var sessionRes = await _client.Session.Create(se);
-                        var sessionId = sessionRes.Response;
-
-                        //this is used so that leader can update shared cluster state
-                        _consulSessionId = sessionId;
-                        _consulLeaderKey = leaderKey;
-
-                        var json = JsonConvert.SerializeObject(new ConsulLeader
-                            {
-                                Host = _host,
-                                Port = _port,
-                                MemberId = _cluster.Id
-                            }
-                        );
-                        var kvp = new KVPair(leaderKey)
-                        {
-                            Key = leaderKey,
-                            Session = sessionId,
-                            Value = Encoding.UTF8.GetBytes(json)
-                        };
-
-
-                        //don't await this, it will block forever
-                        _ = _client.Session.RenewPeriodic(TimeSpan.FromSeconds(1), sessionId, CancellationToken.None
-                        );
-
-                        var waitIndex = 0ul;
-                        while (!_shutdown)
-                        {
-                            try
-                            {
-                                var aquired = await _client.KV.Acquire(kvp);
-                                var isLeader = aquired.Response;
-
-                                var res = await _client.KV.Get(leaderKey, new QueryOptions
-                                    {
-                                        Consistency = ConsistencyMode.Default,
-                                        WaitIndex = waitIndex,
-                                        WaitTime = TimeSpan.FromSeconds(3)
-                                    }
-                                );
-
-
-                                if (res.Response?.Value is null)
-                                {
-                                    _logger.LogError("No leader info was found");
-                                    await Task.Delay(1000);
-                                    continue;
-                                }
-
-                                var value = res.Response.Value;
-                                var json2 = Encoding.UTF8.GetString(value);
-                                var leader = JsonConvert.DeserializeObject<ConsulLeader>(json2);
-                                waitIndex = res.LastIndex;
-
-                                var bannedMembers = Array.Empty<string>();
-                                var banned = await _client.KV.Get(_consulServiceName + "/banned");
-
-                                if (banned.Response?.Value is not null)
-                                {
-                                    var json3 = Encoding.UTF8.GetString(banned.Response.Value);
-                                    bannedMembers = JsonConvert.DeserializeObject<string[]>(json3);
-                                }
-
-                                _memberList.UpdateLeader(new LeaderInfo(leader.MemberId, leader.Host, leader.Port,
-                                        bannedMembers
-                                    )
-                                );
-                            }
-                            catch (Exception x)
-                            {
-                                _logger.LogError("Failed to read session data {x}", x);
-                            }
-                        }
-
-                        await _client.KV.Release(kvp);
-                        await _client.Session.Destroy(sessionId);
-                    }
-                    catch (Exception x)
-                    {
-                        _logger.LogCritical("Leader Election Failed {x}", x);
-                    }
-                }
-            );
-        }
+        //
+        // private void StartLeaderElectionLoop()
+        // {
+        //     _ = Task.Run(async () =>
+        //         {
+        //             try
+        //             {
+        //                 var leaderKey = $"{_consulServiceName}/leader";
+        //                 var se = new SessionEntry
+        //                 {
+        //                     Behavior = SessionBehavior.Delete,
+        //                     Name = leaderKey,
+        //                     TTL = TimeSpan.FromSeconds(20)
+        //                 };
+        //                 var sessionRes = await _client.Session.Create(se);
+        //                 var sessionId = sessionRes.Response;
+        //
+        //                 //this is used so that leader can update shared cluster state
+        //                 _consulSessionId = sessionId;
+        //                 _consulLeaderKey = leaderKey;
+        //
+        //                 var json = JsonConvert.SerializeObject(new ConsulLeader
+        //                     {
+        //                         Host = _host,
+        //                         Port = _port,
+        //                         MemberId = _cluster.Id
+        //                     }
+        //                 );
+        //                 var kvp = new KVPair(leaderKey)
+        //                 {
+        //                     Key = leaderKey,
+        //                     Session = sessionId,
+        //                     Value = Encoding.UTF8.GetBytes(json)
+        //                 };
+        //
+        //
+        //                 //don't await this, it will block forever
+        //                 _ = _client.Session.RenewPeriodic(TimeSpan.FromSeconds(1), sessionId, CancellationToken.None
+        //                 );
+        //
+        //                 var waitIndex = 0ul;
+        //                 while (!_shutdown && !_cluster.System.Shutdown.IsCancellationRequested)
+        //                 {
+        //                     try
+        //                     {
+        //                         var aquired = await _client.KV.Acquire(kvp,_cluster.System.Shutdown);
+        //                         var isLeader = aquired.Response;
+        //
+        //                         var res = await _client.KV.Get(leaderKey, new QueryOptions
+        //                             {
+        //                                 Consistency = ConsistencyMode.Default,
+        //                                 WaitIndex = waitIndex,
+        //                                 WaitTime = TimeSpan.FromSeconds(3)
+        //                             }
+        //                         ,_cluster.System.Shutdown);
+        //
+        //
+        //                         if (res.Response?.Value is null)
+        //                         {
+        //                             _logger.LogError("No leader info was found");
+        //                             await Task.Delay(1000);
+        //                             continue;
+        //                         }
+        //
+        //                         var value = res.Response.Value;
+        //                         var json2 = Encoding.UTF8.GetString(value);
+        //                         var leader = JsonConvert.DeserializeObject<ConsulLeader>(json2);
+        //                         waitIndex = res.LastIndex;
+        //
+        //                         var bannedMembers = Array.Empty<string>();
+        //                         var banned = await _client.KV.Get(_consulServiceName + "/banned");
+        //
+        //                         if (banned.Response?.Value is not null)
+        //                         {
+        //                             var json3 = Encoding.UTF8.GetString(banned.Response.Value);
+        //                             bannedMembers = JsonConvert.DeserializeObject<string[]>(json3);
+        //                         }
+        //
+        //                         _memberList.UpdateLeader(new LeaderInfo(leader.MemberId, leader.Host, leader.Port,
+        //                                 bannedMembers
+        //                             )
+        //                         );
+        //                     }
+        //                     catch (Exception x)
+        //                     {
+        //                         if (!_cluster.System.Shutdown.IsCancellationRequested)
+        //                         {
+        //                             _logger.LogError("Failed to read session data {x}", x);
+        //                         }
+        //                     }
+        //                 }
+        //
+        //               //  await _client.KV.Release(kvp);
+        //              //   await _client.Session.Destroy(sessionId);
+        //             }
+        //             catch (Exception x)
+        //             {
+        //                 _logger.LogCritical("Leader Election Failed {x}", x);
+        //             }
+        //         }
+        //     );
+        //}
 
         //register this cluster in consul.
         private async Task RegisterMemberAsync()

--- a/src/Proto.Cluster.Identity.MongoDb/MongoIdentityStorage.cs
+++ b/src/Proto.Cluster.Identity.MongoDb/MongoIdentityStorage.cs
@@ -93,6 +93,7 @@ namespace Proto.Cluster.Identity.MongoDb
 
         public async Task RemoveActivation(PID pid, CancellationToken ct)
         {
+            
             Logger.LogDebug("Removing activation: {@PID}", pid);
             await _asyncSemaphore.WaitAsync(_pids.DeleteManyAsync(p => p.UniqueIdentity == pid.Id, ct));
         }

--- a/src/Proto.Cluster.Identity.MongoDb/MongoIdentityStorage.cs
+++ b/src/Proto.Cluster.Identity.MongoDb/MongoIdentityStorage.cs
@@ -154,21 +154,14 @@ namespace Proto.Cluster.Identity.MongoDb
 
         private async Task<PidLookupEntity?> LookupKey(string key, CancellationToken ct)
         {
-
-            for (int i = 0; i < 10; i++)
+            try
             {
-                try
-                {
-                    var res= await _asyncSemaphore.WaitAsync(_pids.Find(x => x.Key == key).Limit(1).SingleOrDefaultAsync(ct));
-                    return res;
-                }
-                catch(MongoConnectionException x)
-                {
-                    Logger.LogWarning(x,"Mongo connection failure, retrying");
-                }
-
-                // ReSharper disable once MethodSupportsCancellation
-                await Task.Delay(i * 1000);
+                var res = await _asyncSemaphore.WaitAsync(_pids.Find(x => x.Key == key).Limit(1).SingleOrDefaultAsync(ct));
+                return res;
+            }
+            catch (MongoConnectionException x)
+            {
+                Logger.LogWarning(x, "Mongo connection failure, retrying");
             }
 
             throw new StorageFailure($"Failed to connect to MongoDB while looking up key {key}");

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -103,6 +103,7 @@ namespace Proto.Cluster
 
         public async Task ShutdownAsync(bool graceful = true)
         {
+            await System.ShutdownAsync();
             Logger.LogInformation("Stopping Cluster {Id}", Id);
 
             await _clusterHeartBeat.ShutdownAsync();

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -105,7 +105,7 @@ namespace Proto.Cluster
         {
             await System.ShutdownAsync();
             Logger.LogInformation("Stopping Cluster {Id}", Id);
-
+            
             await _clusterHeartBeat.ShutdownAsync();
             if (graceful) await IdentityLookup!.ShutdownAsync();
             await Config!.ClusterProvider.ShutdownAsync(graceful);

--- a/src/Proto.Cluster/ClusterHeartBeat.cs
+++ b/src/Proto.Cluster/ClusterHeartBeat.cs
@@ -78,12 +78,20 @@ namespace Proto.Cluster
                         }
                         catch (TimeoutException)
                         {
+                            if (_cluster.System.Token.IsCancellationRequested)
+                            {
+                                return;
+                            }
                             _logger.LogWarning("Heartbeat request for member id {MemberId} Address {Address} timed out",
                                 member.Id, member.Address
                             );
                         }
                         catch (DeadLetterException)
                         {
+                            if (_cluster.System.Token.IsCancellationRequested)
+                            {
+                                return;
+                            }
                             _logger.LogWarning(
                                 "Heartbeat request for member id {MemberId} Address {Address} got dead letter response",
                                 member.Id, member.Address

--- a/src/Proto.Cluster/ClusterHeartBeat.cs
+++ b/src/Proto.Cluster/ClusterHeartBeat.cs
@@ -32,7 +32,7 @@ namespace Proto.Cluster
         private const string ClusterHeartBeatName = "ClusterHeartBeat";
         private readonly Cluster _cluster;
         private readonly RootContext _context;
-        private readonly CancellationTokenSource _ct = new();
+
         private ILogger _logger = null!;
         private PID _pid = null!;
 
@@ -55,7 +55,7 @@ namespace Proto.Cluster
         private async Task HeartBeatLoop()
         {
             await Task.Yield();
-            while (!_ct.IsCancellationRequested)
+            while (!_cluster.System.Shutdown.IsCancellationRequested)
             {
                 try
                 {
@@ -110,7 +110,6 @@ namespace Proto.Cluster
         {
             _logger.LogInformation("Shutting down heartbeat");
             _context.Stop(_pid);
-            _ct.Cancel();
             _logger.LogInformation("Shut down heartbeat");
             return Task.CompletedTask;
         }

--- a/src/Proto.Cluster/ClusterHeartBeat.cs
+++ b/src/Proto.Cluster/ClusterHeartBeat.cs
@@ -78,7 +78,7 @@ namespace Proto.Cluster
                         }
                         catch (TimeoutException)
                         {
-                            if (_cluster.System.Token.IsCancellationRequested)
+                            if (_cluster.System.Shutdown.IsCancellationRequested)
                             {
                                 return;
                             }
@@ -88,7 +88,7 @@ namespace Proto.Cluster
                         }
                         catch (DeadLetterException)
                         {
-                            if (_cluster.System.Token.IsCancellationRequested)
+                            if (_cluster.System.Shutdown.IsCancellationRequested)
                             {
                                 return;
                             }

--- a/src/Proto.Cluster/ClusterHeartBeat.cs
+++ b/src/Proto.Cluster/ClusterHeartBeat.cs
@@ -100,8 +100,10 @@ namespace Proto.Cluster
 
         public Task ShutdownAsync()
         {
+            _logger.LogInformation("Shutting down heartbeat");
             _context.Stop(_pid);
             _ct.Cancel();
+            _logger.LogInformation("Shut down heartbeat");
             return Task.CompletedTask;
         }
     }

--- a/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
@@ -80,13 +80,15 @@
 
         internal PID RemotePlacementActor(string address)
         {
-            _system.Token.ThrowIfCancellationRequested();
             return PID.FromAddress(address, PlacementActorName);
         }
 
         public Task RemovePidAsync(PID pid, CancellationToken ct)
         {
-            _system.Token.ThrowIfCancellationRequested();
+            if (_system.Token.IsCancellationRequested)
+            {
+                return Task.CompletedTask;
+            }
             return Storage.RemoveActivation(pid, ct);
         }
 

--- a/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
@@ -16,7 +16,7 @@
         internal MemberList MemberList;
         private PID _placementActor;
         private ActorSystem _system;
-        private PID _router;
+        private PID _worker;
         private string _memberId;
 
         public IdentityStorageLookup(IIdentityStorage storage)
@@ -28,7 +28,7 @@
         {
             var msg = new GetPid(clusterIdentity, ct);
 
-            var res = await _system.Root.RequestAsync<PidResult>(_router, msg, ct);
+            var res = await _system.Root.RequestAsync<PidResult>(_worker, msg, ct);
             return res?.Pid;
         }
 
@@ -45,7 +45,7 @@
 
            
 
-            _router = _system.Root.Spawn(workerProps);
+            _worker = _system.Root.Spawn(workerProps);
 
             //hook up events
             cluster.System.EventStream.Subscribe<ClusterTopology>(e =>
@@ -66,9 +66,8 @@
 
         public async Task ShutdownAsync()
         {
-            
+            await Cluster.System.Root.StopAsync(_worker);
             if (!_isClient) await Cluster.System.Root.StopAsync(_placementActor);
-            await Cluster.System.Root.StopAsync(_router);
 
             await RemoveMemberAsync(_memberId);
         }

--- a/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
@@ -85,7 +85,7 @@
 
         public Task RemovePidAsync(PID pid, CancellationToken ct)
         {
-            if (_system.Token.IsCancellationRequested)
+            if (_system.Shutdown.IsCancellationRequested)
             {
                 return Task.CompletedTask;
             }

--- a/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
@@ -43,9 +43,9 @@
             var workerProps = Props.FromProducer(() => new IdentityStorageWorker(this));
             //TODO: should pool size be configurable?
 
-            var routerProps = _system.Root.NewConsistentHashPool(workerProps, 1);
+           
 
-            _router = _system.Root.Spawn(routerProps);
+            _router = _system.Root.Spawn(workerProps);
 
             //hook up events
             cluster.System.EventStream.Subscribe<ClusterTopology>(e =>

--- a/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
+++ b/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
@@ -73,7 +73,7 @@ namespace Proto.Cluster.Identity
 
         private async Task Terminated(IContext context, Terminated msg)
         {
-            if (context.System.Token.IsCancellationRequested)
+            if (context.System.Shutdown.IsCancellationRequested)
             {
                 return;
             }

--- a/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
+++ b/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
@@ -67,7 +67,7 @@ namespace Proto.Cluster.Identity
         private Task Tick(IContext context)
         {
             var count = _myActors.Count;
-            _logger.LogInformation("Statistics: Actor Count {ActorCount}", count);
+            _logger.LogDebug("Statistics: Actor Count {ActorCount}", count);
             return Task.CompletedTask;
         }
 

--- a/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
+++ b/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
@@ -39,7 +39,7 @@ namespace Proto.Cluster.Identity
         {
             Started _             => Started(context),
             Tick _                => Tick(context),
-            Terminated msg        => Terminated(msg),
+            Terminated msg        => Terminated(context, msg),
             ActivationRequest msg => ActivationRequest(context, msg),
             _                     => Task.CompletedTask
         };
@@ -57,8 +57,9 @@ namespace Proto.Cluster.Identity
             return Task.CompletedTask;
         }
 
-        private async Task Terminated(Terminated msg)
+        private async Task Terminated(IContext context, Terminated msg)
         {
+            
             //TODO: if this turns out to be perf intensive, lets look at optimizations for reverse lookups
             var (identity, pid) = _myActors.FirstOrDefault(kvp => kvp.Value.Equals(msg.Who));
             _myActors.Remove(identity);

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -224,7 +224,7 @@ namespace Proto.Cluster.Identity
             }
             catch (Exception e)
             {
-                if (_shouldThrottle().IsOpen())
+                if (!_cluster.System.Shutdown.IsCancellationRequested && _shouldThrottle().IsOpen() && _memberList.ContainsMemberId(activator.Id))
                     _logger.LogError(e, "Error occured requesting remote PID {@Request}", req);
             }
 

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -19,8 +19,7 @@ namespace Proto.Cluster.Identity
         private readonly MemberList _memberList;
         private readonly IIdentityStorage _storage;
 
-        private readonly Dictionary<ClusterIdentity, Task<PID?>> _inProgress =
-            new();
+        private readonly Dictionary<ClusterIdentity, Task<PID?>> _inProgress = new();
 
         private readonly ShouldThrottle _shouldThrottle;
 
@@ -48,13 +47,13 @@ namespace Proto.Cluster.Identity
             }
 
             var clusterIdentity = msg.ClusterIdentity;
-        //    var ct = msg.CancellationToken;
-            //
-            // if (ct.IsCancellationRequested)
-            // {
-            //     _logger.LogError("CT already timed out....");
-            //     return Task.CompletedTask;
-            // }
+            var ct = msg.CancellationToken;
+            
+            if (ct.IsCancellationRequested)
+            {
+                //_logger.LogError("CT already timed out....");
+                return Task.CompletedTask;
+            }
             
             if (_cluster.PidCache.TryGet(clusterIdentity, out var existing))
             {
@@ -179,7 +178,7 @@ namespace Proto.Cluster.Identity
             }
             catch (Exception e)
             {
-                if (_cluster.System.Token.IsCancellationRequested)
+                if (_cluster.System.Shutdown.IsCancellationRequested)
                 {
                     return null;
                 }

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -27,7 +27,7 @@ namespace Proto.Cluster.Identity
         public IdentityStorageWorker(IdentityStorageLookup storageLookup)
         {
             _shouldThrottle = Throttle.Create(
-                5,
+                0,
                 TimeSpan.FromSeconds(5),
                 i => _logger.LogInformation("Throttled {LogCount} IdentityStorageWorker logs.", i)
             );

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -173,6 +173,10 @@ namespace Proto.Cluster.Identity
             }
             catch (Exception e)
             {
+                if (_cluster.System.Token.IsCancellationRequested)
+                {
+                    return null;
+                }
                 if (_shouldThrottle().IsOpen())
                     _logger.LogError(e, "Failed to get PID for {ClusterIdentity}", clusterIdentity.ToShortString());
                 return null;

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -11,7 +11,7 @@ namespace Proto.Cluster.Identity
 
     internal class IdentityStorageWorker : IActor
     {
-        private static readonly ConcurrentSet<string> StaleMembers = new ConcurrentSet<string>();
+        private static readonly ConcurrentSet<string> StaleMembers = new();
 
         private readonly Cluster _cluster;
         private readonly ILogger _logger = Log.CreateLogger<IdentityStorageWorker>();
@@ -20,7 +20,7 @@ namespace Proto.Cluster.Identity
         private readonly IIdentityStorage _storage;
 
         private readonly Dictionary<ClusterIdentity, Task<PID?>> _inProgress =
-            new Dictionary<ClusterIdentity, Task<PID?>>();
+            new();
 
         private readonly ShouldThrottle _shouldThrottle;
 
@@ -47,9 +47,12 @@ namespace Proto.Cluster.Identity
                 return Task.CompletedTask;
             }
 
-            if (_cluster.PidCache.TryGet(msg.ClusterIdentity, out var existing))
+            var clusterIdentity = msg.ClusterIdentity;
+            var ct = msg.CancellationToken;
+            
+            if (_cluster.PidCache.TryGet(clusterIdentity, out var existing))
             {
-                _logger.LogDebug("Found {ClusterIdentity} in pidcache", msg.ClusterIdentity.ToShortString());
+                _logger.LogDebug("Found {ClusterIdentity} in pidcache", clusterIdentity.ToShortString());
                 context.Respond(new PidResult
                     {
                         Pid = existing
@@ -60,7 +63,7 @@ namespace Proto.Cluster.Identity
 
             try
             {
-                if (_inProgress.TryGetValue(msg.ClusterIdentity, out Task<PID?> getPid) && getPid.IsCompleted)
+                if (_inProgress.TryGetValue(clusterIdentity, out Task<PID?> getPid) && getPid.IsCompleted)
                 {
                     try
                     {
@@ -69,7 +72,7 @@ namespace Proto.Cluster.Identity
                             var pid = getPid.Result;
                             if (pid != null)
                             {
-                                _cluster.PidCache.TryAdd(msg.ClusterIdentity, pid);
+                                _cluster.PidCache.TryAdd(clusterIdentity, pid);
                             }
 
                             context.Respond(new PidResult
@@ -82,19 +85,19 @@ namespace Proto.Cluster.Identity
                         else
                         {
                             if (_shouldThrottle().IsOpen())
-                                _logger.LogWarning(getPid.Exception, "GetWithGlobalLock for {ClusterIdentity} failed", msg.ClusterIdentity.ToShortString());
+                                _logger.LogWarning(getPid.Exception, "GetWithGlobalLock for {ClusterIdentity} failed", clusterIdentity.ToShortString());
                         }
                     }
                     finally
                     {
-                        _inProgress.Remove(msg.ClusterIdentity);
+                        _inProgress.Remove(clusterIdentity);
                     }
                 }
 
                 if (getPid == null)
                 {
-                    getPid = GetWithGlobalLock(context.Sender!, msg.ClusterIdentity, context.CancellationToken);
-                    _inProgress[msg.ClusterIdentity] = getPid;
+                    getPid = GetWithGlobalLock(context.Sender!, clusterIdentity, ct);
+                    _inProgress[clusterIdentity] = getPid;
                 }
 
                 context.ReenterAfter(getPid, task =>
@@ -118,7 +121,7 @@ namespace Proto.Cluster.Identity
                         }
                         finally
                         {
-                            _inProgress.Remove(msg.ClusterIdentity);
+                            _inProgress.Remove(clusterIdentity);
                         }
                     }
                 );

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -27,7 +27,7 @@ namespace Proto.Cluster.Identity
         public IdentityStorageWorker(IdentityStorageLookup storageLookup)
         {
             _shouldThrottle = Throttle.Create(
-                0,
+                10,
                 TimeSpan.FromSeconds(5),
                 i => _logger.LogInformation("Throttled {LogCount} IdentityStorageWorker logs.", i)
             );
@@ -48,7 +48,13 @@ namespace Proto.Cluster.Identity
             }
 
             var clusterIdentity = msg.ClusterIdentity;
-            var ct = msg.CancellationToken;
+        //    var ct = msg.CancellationToken;
+            //
+            // if (ct.IsCancellationRequested)
+            // {
+            //     _logger.LogError("CT already timed out....");
+            //     return Task.CompletedTask;
+            // }
             
             if (_cluster.PidCache.TryGet(clusterIdentity, out var existing))
             {
@@ -96,7 +102,7 @@ namespace Proto.Cluster.Identity
 
                 if (getPid == null)
                 {
-                    getPid = GetWithGlobalLock(context.Sender!, clusterIdentity, ct);
+                    getPid = GetWithGlobalLock(context.Sender!, clusterIdentity, CancellationToken.None);
                     _inProgress[clusterIdentity] = getPid;
                 }
 

--- a/src/Proto.Cluster/Member/MemberList.cs
+++ b/src/Proto.Cluster/Member/MemberList.cs
@@ -226,7 +226,7 @@ namespace Proto.Cluster
             _members = _members.Remove(memberThatLeft.Id);
 
             var endpointTerminated = new EndpointTerminatedEvent {Address = memberThatLeft.Address};
-            _logger.LogInformation("Published event {@EndpointTerminated}", endpointTerminated);
+            _logger.LogDebug("Published event {@EndpointTerminated}", endpointTerminated);
             _cluster.System.EventStream.Publish(endpointTerminated);
         }
 
@@ -254,10 +254,14 @@ namespace Proto.Cluster
         ///     broadcast a message to all members eventstream
         /// </summary>
         /// <param name="message"></param>
-        public void BroadcastEvent(object message)
+        public void BroadcastEvent(object message, bool includeSelf = true)
         {
             foreach (var m in _members.ToArray())
             {
+                if (!includeSelf && m.Key == _cluster.Id.ToString())
+                {
+                    continue;
+                }
                 var pid = PID.FromAddress(m.Value.Address, "eventstream");
                 try
                 {

--- a/src/Proto.Cluster/Protos.proto
+++ b/src/Proto.Cluster/Protos.proto
@@ -78,3 +78,7 @@ message HeartbeatRequest {
 message HeartbeatResponse {
     uint32 actor_count = 1;
 }
+
+message GracefulShutdown {
+  string member_id = 3;
+}

--- a/src/Proto.Cluster/RequestAsyncStrategy.cs
+++ b/src/Proto.Cluster/RequestAsyncStrategy.cs
@@ -119,7 +119,7 @@ namespace Proto.Cluster
                     }
                     
                     if (_requestLogThrottle().IsOpen())
-                        _logger.LogWarning("Failed to get PID from IIdentityLookup, {cancel}",context.System.Token.IsCancellationRequested);
+                        _logger.LogWarning("Failed to get PID from IIdentityLookup");
                     await Task.Delay(delay, CancellationToken.None);
                 }
             }

--- a/src/Proto.Cluster/RequestAsyncStrategy.cs
+++ b/src/Proto.Cluster/RequestAsyncStrategy.cs
@@ -48,7 +48,7 @@ namespace Proto.Cluster
             var i = 0;
             while (!ct.IsCancellationRequested)
             {
-                if (context.System.Token.IsCancellationRequested)
+                if (context.System.Shutdown.IsCancellationRequested)
                 {
                     return default;
                 }
@@ -70,7 +70,7 @@ namespace Proto.Cluster
                 {
                     var pid = await _identityLookup.GetAsync(clusterIdentity, ct);
                     
-                    if (context.System.Token.IsCancellationRequested)
+                    if (context.System.Shutdown.IsCancellationRequested)
                     {
                         return default;
                     }
@@ -93,7 +93,7 @@ namespace Proto.Cluster
                         clusterIdentity.Identity, clusterIdentity.Kind, message, pid
                     );
                     
-                    if (context.System.Token.IsCancellationRequested)
+                    if (context.System.Shutdown.IsCancellationRequested)
                     {
                         return default;
                     }
@@ -113,7 +113,7 @@ namespace Proto.Cluster
                 }
                 catch
                 {
-                    if (context.System.Token.IsCancellationRequested)
+                    if (context.System.Shutdown.IsCancellationRequested)
                     {
                         return default;
                     }
@@ -141,19 +141,19 @@ namespace Proto.Cluster
             }
             catch (DeadLetterException)
             {
-                if (!context.System.Token.IsCancellationRequested && _requestLogThrottle().IsOpen())
+                if (!context.System.Shutdown.IsCancellationRequested && _requestLogThrottle().IsOpen())
                     _logger.LogInformation("TryRequestAsync failed, dead PID from {Source}", source);
                 _pidCache.RemoveByVal(clusterIdentity, cachedPid);
                 return (ResponseStatus.DeadLetter, default)!;
             }
             catch (TimeoutException)
             {
-                if (!context.System.Token.IsCancellationRequested && _requestLogThrottle().IsOpen())
+                if (!context.System.Shutdown.IsCancellationRequested && _requestLogThrottle().IsOpen())
                     _logger.LogWarning("TryRequestAsync timed out, PID from {Source}", source);
             }
             catch (Exception x)
             {
-                if (!context.System.Token.IsCancellationRequested && _requestLogThrottle().IsOpen())
+                if (!context.System.Shutdown.IsCancellationRequested && _requestLogThrottle().IsOpen())
                     _logger.LogWarning(x, "TryRequestAsync failed with exception, PID from {Source}", source);
             }
 

--- a/src/Proto.Cluster/RequestAsyncStrategy.cs
+++ b/src/Proto.Cluster/RequestAsyncStrategy.cs
@@ -34,8 +34,8 @@ namespace Proto.Cluster
             _context = context;
             _logger = logger;
             _requestLogThrottle = Throttle.Create(
-                0,
-                TimeSpan.FromSeconds(5),
+                3,
+                TimeSpan.FromSeconds(2),
                 i => _logger.LogInformation("Throttled {LogCount} TryRequestAsync logs.", i)
             );
         }

--- a/src/Proto.Cluster/RequestAsyncStrategy.cs
+++ b/src/Proto.Cluster/RequestAsyncStrategy.cs
@@ -34,7 +34,7 @@ namespace Proto.Cluster
             _context = context;
             _logger = logger;
             _requestLogThrottle = Throttle.Create(
-                5,
+                0,
                 TimeSpan.FromSeconds(5),
                 i => _logger.LogInformation("Throttled {LogCount} TryRequestAsync logs.", i)
             );
@@ -141,19 +141,19 @@ namespace Proto.Cluster
             }
             catch (DeadLetterException)
             {
-                if (_requestLogThrottle().IsOpen())
+                if (!context.System.Token.IsCancellationRequested && _requestLogThrottle().IsOpen())
                     _logger.LogInformation("TryRequestAsync failed, dead PID from {Source}", source);
                 _pidCache.RemoveByVal(clusterIdentity, cachedPid);
                 return (ResponseStatus.DeadLetter, default)!;
             }
             catch (TimeoutException)
             {
-                if (_requestLogThrottle().IsOpen())
+                if (!context.System.Token.IsCancellationRequested && _requestLogThrottle().IsOpen())
                     _logger.LogWarning("TryRequestAsync timed out, PID from {Source}", source);
             }
             catch (Exception x)
             {
-                if (_requestLogThrottle().IsOpen())
+                if (!context.System.Token.IsCancellationRequested && _requestLogThrottle().IsOpen())
                     _logger.LogWarning(x, "TryRequestAsync failed with exception, PID from {Source}", source);
             }
 

--- a/src/Proto.Remote.GrpcCore/GrpcCoreRemote.cs
+++ b/src/Proto.Remote.GrpcCore/GrpcCoreRemote.cs
@@ -90,7 +90,7 @@ namespace Proto.Remote.GrpcCore
                     await _server.KillAsync();
                 }
 
-                Logger.LogDebug(
+                Logger.LogInformation(
                     "Proto.Actor server stopped on {Address}. Graceful: {Graceful}",
                     System.Address, graceful
                 );

--- a/src/Proto.Remote/EndpointManager.cs
+++ b/src/Proto.Remote/EndpointManager.cs
@@ -85,7 +85,7 @@ namespace Proto.Remote
 
         private void OnEndpointTerminated(EndpointTerminatedEvent evt)
         {
-            Logger.LogInformation("[EndpointManager] Endpoint {Address} terminated, removing from connections", evt.Address);
+            Logger.LogDebug("[EndpointManager] Endpoint {Address} terminated, removing from connections", evt.Address);
             lock (_synLock)
             {
                 if (_connections.TryRemove(evt.Address, out var endpoint))

--- a/src/Proto.Remote/EndpointManager.cs
+++ b/src/Proto.Remote/EndpointManager.cs
@@ -85,7 +85,7 @@ namespace Proto.Remote
 
         private void OnEndpointTerminated(EndpointTerminatedEvent evt)
         {
-            Logger.LogDebug("[EndpointManager] Endpoint {Address} terminated removing from connections", evt.Address);
+            Logger.LogInformation("[EndpointManager] Endpoint {Address} terminated, removing from connections", evt.Address);
             lock (_synLock)
             {
                 if (_connections.TryRemove(evt.Address, out var endpoint))

--- a/src/Proto.Remote/EndpointManager.cs
+++ b/src/Proto.Remote/EndpointManager.cs
@@ -17,8 +17,8 @@ namespace Proto.Remote
     public class EndpointManager
     {
         private static readonly ILogger Logger = Log.CreateLogger<EndpointManager>();
-        private readonly ConcurrentDictionary<string, PID> _connections = new ConcurrentDictionary<string, PID>();
-        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private readonly ConcurrentDictionary<string, PID> _connections = new();
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
         private readonly ActorSystem _system;
         private readonly EventStreamSubscription<object>? _endpointConnectedEvnSub;
         private readonly EventStreamSubscription<object>? _endpointTerminatedEvnSub;


### PR DESCRIPTION
Global Killswitch WiP.

This adds a CancellationTokenSource to the ActorSystem.
Whenever system.ShutdownAsync is called, the token is cancelled.
This way, other subsystems can check if the token is cancelled

There are a lot of moving parts, requests, heartbeats, endpoints etc that all should interact with this token.

It's a bit of trial and error on where to use the token and if it should just silently return, or throw in those cases.

at the very least, the shutdown process is clean now and will unregister whatever should be unregistered.

cc @Damian-P @mhelleborg @alexeyzimarev 