### PR TITLE
System ID

### DIFF
--- a/src/Proto.Actor/ActorSystem.cs
+++ b/src/Proto.Actor/ActorSystem.cs
@@ -14,6 +14,7 @@ namespace Proto
     [PublicAPI]
     public class ActorSystem
     {
+        public Guid Id { get; } = Guid.NewGuid();
         //  public static readonly ActorSystem Default = new ActorSystem();
         internal const string NoHost = "nonhost";
         private string _host = NoHost;

--- a/src/Proto.Actor/ActorSystem.cs
+++ b/src/Proto.Actor/ActorSystem.cs
@@ -14,7 +14,7 @@ namespace Proto
     [PublicAPI]
     public class ActorSystem
     {
-        public Guid Id { get; } = Guid.NewGuid();
+        public string Id { get; } = Guid.NewGuid().ToString("N");
         //  public static readonly ActorSystem Default = new ActorSystem();
         internal const string NoHost = "nonhost";
         private string _host = NoHost;

--- a/src/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/Proto.Cluster.Consul/ConsulProvider.cs
@@ -335,7 +335,7 @@ namespace Proto.Cluster.Consul
                     //if a node with host X and port Y, joins, then leaves, then joins again.
                     //we need a way to distinguish the new node from the old node.
                     //this is what this ID is for
-                    {"id", _cluster.System.Id.ToString()}
+                    {"id", _cluster.System.Id}
                 }
             };
             await _client.Agent.ServiceRegister(s);

--- a/src/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/Proto.Cluster.Consul/ConsulProvider.cs
@@ -138,7 +138,7 @@ namespace Proto.Cluster.Consul
             MemberList memberList)
         {
             _cluster = cluster;
-            _consulServiceInstanceId = $"{clusterName}-{_cluster.Id}@{host}:{port}";
+            _consulServiceInstanceId = $"{clusterName}-{_cluster.System.Id}@{host}:{port}";
             _consulServiceName = clusterName;
             _host = host;
             _port = port;
@@ -335,7 +335,7 @@ namespace Proto.Cluster.Consul
                     //if a node with host X and port Y, joins, then leaves, then joins again.
                     //we need a way to distinguish the new node from the old node.
                     //this is what this ID is for
-                    {"id", _cluster.Id.ToString()}
+                    {"id", _cluster.System.Id.ToString()}
                 }
             };
             await _client.Agent.ServiceRegister(s);

--- a/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
@@ -106,7 +106,7 @@ namespace Proto.Cluster.Kubernetes
             {
                 [LabelCluster] = _clusterName,
                 [LabelPort] = _port.ToString(),
-                [LabelMemberId] = _cluster.Id.ToString()
+                [LabelMemberId] = _cluster.System.Id.ToString()
             };
 
             foreach (var kind in _kinds)
@@ -149,7 +149,7 @@ namespace Proto.Cluster.Kubernetes
                     Address = _address,
                     Port = _port,
                     Kinds = _kinds,
-                    MemberId = _cluster.Id.ToString()
+                    MemberId = _cluster.System.Id.ToString()
                 }
             );
         }

--- a/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
@@ -106,7 +106,7 @@ namespace Proto.Cluster.Kubernetes
             {
                 [LabelCluster] = _clusterName,
                 [LabelPort] = _port.ToString(),
-                [LabelMemberId] = _cluster.System.Id.ToString()
+                [LabelMemberId] = _cluster.System.Id
             };
 
             foreach (var kind in _kinds)
@@ -149,7 +149,7 @@ namespace Proto.Cluster.Kubernetes
                     Address = _address,
                     Port = _port,
                     Kinds = _kinds,
-                    MemberId = _cluster.System.Id.ToString()
+                    MemberId = _cluster.System.Id
                 }
             );
         }

