### PR TITLE
Logging extensions take2

### DIFF
--- a/examples/EscalateSupervision/Program.cs
+++ b/examples/EscalateSupervision/Program.cs
@@ -13,6 +13,8 @@ namespace EscalateSupervision
     {
         private static void Main(string[] args)
         {
+            var system = new ActorSystem();
+            
             var childProps = Props.FromFunc(context => {
                     Console.WriteLine($"{context.Self.Id}: MSG: {context.Message.GetType()}");
 
@@ -42,12 +44,12 @@ namespace EscalateSupervision
                         return Task.CompletedTask;
                     }
                 )
-                .WithChildSupervisorStrategy(new OneForOneStrategy((pid, reason) => SupervisorDirective.Escalate, 0,
+                .WithChildSupervisorStrategy(new OneForOneStrategy(system,(pid, reason) => SupervisorDirective.Escalate, 0,
                         null
                     )
                 );
 
-            var rootContext = new RootContext(new ActorSystem());
+            var rootContext = new RootContext(system);
             rootContext.SpawnNamed(rootProps, "root");
 
             Console.ReadLine();

--- a/examples/Patterns/Saga/Factories/TransferFactory.cs
+++ b/examples/Patterns/Saga/Factories/TransferFactory.cs
@@ -33,6 +33,7 @@ namespace Saga.Factories
         }
 
         internal PID CreateTransfer(
+            ActorSystem system,
             string actorName,
             PID fromAccount,
             PID toAccount,
@@ -45,7 +46,7 @@ namespace Saga.Factories
                     )
                 )
                 .WithChildSupervisorStrategy(
-                    new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, _retryAttempts, null)
+                    new OneForOneStrategy(system,(pid, reason) => SupervisorDirective.Restart, _retryAttempts, null)
                 );
             var transfer = _context.SpawnNamed(transferProps, actorName);
             return transfer;

--- a/examples/Patterns/Saga/Program.cs
+++ b/examples/Patterns/Saga/Program.cs
@@ -10,10 +10,13 @@ namespace Saga
 {
     class Program
     {
-        private static readonly RootContext Context = new ActorSystem().Root;
+        
 
         public static void Main(string[] args)
         {
+            var system = new ActorSystem();
+            var context = system.Root;
+            
             Console.WriteLine("Starting");
             var random = new Random();
             var numberOfTransfers = 5;
@@ -28,13 +31,13 @@ namespace Saga
                         refusalProbability, busyProbability, retryAttempts, verbose
                     )
                 )
-                .WithChildSupervisorStrategy(new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart,
+                .WithChildSupervisorStrategy(new OneForOneStrategy(system,(pid, reason) => SupervisorDirective.Restart,
                         retryAttempts, null
                     )
                 );
 
             Console.WriteLine("Spawning runner");
-            var runner = Context.SpawnNamed(props, "runner");
+            var runner = context.SpawnNamed(props, "runner");
 
             Console.ReadLine();
         }

--- a/examples/Patterns/Saga/Runner.cs
+++ b/examples/Patterns/Saga/Runner.cs
@@ -83,7 +83,7 @@ namespace Saga
                             var factory = new TransferFactory(context, _inMemoryProvider, random, _uptime,
                                 _retryAttempts
                             );
-                            var transfer = factory.CreateTransfer(actorName, fromAccount, toAccount, 10, persistanceID);
+                            var transfer = factory.CreateTransfer(context.System, actorName, fromAccount, toAccount, 10, persistanceID);
                             _transfers.Add(transfer);
                             if (i == _numberOfIterations && !nth)
                                 Console.WriteLine($"Started {j}/{_numberOfIterations} proesses");

--- a/examples/Supervision/Program.cs
+++ b/examples/Supervision/Program.cs
@@ -14,11 +14,12 @@ class Program
 {
     private static void Main()
     {
-        var context = new RootContext(new ActorSystem());
+        var system = new ActorSystem();
+        var context = new RootContext(system);
         Log.SetLoggerFactory(LoggerFactory.Create(b => b.AddConsole().SetMinimumLevel(LogLevel.Debug)));
 
         var props = Props.FromProducer(() => new ParentActor())
-            .WithChildSupervisorStrategy(new OneForOneStrategy(Decider.Decide, 1, null));
+            .WithChildSupervisorStrategy(new OneForOneStrategy(system, Decider.Decide, 1, null));
 
         var actor = context.Spawn(props);
 

--- a/src/Proto.Actor/Configuration/ActorSystemConfig.cs
+++ b/src/Proto.Actor/Configuration/ActorSystemConfig.cs
@@ -5,6 +5,8 @@
 // -----------------------------------------------------------------------
 using System;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+using Proto.Logging;
 using Proto.Metrics;
 using Ubiquitous.Metrics;
 using Ubiquitous.Metrics.NoMetrics;
@@ -21,6 +23,7 @@ namespace Proto
     [PublicAPI]
     public record ActorSystemConfig
     {
+        public ILoggerFactory LoggerFactory { get; init; } = new NullLoggerFactory();
         public TimeSpan DeadLetterThrottleInterval { get; init; }
 
         public IMetricsProvider[] MetricsProviders { get; init; } = {new NoMetricsProvider()};
@@ -33,6 +36,9 @@ namespace Proto
 
         public ActorSystemConfig WithDeadLetterThrottleCount(int deadLetterThrottleCount) =>
             this with {DeadLetterThrottleCount = deadLetterThrottleCount};
+        
+        public ActorSystemConfig WithLoggerFactory(ILoggerFactory loggerFactory) =>
+            this with {LoggerFactory = loggerFactory};
 
         public ActorSystemConfig WithMetricsProviders(params IMetricsProvider[] providers) => this with {MetricsProviders = providers};
     }

--- a/src/Proto.Actor/Logging/Log.cs
+++ b/src/Proto.Actor/Logging/Log.cs
@@ -19,8 +19,8 @@ namespace Proto
 
         public static ILoggerFactory GetLoggerFactory() => _loggerFactory;
 
-        public static ILogger CreateLogger(string categoryName) => _loggerFactory.CreateLogger(categoryName);
+      //  public static ILogger CreateLogger(string categoryName) => _loggerFactory.CreateLogger(categoryName);
 
-        public static ILogger CreateLogger<T>() => _loggerFactory.CreateLogger<T>();
+      //  public static ILogger CreateLogger<T>() => _loggerFactory.CreateLogger<T>();
     }
 }

--- a/src/Proto.Actor/Logging/Log.cs
+++ b/src/Proto.Actor/Logging/Log.cs
@@ -19,8 +19,8 @@ namespace Proto
 
         public static ILoggerFactory GetLoggerFactory() => _loggerFactory;
 
-      //  public static ILogger CreateLogger(string categoryName) => _loggerFactory.CreateLogger(categoryName);
+        public static ILogger CreateLogger(string categoryName) => _loggerFactory.CreateLogger(categoryName);
 
-      //  public static ILogger CreateLogger<T>() => _loggerFactory.CreateLogger<T>();
+        public static ILogger CreateLogger<T>() => _loggerFactory.CreateLogger<T>();
     }
 }

