### PR TITLE
minor fix to hashcode in HashedConcurrentDictionary

### DIFF
--- a/src/Proto.Actor/HashedConcurrentDictionary.cs
+++ b/src/Proto.Actor/HashedConcurrentDictionary.cs
@@ -29,7 +29,7 @@ namespace Proto
 
         private Partition GetPartition(string key)
         {
-            var hash = key.GetHashCode() & 0x7FFFFFFF % HashSize;
+            var hash = (key.GetHashCode() & 0x7FFFFFFF) % HashSize;
             var p = _partitions[hash];
             return p;
         }


### PR DESCRIPTION
## Description

Previous fix in this area (from `Math.Abs`) was done on my suggestion, that in rare cases hashcode can be `int.MinValue` which will make `Math.Abs` fail with `ArithmeticException` (or `OverflowException`, one of those two).

Unfortunately, previous fix is missing parenthesis which may cause hash clustering if table size is not power of 2.
What is actually doing right now is: `hash & (HashSize - 1)` as long as HashSize is 2^n, but, if it is not, lets say 1000 it will be reduced to `hash & 0x2d7` which makes some bits always 0, which leads to clustering.

This PR fixes it specifying correct order of operations: remove sign (`& 0x7FFFFFFF`) first and then divide (`% HashSize`)

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes potential issue)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works

`HashedConcurrentDictionary` is internal class and change is minor (no tests existed before, either). I reran all `ProcessRegistry` tests, of course.

Some tests for hash functions can be written though - for example calculating standard deviation to find hash functions with bad distribution, but in this very case I don't think it is worth it.