--- a/src/Proto.Cluster.TestProvider/AgentServiceRegistration.cs
+++ b/src/Proto.Cluster.TestProvider/AgentServiceRegistration.cs
@@ -9,7 +9,7 @@ namespace Proto.Cluster.Testing
 {
     public class AgentServiceRegistration
     {
-        public Guid ID { get; set; }
+        public string ID { get; set; }
         public string Host { get; set; }
         public int Port { get; set; }
         public string[] Kinds { get; set; }

--- a/src/Proto.Cluster.TestProvider/InMemAgent.cs
+++ b/src/Proto.Cluster.TestProvider/InMemAgent.cs
@@ -11,7 +11,7 @@ namespace Proto.Cluster.Testing
 {
     public class AgentServiceStatus
     {
-        public Guid ID { get; set; }
+        public string ID { get; set; }
         public DateTimeOffset TTL { get; set; }
         public bool Alive => DateTimeOffset.Now - TTL <= TimeSpan.FromSeconds(5);
 
@@ -24,7 +24,7 @@ namespace Proto.Cluster.Testing
 
     public sealed class InMemAgent
     {
-        private readonly ConcurrentDictionary<Guid, AgentServiceStatus> _services = new();
+        private readonly ConcurrentDictionary<string, AgentServiceStatus> _services = new();
 
         public event EventHandler StatusUpdate;
 
@@ -46,13 +46,13 @@ namespace Proto.Cluster.Testing
             OnStatusUpdate(EventArgs.Empty);
         }
 
-        public void DeregisterService(Guid id)
+        public void DeregisterService(string id)
         {
             _services.TryRemove(id, out _);
             OnStatusUpdate(EventArgs.Empty);
         }
 
-        public void RefreshServiceTTL(Guid id)
+        public void RefreshServiceTTL(string id)
         {
             //TODO: this is racy, but yolo for now
             if (_services.TryGetValue(id, out var service)) service.TTL = DateTimeOffset.Now;

--- a/src/Proto.Cluster.TestProvider/TestProvider.cs
+++ b/src/Proto.Cluster.TestProvider/TestProvider.cs
@@ -20,7 +20,7 @@ namespace Proto.Cluster.Testing
         private string _clusterName;
 
         private ulong _eventId;
-        private Guid _id;
+        private string _id;
         private MemberList _memberList;
         private ActorSystem _system;
         private Timer _ttlReportTimer;
@@ -37,7 +37,7 @@ namespace Proto.Cluster.Testing
             var clusterName = cluster.Config.ClusterName;
             var (host, port) = cluster.System.GetAddress();
             var kinds = cluster.GetClusterKinds();
-            _id = cluster.Id;
+            _id = cluster.System.Id;
             _clusterName = clusterName;
             _system = cluster.System;
             _memberList = memberList;
@@ -61,7 +61,7 @@ namespace Proto.Cluster.Testing
             var memberList = cluster.MemberList;
             var clusterName = cluster.Config.ClusterName;
 
-            _id = cluster.Id;
+            _id = cluster.System.Id;
             _clusterName = clusterName;
             _system = cluster.System;
             _memberList = memberList;

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -24,8 +24,6 @@ namespace Proto.Cluster
         public Cluster(ActorSystem system, ClusterConfig config)
         {
             system.Extensions.Register(this);
-
-            Id = Guid.NewGuid();
             PidCache = new PidCache();
             System = system;
             Config = config;
@@ -42,10 +40,10 @@ namespace Proto.Cluster
             );
         }
 
+        public Guid Id => System.Id;
+
         public ILogger Logger { get; private set; } = null!;
         public IClusterContext ClusterContext { get; private set; } = null!;
-
-        public Guid Id { get; }
 
         public ClusterConfig Config { get; }
 
@@ -104,14 +102,14 @@ namespace Proto.Cluster
         public async Task ShutdownAsync(bool graceful = true)
         {
             await System.ShutdownAsync();
-            Logger.LogInformation("Stopping Cluster {Id}", Id);
+            Logger.LogInformation("Stopping Cluster {Id}", System.Id);
             
             await _clusterHeartBeat.ShutdownAsync();
             if (graceful) await IdentityLookup!.ShutdownAsync();
             await Config!.ClusterProvider.ShutdownAsync(graceful);
             await Remote.ShutdownAsync(graceful);
 
-            Logger.LogInformation("Stopped Cluster {Id}", Id);
+            Logger.LogInformation("Stopped Cluster {Id}", System.Id);
         }
 
         public Task<PID?> GetAsync(string identity, string kind) => GetAsync(identity, kind, CancellationToken.None);

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -40,8 +40,6 @@ namespace Proto.Cluster
             );
         }
 
-        public Guid Id => System.Id;
-
         public ILogger Logger { get; private set; } = null!;
         public IClusterContext ClusterContext { get; private set; } = null!;
 

--- a/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
@@ -35,7 +35,7 @@
         {
             Cluster = cluster;
             _system = cluster.System;
-            _memberId = cluster.System.Id.ToString();
+            _memberId = cluster.System.Id;
             MemberList = cluster.MemberList;
             _isClient = isClient;
 

--- a/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
@@ -35,7 +35,7 @@
         {
             Cluster = cluster;
             _system = cluster.System;
-            _memberId = cluster.Id.ToString();
+            _memberId = cluster.System.Id.ToString();
             MemberList = cluster.MemberList;
             _isClient = isClient;
 

--- a/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
+++ b/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
@@ -139,7 +139,7 @@ namespace Proto.Cluster.Identity
             var spawnLock = new SpawnLock(msg.RequestId, msg.ClusterIdentity);
             try
             {
-                _identityLookup.Storage.StoreActivation(_cluster.System.Id.ToString(), spawnLock, pid,
+                _identityLookup.Storage.StoreActivation(_cluster.System.Id, spawnLock, pid,
                     context.CancellationToken
                 );
             }

--- a/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
+++ b/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
@@ -139,7 +139,7 @@ namespace Proto.Cluster.Identity
             var spawnLock = new SpawnLock(msg.RequestId, msg.ClusterIdentity);
             try
             {
-                _identityLookup.Storage.StoreActivation(_cluster.Id.ToString(), spawnLock, pid,
+                _identityLookup.Storage.StoreActivation(_cluster.System.Id.ToString(), spawnLock, pid,
                     context.CancellationToken
                 );
             }

--- a/src/Proto.Cluster/Member/MemberList.cs
+++ b/src/Proto.Cluster/Member/MemberList.cs
@@ -256,13 +256,13 @@ namespace Proto.Cluster
         /// <param name="message"></param>
         public void BroadcastEvent(object message, bool includeSelf = true)
         {
-            foreach (var m in _members.ToArray())
+            foreach (var (id, member) in _members.ToArray())
             {
-                if (!includeSelf && m.Key == _cluster.System.Id.ToString())
+                if (!includeSelf && id == _cluster.System.Id)
                 {
                     continue;
                 }
-                var pid = PID.FromAddress(m.Value.Address, "eventstream");
+                var pid = PID.FromAddress(member.Address, "eventstream");
                 try
                 {
                     _system.Root.Send(pid, message);

--- a/src/Proto.Cluster/Member/MemberList.cs
+++ b/src/Proto.Cluster/Member/MemberList.cs
@@ -60,7 +60,7 @@ namespace Proto.Cluster
         //TODO: actually use this to prevent banned members from rejoining
         private ConcurrentSet<string> _bannedMembers { get; init; }
 
-        public bool IsLeader => _cluster.Id.Equals(_leader?.MemberId);
+        public bool IsLeader => _cluster.System.Id.Equals(_leader?.MemberId);
 
         public Member? GetActivator(string kind, string requestSourceAddress)
         {
@@ -258,7 +258,7 @@ namespace Proto.Cluster
         {
             foreach (var m in _members.ToArray())
             {
-                if (!includeSelf && m.Key == _cluster.Id.ToString())
+                if (!includeSelf && m.Key == _cluster.System.Id.ToString())
                 {
                     continue;
                 }


### PR DESCRIPTION
Moving ID from Cluster to ActorSystem.
Changed ID from Guid to string. this opens up for better compat with new cluster providers and other language implementations. and if we ever for some reason want to have named members.