--- a/src/Proto.Actor/Logging/LoggingExtension.cs
+++ b/src/Proto.Actor/Logging/LoggingExtension.cs
@@ -1,0 +1,30 @@
+// -----------------------------------------------------------------------
+// <copyright file="LoggingExtension.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.Logging;
+using Proto.Context;
+using Proto.Extensions;
+
+namespace Proto.Logging
+{
+    public class LogExtension : IActorSystemExtension<LogExtension>
+    {
+        public LogExtension(ILoggerFactory loggerFactory)
+        {
+            LoggerFactory = loggerFactory;
+            ActorContextLogger = loggerFactory.CreateLogger<ActorContext>();
+        }
+
+        public ILoggerFactory LoggerFactory { get; } 
+
+        internal readonly ILogger ActorContextLogger;
+    }
+    
+    public static class LogExtensionExtensions
+    {
+        public static ILoggerFactory LoggerFactory(this ActorSystem actorSystem) => 
+            actorSystem.Extensions.Get<LogExtension>()!.LoggerFactory;
+    }
+}

--- a/src/Proto.Actor/Props.cs
+++ b/src/Proto.Actor/Props.cs
@@ -21,7 +21,7 @@ namespace Proto
         public ProducerWithSystem Producer { get; init; } = _ => null!;
         public MailboxProducer MailboxProducer { get; init; } = () => UnboundedMailbox.Create();
         public ISupervisorStrategy? GuardianStrategy { get; init; }
