### PR TITLE
Moved build into dockerfiles for ClusterGrainHelloWorld example, and …

### DIFF
--- a/examples/ClusterGrainHelloWorld/Node1/Dockerfile
+++ b/examples/ClusterGrainHelloWorld/Node1/Dockerfile
@@ -1,10 +1,10 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.0-alpine3.10
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS base
+COPY . .
+WORKDIR ./examples/ClusterGrainHelloWorld/Node1
+RUN dotnet publish -c Release -r linux-x64 Node1.csproj
 
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.8/main' >> /etc/apk/repositories && \
-    apk update --no-cache && \
-    apk add --no-cache bash libc6-compat=1.1.19-r11
-
-ADD ./bin/Release/netcoreapp3.1/publish/ /app
+FROM mcr.microsoft.com/dotnet/runtime:5.0 as publish
+COPY --from=base ./examples/ClusterGrainHelloWorld/Node1/bin/Release/net5.0/linux-x64/publish /app
 
 WORKDIR /app
 EXPOSE 12001

--- a/examples/ClusterGrainHelloWorld/Node2/Dockerfile
+++ b/examples/ClusterGrainHelloWorld/Node2/Dockerfile
@@ -1,11 +1,15 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.0-alpine3.10
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS base
+COPY . .
+WORKDIR ./examples/ClusterGrainHelloWorld/Node2
+RUN dotnet publish -c Release -r linux-x64 Node2.csproj
 
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.8/main' >> /etc/apk/repositories && \
-    apk update --no-cache && \
-    apk add --no-cache bash libc6-compat=1.1.19-r11
+FROM mcr.microsoft.com/dotnet/runtime:5.0 as publish
+#RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.8/main' >> /etc/apk/repositories && \
+#    apk update --no-cache && \
+#    apk add --no-cache bash libc6-compat=1.1.19-r11
 
-ADD ./bin/Release/netcoreapp3.1/publish/ /app
+COPY --from=base ./examples/ClusterGrainHelloWorld/Node2/bin/Release/net5.0/linux-x64/publish /app
 
 WORKDIR /app
-EXPOSE 12000
+EXPOSE 12001
 ENTRYPOINT [ "dotnet", "Node2.dll" ]

--- a/examples/ClusterGrainHelloWorld/Node2/Dockerfile
+++ b/examples/ClusterGrainHelloWorld/Node2/Dockerfile
@@ -4,10 +4,6 @@ WORKDIR ./examples/ClusterGrainHelloWorld/Node2
 RUN dotnet publish -c Release -r linux-x64 Node2.csproj
 
 FROM mcr.microsoft.com/dotnet/runtime:5.0 as publish
-#RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.8/main' >> /etc/apk/repositories && \
-#    apk update --no-cache && \
-#    apk add --no-cache bash libc6-compat=1.1.19-r11
-
 COPY --from=base ./examples/ClusterGrainHelloWorld/Node2/bin/Release/net5.0/linux-x64/publish /app
 
 WORKDIR /app

--- a/examples/ClusterGrainHelloWorld/docker-compose.yml
+++ b/examples/ClusterGrainHelloWorld/docker-compose.yml
@@ -2,12 +2,16 @@ version: "3.7"
 
 services:
   node1:
-    build: ./Node1
+    build:
+      context: ../../
+      dockerfile: examples/ClusterGrainHelloWorld/Node1/Dockerfile
     ports:
       - 12001:12001
   
   node2:
-    build: ./Node2
+    build: 
+      context: ../../
+      dockerfile: examples/ClusterGrainHelloWorld/Node2/Dockerfile
     ports:
       - 12000:12000
 

--- a/examples/ClusterGrainHelloWorld/run.sh
+++ b/examples/ClusterGrainHelloWorld/run.sh
@@ -1,3 +1,1 @@
-dotnet publish -c Release -r linux-musl-x64 Node1/Node1.csproj
-dotnet publish -c Release -r linux-musl-x64 Node2/Node2.csproj
 docker-compose up --build


### PR DESCRIPTION
…updated docker-compose.

## Description

running run.sh in /examples/ClusterGrainHelloWorld, failed due to a static path requiring the example to be compiled with Core 3.1. 

moved the build of the cotainers into the dockerfiles with the correct base images for build, so that we do not rely on static paths.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

