### PR TITLE
Cluster remote experiments

### DIFF
--- a/benchmarks/ClusterBenchmark/Program.cs
+++ b/benchmarks/ClusterBenchmark/Program.cs
@@ -120,7 +120,7 @@ namespace ClusterExperiment1
                         var id = "myactor" + rnd.Next(0, ActorCount);
                         semaphore.Wait(() => {
                                 return cluster.RequestAsync<HelloResponse>(id, "hello", new HelloRequest(),
-                                    CancellationTokens.WithTimeout(20)
+                                    CancellationTokens.WithTimeout(20*1000)
                                 ).ContinueWith(task => { Console.Write(task.Result is null ? "X" : "."); }
                                 );
                             }
@@ -150,7 +150,7 @@ namespace ClusterExperiment1
                             {
                                 var id = "myactor" + rnd.Next(0, ActorCount);
                                 var request = cluster.RequestAsync<HelloResponse>(id, "hello", new HelloRequest(),
-                                    CancellationTokens.WithTimeout(20)
+                                    CancellationTokens.WithTimeout(20*1000)
                                 );
 
                                 requests.Add(request);
@@ -185,7 +185,7 @@ namespace ClusterExperiment1
                         try
                         {
                             var res = await cluster.RequestAsync<HelloResponse>(id, "hello", new HelloRequest(),
-                                CancellationTokens.WithTimeout(20)
+                                CancellationTokens.WithTimeout(20*1000)
                             );
 
                             if (res is null)

--- a/benchmarks/ClusterBenchmark/Program.cs
+++ b/benchmarks/ClusterBenchmark/Program.cs
@@ -23,7 +23,7 @@ namespace ClusterExperiment1
         {
             ThreadPool.SetMinThreads(500, 500);
 
-            Configuration.SetupLogger();
+            
 
             if (args.Length > 0)
             {
@@ -32,6 +32,8 @@ namespace ClusterExperiment1
                 Thread.Sleep(Timeout.Infinite);
                 return;
             }
+
+            Configuration.SetupLogger();
 
             _ts = new TaskCompletionSource<bool>();
 

--- a/benchmarks/ClusterBenchmark/Program.cs
+++ b/benchmarks/ClusterBenchmark/Program.cs
@@ -106,6 +106,7 @@ namespace ClusterExperiment1
         private static void RunFireForgetClient()
         {
             var logger = Log.CreateLogger(nameof(Program));
+            
 
             _ = SafeTask.Run(async () => {
                     await Task.Delay(5000);
@@ -119,7 +120,7 @@ namespace ClusterExperiment1
                         var id = "myactor" + rnd.Next(0, ActorCount);
                         semaphore.Wait(() => {
                                 return cluster.RequestAsync<HelloResponse>(id, "hello", new HelloRequest(),
-                                    new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token
+                                    CancellationTokens.WithTimeout(20)
                                 ).ContinueWith(task => { Console.Write(task.Result is null ? "X" : "."); }
                                 );
                             }
@@ -149,7 +150,7 @@ namespace ClusterExperiment1
                             {
                                 var id = "myactor" + rnd.Next(0, ActorCount);
                                 var request = cluster.RequestAsync<HelloResponse>(id, "hello", new HelloRequest(),
-                                    new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token
+                                    CancellationTokens.WithTimeout(20)
                                 );
 
                                 requests.Add(request);
@@ -184,7 +185,7 @@ namespace ClusterExperiment1
                         try
                         {
                             var res = await cluster.RequestAsync<HelloResponse>(id, "hello", new HelloRequest(),
-                                new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token
+                                CancellationTokens.WithTimeout(20)
                             );
 
                             if (res is null)

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -127,17 +127,17 @@ namespace Proto.Cluster.Identity
                     if (activator == null) return null;
 
                     //try to acquire global lock
-                    spawnLock ??= await _storage.TryAcquireLock(clusterIdentity, CancellationTokens.WithTimeout(6000));
+                    spawnLock ??= await _storage.TryAcquireLock(clusterIdentity, CancellationTokens.WithTimeout(5000));
 
                     //we didn't get the lock, wait for activation to complete
-                    if (spawnLock == null) result = await WaitForActivation(clusterIdentity, CancellationTokens.WithTimeout(6000));
+                    if (spawnLock == null) result = await WaitForActivation(clusterIdentity, CancellationTokens.WithTimeout(5000));
                     else
                     {
                         //we have the lock, spawn and return
                         (result, spawnLock) = await SpawnActivationAsync(activator, spawnLock, CancellationTokens.WithTimeout(1000));
                     }
                 }
-                catch (TaskCanceledException e)
+                catch (OperationCanceledException e)
                 {
                     if (_cluster.System.Shutdown.IsCancellationRequested) return null;
 
@@ -204,7 +204,7 @@ namespace Proto.Cluster.Identity
             }
             catch (TimeoutException)
             {
-                _logger.LogError("[SpawnActivationAsync] Remote PID request timeout {@Request}", req);
+                _logger.LogWarning("[SpawnActivationAsync] Remote PID request timeout {@Request}", req);
             }
             catch (Exception e)
             {

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -140,8 +140,7 @@ namespace Proto.Cluster.Identity
                 catch (OperationCanceledException e)
                 {
                     if (_cluster.System.Shutdown.IsCancellationRequested) return null;
-
-                    Console.Write("RETRY");
+                    
                     if (_shouldThrottle().IsOpen())
                         _logger.LogWarning(e, "Failed to get PID for {ClusterIdentity}", clusterIdentity);
                     

--- a/src/Proto.Remote/Endpoints/EndpointSupervisorStrategy.cs
+++ b/src/Proto.Remote/Endpoints/EndpointSupervisorStrategy.cs
@@ -42,7 +42,7 @@ namespace Proto.Remote
         {
             if (ShouldStop(rs))
             {
-                Logger.LogError(reason,
+                Logger.LogError(
                     "Stopping connection to address {Address} after retries expired because of {Reason}",
                     _address, reason.GetType().Name
                 );


### PR DESCRIPTION
Reduce noisiness on topology changes.

Any retriable action is changed from Error to Warn logging except for the last attempt.
This affects IdentityWorker and EndpointActor.

Removed stacktrace for known Error types, such as Unavailable gRPC status.
We know what that means, the remote node is unavailable, there is no value in seeing the entire stacktrace for gRPC there.