-        public ISupervisorStrategy SupervisorStrategy { get; init; } = Supervision.DefaultStrategy;
+        public ISupervisorStrategy? SupervisorStrategy { get; init; } 
         public IDispatcher Dispatcher { get; init; } = Dispatchers.DefaultDispatcher;
 
         public ImmutableList<Func<Receiver, Receiver>> ReceiverMiddleware { get; init; } =

--- a/src/Proto.Actor/Supervision/AllForOneStrategy.cs
+++ b/src/Proto.Actor/Supervision/AllForOneStrategy.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Proto.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace Proto
@@ -18,13 +19,15 @@ namespace Proto
     /// </summary>
     public class AllForOneStrategy : ISupervisorStrategy
     {
-        private static readonly ILogger Logger = Log.CreateLogger<AllForOneStrategy>();
+        
         private readonly Decider _decider;
         private readonly int _maxNrOfRetries;
         private readonly TimeSpan? _withinTimeSpan;
+        private ILogger _logger;
 
-        public AllForOneStrategy(Decider decider, int maxNrOfRetries, TimeSpan? withinTimeSpan)
+        public AllForOneStrategy(ActorSystem system, Decider decider, int maxNrOfRetries, TimeSpan? withinTimeSpan)
         {
+            _logger = system.LoggerFactory().CreateLogger<OneForOneStrategy>();
             _decider = decider;
             _maxNrOfRetries = maxNrOfRetries;
             _withinTimeSpan = withinTimeSpan;
@@ -70,7 +73,7 @@ namespace Proto
                     throw new ArgumentOutOfRangeException();
             }
 
-            void LogInfo(string action) => Logger.LogInformation("{Action} {Actor} because of {Reason}", action,
+            void LogInfo(string action) => _logger.LogInformation("{Action} {Actor} because of {Reason}", action,
                 child, reason
             );
         }

--- a/src/Proto.Actor/Supervision/OneForOneStrategy.cs
+++ b/src/Proto.Actor/Supervision/OneForOneStrategy.cs
@@ -5,20 +5,23 @@
 // -----------------------------------------------------------------------
 using System;
 using Microsoft.Extensions.Logging;
+using Proto.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace Proto
 {
     public class OneForOneStrategy : ISupervisorStrategy
     {
-        private static readonly ILogger Logger = Log.CreateLogger<OneForOneStrategy>();
+        
 
         private readonly Decider _decider;
         private readonly int _maxNrOfRetries;
         private readonly TimeSpan? _withinTimeSpan;
+        private readonly ILogger _logger;
 
-        public OneForOneStrategy(Decider decider, int maxNrOfRetries, TimeSpan? withinTimeSpan)
+        public OneForOneStrategy(ActorSystem system, Decider decider, int maxNrOfRetries, TimeSpan? withinTimeSpan)
         {
+            _logger = system.LoggerFactory().CreateLogger<OneForOneStrategy>();
             _decider = decider;
             _maxNrOfRetries = maxNrOfRetries;
             _withinTimeSpan = withinTimeSpan;
@@ -64,7 +67,7 @@ namespace Proto
                     throw new ArgumentOutOfRangeException();
             }
 
-            void LogInfo(string action) => Logger.LogInformation("{Action} {Actor} because of {Reason}", action,
+            void LogInfo(string action) => _logger.LogInformation("{Action} {Actor} because of {Reason}", action,
                 child, reason
             );
         }

--- a/src/Proto.Actor/Supervision/Supervision.cs
+++ b/src/Proto.Actor/Supervision/Supervision.cs
@@ -8,12 +8,20 @@ using System;
 // ReSharper disable once CheckNamespace
 namespace Proto
 {
-    public static class Supervision
+    public class Supervision
     {
-        public static ISupervisorStrategy DefaultStrategy { get; } =
-            new OneForOneStrategy((who, reason) => SupervisorDirective.Restart, 10, TimeSpan.FromSeconds(10));
+        private ActorSystem _system;
 
-        public static ISupervisorStrategy AlwaysRestartStrategy { get; } = new AlwaysRestartStrategy();
+        public Supervision(ActorSystem system)
+        {
+            _system = system;
+            DefaultStrategy = new OneForOneStrategy(_system,(who, reason) => SupervisorDirective.Restart, 10, TimeSpan.FromSeconds(10));
+            AlwaysRestartStrategy = new AlwaysRestartStrategy();
+        }
+        public ISupervisorStrategy DefaultStrategy { get; } 
+            
+
+        public ISupervisorStrategy AlwaysRestartStrategy { get; } 
     }
 
     public delegate SupervisorDirective Decider(PID pid, Exception reason);

--- a/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
@@ -56,7 +56,7 @@ namespace Proto.Cluster.Kubernetes
             _port = port;
             _kinds = kinds;
             _address = host + ":" + port;
-            StartClusterMonitor();
+            StartClusterMonitor(cluster.System);
             await RegisterMemberAsync();
             MonitorMemberStatusChanges();
         }
@@ -72,7 +72,7 @@ namespace Proto.Cluster.Kubernetes
             _host = host;
             _port = port;
             _kinds = Array.Empty<string>();
-            StartClusterMonitor();
+            StartClusterMonitor(cluster.System);
             MonitorMemberStatusChanges();
             return Task.CompletedTask;
         }
@@ -132,11 +132,11 @@ namespace Proto.Cluster.Kubernetes
             }
         }
 
