### PR TITLE
remove hardcoded configuration from DefaultClusterContext

### DIFF
--- a/src/Proto.Cluster/ClusterConfig.cs
+++ b/src/Proto.Cluster/ClusterConfig.cs
@@ -21,6 +21,7 @@ namespace Proto.Cluster
             ClusterProvider = clusterProvider ?? throw new ArgumentNullException(nameof(clusterProvider));
             TimeoutTimespan = TimeSpan.FromSeconds(5);
             ActorRequestTimeout = TimeSpan.FromSeconds(5);
+            MaxNumberOfEventsInRequestLogThrottlePeriod = 3;
             RequestLogThrottlePeriod = TimeSpan.FromSeconds(2);
             HeartBeatInterval = TimeSpan.FromSeconds(30);
             MemberStrategyBuilder = (_, _) => new SimpleMemberStrategy();

--- a/src/Proto.Cluster/ClusterConfig.cs
+++ b/src/Proto.Cluster/ClusterConfig.cs
@@ -20,6 +20,8 @@ namespace Proto.Cluster
             ClusterName = clusterName ?? throw new ArgumentNullException(nameof(clusterName));
             ClusterProvider = clusterProvider ?? throw new ArgumentNullException(nameof(clusterProvider));
             TimeoutTimespan = TimeSpan.FromSeconds(5);
+            ActorRequestTimeout = TimeSpan.FromSeconds(5);
+            RequestLogThrottlePeriod = TimeSpan.FromSeconds(2);
             HeartBeatInterval = TimeSpan.FromSeconds(30);
             MemberStrategyBuilder = (_, _) => new SimpleMemberStrategy();
             ClusterKinds = ImmutableDictionary<string, Props>.Empty;
@@ -33,6 +35,9 @@ namespace Proto.Cluster
         public IClusterProvider ClusterProvider { get; }
 
         public TimeSpan TimeoutTimespan { get; init; }
+        public TimeSpan ActorRequestTimeout { get; init; }
+        public TimeSpan RequestLogThrottlePeriod { get; init; }
+        public int MaxNumberOfEventsInRequestLogThrottlePeriod { get; init; }
 
         public Func<Cluster, string, IMemberStrategy> MemberStrategyBuilder { get; init; }
 
@@ -40,10 +45,19 @@ namespace Proto.Cluster
         public TimeSpan HeartBeatInterval { get; init; }
 
         public Func<Cluster, IClusterContext> ClusterContextProducer { get; init; } =
-            c => new DefaultClusterContext(c.IdentityLookup, c.PidCache, c.Logger);
+            c => new DefaultClusterContext(c.IdentityLookup, c.PidCache, c.Logger, c.Config.ToClusterContextConfig());
 
         public ClusterConfig WithTimeout(TimeSpan timeSpan) =>
             this with {TimeoutTimespan = timeSpan};
+
+        public ClusterConfig WithActorRequestTimeout(TimeSpan timeSpan) =>
+            this with { ActorRequestTimeout = timeSpan };
+
+        public ClusterConfig WithRequestLogThrottlePeriod(TimeSpan timeSpan) =>
+            this with { RequestLogThrottlePeriod = timeSpan };
+
+        public ClusterConfig WithMaxNumberOfEventsInRequestLogThrottlePeriod(int max) =>
+            this with { MaxNumberOfEventsInRequestLogThrottlePeriod = max };
 
         public ClusterConfig WithMemberStrategyBuilder(Func<Cluster, string, IMemberStrategy> builder) =>
             this with {MemberStrategyBuilder = builder};

--- a/src/Proto.Cluster/ClusterContextConfig.cs
+++ b/src/Proto.Cluster/ClusterContextConfig.cs
@@ -1,0 +1,34 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ClusterContextConfiguration.cs" company="Asynkron AB">
+//      Copyright (C) 2015-$CURRENT_YEAR$ Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+
+namespace Proto.Cluster
+{
+    public record ClusterContextConfig
+    {
+        public TimeSpan ActorRequestTimeout { get; init; }
+        public TimeSpan RequestLogThrottlePeriod { get; init; }
+        public int MaxNumberOfEventsInRequestLogThrottlePeriod { get; init; }
+        public ClusterContextConfig()
+        {
+            ActorRequestTimeout = TimeSpan.FromSeconds(5);
+            MaxNumberOfEventsInRequestLogThrottlePeriod = 3;
+            RequestLogThrottlePeriod = TimeSpan.FromSeconds(2);
+        }
+    }
+
+    public static class ClusterConfigExtensions
+    {
+        public static ClusterContextConfig ToClusterContextConfig(this ClusterConfig clusterConfig)
+            => new()
+            {
+                ActorRequestTimeout = clusterConfig.ActorRequestTimeout,
+                MaxNumberOfEventsInRequestLogThrottlePeriod = clusterConfig.MaxNumberOfEventsInRequestLogThrottlePeriod,
+                RequestLogThrottlePeriod = clusterConfig.RequestLogThrottlePeriod
+            };
+    }
+}

--- a/tests/Proto.Cluster.Tests/PidCacheTests.cs
+++ b/tests/Proto.Cluster.Tests/PidCacheTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using ClusterTest.Messages;
 using FluentAssertions;
 using Proto.Cluster.Identity;
+using Proto.Cluster.Testing;
 using Xunit;
 
 namespace Proto.Cluster.Tests
@@ -40,7 +41,7 @@ namespace Proto.Cluster.Tests
             var logger = Log.CreateLogger("dummylog");
             var clusterIdentity = new ClusterIdentity {Identity = "identity", Kind = "kind"};
             pidCache.TryAdd(clusterIdentity, deadPid);
-            var requestAsyncStrategy = new DefaultClusterContext(dummyIdentityLookup, pidCache, logger);
+            var requestAsyncStrategy = new DefaultClusterContext(dummyIdentityLookup, pidCache, logger, new ClusterContextConfig());
 
             var res = await requestAsyncStrategy.RequestAsync<Pong>(clusterIdentity, new Ping {Message = "msg"}, system.Root,
                 new CancellationTokenSource(6000).Token


### PR DESCRIPTION
## Description

Removal of hardcoded configuration from DefaultClusterContext. It is possible to override it using ClusterConfig class.

## Purpose
This pull request is a:

- [x ] New feature (non-breaking change which adds functionality)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