-        private void StartClusterMonitor()
+        private void StartClusterMonitor(ActorSystem system)
         {
             var props = Props
                 .FromProducer(() => new KubernetesClusterMonitor(_cluster, _kubernetes))
-                .WithGuardianSupervisorStrategy(Supervision.AlwaysRestartStrategy)
+                .WithGuardianSupervisorStrategy( system.Supervision.AlwaysRestartStrategy)
                 .WithDispatcher(Dispatchers.SynchronousDispatcher);
             _clusterMonitor = _cluster.System.Root.SpawnNamed(props, "ClusterMonitor");
             _podName = KubernetesExtensions.GetPodName();

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -13,6 +13,7 @@ using Proto.Cluster.Identity;
 using Proto.Cluster.Metrics;
 using Proto.Cluster.Partition;
 using Proto.Extensions;
+using Proto.Logging;
 using Proto.Remote;
 
 namespace Proto.Cluster
@@ -90,7 +91,7 @@ namespace Proto.Cluster
             Remote = System.Extensions.Get<IRemote>() ?? throw new NotSupportedException("Remote module must be configured when using cluster");
             
             await Remote.StartAsync();
-            Logger = Log.CreateLogger($"Cluster-{LoggerId}");
+            Logger = System.LoggerFactory().CreateLogger($"Cluster-{LoggerId}");
             Logger.LogInformation("Starting");
             MemberList = new MemberList(this);
             ClusterContext = Config.ClusterContextProducer(this);

--- a/src/Proto.Cluster/Partition/PartitionManager.cs
+++ b/src/Proto.Cluster/Partition/PartitionManager.cs
@@ -48,7 +48,7 @@ namespace Proto.Cluster.Partition
             {
                 var partitionActorProps = Props
                     .FromProducer(() => new PartitionIdentityActor(_cluster))
-                    .WithGuardianSupervisorStrategy(Supervision.AlwaysRestartStrategy);
+                    .WithGuardianSupervisorStrategy(_system.Supervision.AlwaysRestartStrategy);
                 _partitionActor = _context.SpawnNamed(partitionActorProps, PartitionIdentityActorName);
 
                 var partitionActivatorProps =

--- a/src/Proto.Remote.GrpcCore/GrpcCoreRemote.cs
+++ b/src/Proto.Remote.GrpcCore/GrpcCoreRemote.cs
@@ -12,6 +12,7 @@ using Grpc.Health.V1;
 using Grpc.HealthCheck;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
+using Proto.Logging;
 using Proto.Remote.Metrics;
 
 namespace Proto.Remote.GrpcCore
@@ -19,7 +20,7 @@ namespace Proto.Remote.GrpcCore
     [PublicAPI]
     public class GrpcCoreRemote : IRemote
     {
-        private static readonly ILogger Logger = Log.CreateLogger<GrpcCoreRemote>();
+        private readonly ILogger _logger;
         private readonly GrpcCoreRemoteConfig _config;
         private EndpointManager _endpointManager = null!;
         private EndpointReader _endpointReader = null!;
@@ -29,6 +30,7 @@ namespace Proto.Remote.GrpcCore
         public GrpcCoreRemote(ActorSystem system, GrpcCoreRemoteConfig config)
         {
             System = system;
+            _logger = system.LoggerFactory().CreateLogger<GrpcCoreRemote>();
             _config = config;
             system.Metrics.RegisterKnownMetrics(new RemoteMetrics(system.Metrics));
             System.Extensions.Register(this);
@@ -66,7 +68,7 @@ namespace Proto.Remote.GrpcCore
                 );
                 _endpointManager.Start();
 
-                Logger.LogInformation("Starting Proto.Actor server on {Host}:{Port} ({Address})", Config.Host, boundPort,
+                _logger.LogInformation("Starting Proto.Actor server on {Host}:{Port} ({Address})", Config.Host, boundPort,
                     System.Address
                 );
                 Started = true;
@@ -93,14 +95,14 @@ namespace Proto.Remote.GrpcCore
                 }
                 else await _server.KillAsync();
 
-                Logger.LogInformation(
+                _logger.LogInformation(
                     "Proto.Actor server stopped on {Address}. Graceful: {Graceful}",
                     System.Address, graceful
                 );
             }
             catch (Exception ex)
             {
-                Logger.LogError(
+                _logger.LogError(
                     ex, "Proto.Actor server stopped on {Address} with error: {Message}",
                     System.Address, ex.Message
                 );

--- a/src/Proto.Remote.GrpcNet/GrpcNetRemote.cs
+++ b/src/Proto.Remote.GrpcNet/GrpcNetRemote.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Proto.Logging;
 using Proto.Remote.Metrics;
 
 namespace Proto.Remote.GrpcNet
@@ -17,7 +18,7 @@ namespace Proto.Remote.GrpcNet
     public class GrpcNetRemote : IRemote
     {
         private readonly GrpcNetRemoteConfig _config;
-        private readonly ILogger _logger = Log.CreateLogger<GrpcNetRemote>();
+        private readonly ILogger _logger;
         private EndpointManager _endpointManager = null!;
         private EndpointReader _endpointReader = null!;
         private HealthServiceImpl _healthCheck = null!;
@@ -26,6 +27,7 @@ namespace Proto.Remote.GrpcNet
         public GrpcNetRemote(ActorSystem system, GrpcNetRemoteConfig config)
         {
             System = system;
+            _logger = system.LoggerFactory().CreateLogger<GrpcNetRemote>();
             _config = config;
             system.Metrics.RegisterKnownMetrics(new RemoteMetrics(system.Metrics));
             System.Extensions.Register(this);

--- a/tests/Proto.Actor.Tests/DisposableActorTests.cs
+++ b/tests/Proto.Actor.Tests/DisposableActorTests.cs
@@ -14,9 +14,10 @@ namespace Proto.Tests
         [Fact]
         public void WhenActorRestarted_DisposeIsCalled()
         {
+            
             var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
             var disposeCalled = false;
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 0, null);
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Restart, 0, null);
             var childProps = Props.FromProducer(() => new DisposableActor(() => disposeCalled = true))
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats))
                 .WithChildSupervisorStrategy(strategy);
@@ -34,7 +35,7 @@ namespace Proto.Tests
         {
             var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
             var disposeCalled = false;
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 0, null);
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Restart, 0, null);
             var childProps = Props.FromProducer(() => new AsyncDisposableActor(() => disposeCalled = true))
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats))
                 .WithChildSupervisorStrategy(strategy);
@@ -52,7 +53,7 @@ namespace Proto.Tests
         {
             var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
             var disposeCalled = false;
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Resume, 0, null);
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Resume, 0, null);
             var childProps = Props.FromProducer(() => new DisposableActor(() => disposeCalled = true))
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats))
                 .WithChildSupervisorStrategy(strategy);
@@ -70,7 +71,7 @@ namespace Proto.Tests
         {
             var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
             var disposeCalled = false;
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Resume, 0, null);
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Resume, 0, null);
             var childProps = Props.FromProducer(() => new AsyncDisposableActor(() => disposeCalled = true))
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats))
                 .WithChildSupervisorStrategy(strategy);
@@ -112,7 +113,7 @@ namespace Proto.Tests
             var child2Disposed = false;
             var child1MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
             var child2MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-            var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Stop, 1, null);
+            var strategy = new AllForOneStrategy(System,(pid, reason) => SupervisorDirective.Stop, 1, null);
             var child1Props = Props.FromProducer(() => new DisposableActor(() => child1Disposed = true))
                 .WithMailbox(() => UnboundedMailbox.Create(child1MailboxStats));
             var child2Props = Props.FromProducer(() => new DisposableActor(() => child2Disposed = true))

--- a/tests/Proto.Actor.Tests/EventStreamTests.cs
+++ b/tests/Proto.Actor.Tests/EventStreamTests.cs
@@ -9,8 +9,9 @@ namespace Proto.Tests
         [Fact]
         public void EventStream_CanSubscribeToSpecificEventTypes()
         {
+            var system = new ActorSystem();
             var received = "";
-            var eventStream = new EventStream();
+            var eventStream = new EventStream(system);
             eventStream.Subscribe<string>(theString => received = theString);
             eventStream.Publish("hello");
             Assert.Equal("hello", received);
@@ -19,8 +20,9 @@ namespace Proto.Tests
         [Fact]
         public void EventStream_CanSubscribeToAllEventTypes()
         {
+            var system = new ActorSystem();
             var receivedEvents = new List<object>();
-            var eventStream = new EventStream();
+            var eventStream = new EventStream(system);
             eventStream.Subscribe(@event => receivedEvents.Add(@event));
             eventStream.Publish("hello");
             eventStream.Publish(1);
@@ -31,8 +33,9 @@ namespace Proto.Tests
         [Fact]
         public void EventStream_CanUnsubscribeFromEvents()
         {
+            var system = new ActorSystem();
             var receivedEvents = new List<object>();
-            var eventStream = new EventStream();
+            var eventStream = new EventStream(system);
             var subscription = eventStream.Subscribe<string>(@event => receivedEvents.Add(@event));
             eventStream.Publish("first message");
             subscription.Unsubscribe();
@@ -43,8 +46,9 @@ namespace Proto.Tests
         [Fact]
         public void EventStream_OnlyReceiveSubscribedToEventTypes()
         {
+            var system = new ActorSystem();
             var eventsReceived = new List<object>();
-            var eventStream = new EventStream();
+            var eventStream = new EventStream(system);
             eventStream.Subscribe<int>(@event => eventsReceived.Add(@event));
             eventStream.Publish("not an int");
             Assert.Empty(eventsReceived);
@@ -53,8 +57,9 @@ namespace Proto.Tests
         [Fact]
         public void EventStream_CanSubscribeToSpecificEventTypes_Async()
         {
+            var system = new ActorSystem();
             string received;
-            var eventStream = new EventStream();
+            var eventStream = new EventStream(system);
             eventStream.Subscribe<string>(theString => {
                     received = theString;
                     Assert.Equal("hello", received);

--- a/tests/Proto.Actor.Tests/SupervisionTests_AllForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_AllForOne.cs
@@ -18,7 +18,7 @@ namespace Proto.Tests
         {
             var child1MailboxStats = new TestMailboxStatistics(msg => msg is ResumeMailbox);
             var child2MailboxStats = new TestMailboxStatistics(msg => msg is ResumeMailbox);
-            var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Resume, 1, null);
+            var strategy = new AllForOneStrategy(System,(pid, reason) => SupervisorDirective.Resume, 1, null);
             var child1Props = Props.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(child1MailboxStats));
             var child2Props = Props.FromProducer(() => new ChildActor())
@@ -41,7 +41,7 @@ namespace Proto.Tests
         {
             var child1MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
             var child2MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-            var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Stop, 1, null);
+            var strategy = new AllForOneStrategy(System,(pid, reason) => SupervisorDirective.Stop, 1, null);
             var child1Props = Props.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(child1MailboxStats));
             var child2Props = Props.FromProducer(() => new ChildActor())
@@ -65,7 +65,7 @@ namespace Proto.Tests
         {
             var child1MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
             var child2MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-            var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
+            var strategy = new AllForOneStrategy(System,(pid, reason) => SupervisorDirective.Restart, 1, null);
             var child1Props = Props.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(child1MailboxStats));
             var child2Props = Props.FromProducer(() => new ChildActor())
@@ -89,7 +89,7 @@ namespace Proto.Tests
         {
             var child1MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
             var child2MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-            var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
+            var strategy = new AllForOneStrategy(System,(pid, reason) => SupervisorDirective.Restart, 1, null);
             var child1Props = Props.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(child1MailboxStats));
             var child2Props = Props.FromProducer(() => new ChildActor())
@@ -112,7 +112,7 @@ namespace Proto.Tests
         public void AllForOneStrategy_Should_EscalateFailureToParent()
         {
             var parentMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-            var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Escalate, 1, null);
+            var strategy = new AllForOneStrategy(System,(pid, reason) => SupervisorDirective.Escalate, 1, null);
             var childProps = Props.FromProducer(() => new ChildActor());
             var parentProps = Props.FromProducer(() => new ParentActor(childProps, childProps))
                 .WithChildSupervisorStrategy(strategy)

--- a/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
@@ -18,7 +18,7 @@ namespace Proto.Tests
         public void OneForOneStrategy_Should_ResumeChildOnFailure()
         {
             var childMailboxStats = new TestMailboxStatistics(msg => msg is ResumeMailbox);
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Resume, 1, null);
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Resume, 1, null);
             var childProps = Props.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
             var parentProps = Props.FromProducer(() => new ParentActor(childProps))
@@ -36,7 +36,7 @@ namespace Proto.Tests
         public void OneForOneStrategy_Should_StopChildOnFailure()
         {
             var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Stop, 1, null);
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Stop, 1, null);
             var childProps = Props.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
             var parentProps = Props.FromProducer(() => new ParentActor(childProps))
@@ -54,7 +54,7 @@ namespace Proto.Tests
         public void OneForOneStrategy_Should_RestartChildOnFailure()
         {
             var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Restart, 1, null);
             var childProps = Props.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
             var parentProps = Props.FromProducer(() => new ParentActor(childProps))
@@ -73,7 +73,7 @@ namespace Proto.Tests
             OneForOneStrategy_WhenRestartedLessThanMaximumAllowedRetriesWithinSpecifiedTimePeriod_ShouldNotStopChild()
         {
             var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 3,
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Restart, 3,
                 TimeSpan.FromMilliseconds(100)
             );
             var childProps = Props.FromProducer(() => new ChildActor())
@@ -103,7 +103,7 @@ namespace Proto.Tests
             OneForOneStrategy_WhenRestartedMoreThanMaximumAllowedRetriesWithinSpecifiedTimePeriod_ShouldStopChild()
         {
             var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 3,
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Restart, 3,
                 TimeSpan.FromMilliseconds(100)
             );
             var childProps = Props.FromProducer(() => new ChildActor())
@@ -126,7 +126,7 @@ namespace Proto.Tests
         public void OneForOneStrategy_Should_PassExceptionOnRestart()
         {
             var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Restart, 1, null);
             var childProps = Props.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
             var parentProps = Props.FromProducer(() => new ParentActor(childProps))
@@ -144,7 +144,7 @@ namespace Proto.Tests
         public void OneForOneStrategy_Should_StopChildWhenRestartLimitReached()
         {
             var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Restart, 1, null);
             var childProps = Props.FromProducer(() => new ChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
             var parentProps = Props.FromProducer(() => new ParentActor(childProps))
@@ -163,7 +163,7 @@ namespace Proto.Tests
         public void OneForOneStrategy_WhenEscalateDirectiveWithoutGrandparent_ShouldRevertToDefaultDirective()
         {
             var parentMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Escalate, 1, null);
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Escalate, 1, null);
             var childProps = Props.FromProducer(() => new ThrowOnStartedChildActor());
             var parentProps = Props.FromProducer(() => new ParentActor(childProps))
                 .WithChildSupervisorStrategy(strategy)
@@ -191,7 +191,7 @@ namespace Proto.Tests
         public void OneForOneStrategy_Should_EscalateFailureToParent()
         {
             var parentMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Escalate, 1, null);
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Escalate, 1, null);
             var childProps = Props.FromProducer(() => new ChildActor());
             var parentProps = Props.FromProducer(() => new ParentActor(childProps))
                 .WithChildSupervisorStrategy(strategy)
@@ -209,7 +209,7 @@ namespace Proto.Tests
         public void OneForOneStrategy_Should_StopChildOnFailureWhenStarted()
         {
             var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Stop, 1, null);
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Stop, 1, null);
             var childProps = Props.FromProducer(() => new ThrowOnStartedChildActor())
                 .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
             var parentProps = Props.FromProducer(() => new ParentActor(childProps))
@@ -225,13 +225,13 @@ namespace Proto.Tests
         public void OneForOneStrategy_Should_RestartParentOnEscalateFailure()
         {
             var parentMailboxStats = new TestMailboxStatistics(msg => msg is Restart);
-            var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Escalate, 0, null);
+            var strategy = new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Escalate, 0, null);
             var childProps = Props.FromProducer(() => new ThrowOnStartedChildActor());
             var parentProps = Props.FromProducer(() => new ParentActor(childProps))
                 .WithChildSupervisorStrategy(strategy)
                 .WithMailbox(() => UnboundedMailbox.Create(parentMailboxStats));
             var grandParentProps = Props.FromProducer(() => new ParentActor(parentProps))
-                .WithChildSupervisorStrategy(new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1,
+                .WithChildSupervisorStrategy(new OneForOneStrategy(System,(pid, reason) => SupervisorDirective.Restart, 1,
                         TimeSpan.FromSeconds(1)
                     )
                 );

--- a/tests/Proto.Remote.Tests/EchoActor.cs
+++ b/tests/Proto.Remote.Tests/EchoActor.cs
@@ -1,30 +1,36 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Proto.Logging;
 using Proto.Remote.Tests.Messages;
 
 namespace Proto.Remote.Tests
 {
     public class EchoActor : IActor
     {
-        private static readonly ILogger Logger = Log.CreateLogger<EchoActor>();
+        private readonly ILogger _logger;
+
+        public EchoActor(ActorSystem system)
+        {
+            _logger = system.LoggerFactory().CreateLogger<EchoActor>();
+        }
 
         public Task ReceiveAsync(IContext context)
         {
             switch (context.Message)
             {
                 case Started _:
-                    Logger.LogDebug($"{context.Self}");
+                    _logger.LogDebug($"{context.Self}");
                     break;
                 case Ping ping:
-                    Logger.LogDebug("Received Ping, replying Pong");
+                    _logger.LogDebug("Received Ping, replying Pong");
                     context.Respond(new Pong {Message = $"{context.System.Address} {ping.Message}"});
                     break;
                 case Die _:
-                    Logger.LogDebug("Received termination request, stopping");
+                    _logger.LogDebug("Received termination request, stopping");
                     context.Stop(context.Self);
                     break;
                 default:
-                    Logger.LogDebug(context.Message.GetType().Name);
+                    _logger.LogDebug(context.Message.GetType().Name);
                     break;
             }
 

--- a/tests/Proto.Remote.Tests/RemoteFixture.cs
+++ b/tests/Proto.Remote.Tests/RemoteFixture.cs
@@ -22,7 +22,7 @@ namespace Proto.Remote.Tests
 
     public abstract class RemoteFixture : IRemoteFixture
     {
-        private static readonly Props EchoActorProps = Props.FromProducer(() => new EchoActor());
+        private Props EchoActorProps => Props.FromProducer(() => new EchoActor(ActorSystem));
         public string RemoteAddress => ServerRemote.System.Address;
 
         public IRemote Remote { get; protected set; }
@@ -43,7 +43,7 @@ namespace Proto.Remote.Tests
             await ServerRemote.ShutdownAsync();
         }
 
-        protected static TRemoteConfig ConfigureServerRemoteConfig<TRemoteConfig>(TRemoteConfig serverRemoteConfig)
+        protected  TRemoteConfig ConfigureServerRemoteConfig<TRemoteConfig>(TRemoteConfig serverRemoteConfig)
             where TRemoteConfig : RemoteConfigBase =>
             serverRemoteConfig
                 .WithProtoMessages(Messages.ProtosReflection.Descriptor)


### PR DESCRIPTION
Massive update to get rid of static Logging.
Logging can now be provided using the ActorSystemConfig instead.
The old static API is still there for the parts that have not yet been ported. mainly cluster.

Is this a direction we want to go in?
It does complicate some things, like initializing loggers in class fields directly.
And ActorSystem has to be passed to every place that needs a logger. (or at least passing the logger)