### PR TITLE
filter out identical topology events

### DIFF
--- a/src/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/Proto.Cluster.Consul/ConsulProvider.cs
@@ -175,12 +175,8 @@ namespace Proto.Cluster.Consul
                                     .Where(v => IsAlive(v.Checks)) //only include members that are alive
                                     .Select(ToMember)
                                     .ToArray();
-
-                            //why is this not updated via the ClusterTopologyEvents?
-                            //because following events is messy
+                            
                             _memberList.UpdateClusterTopology(currentMembers, waitIndex);
-                            var res = new ClusterTopologyEvent(currentMembers);
-                            _cluster.System.EventStream.Publish(res);
                         }
                         catch (Exception x)
                         {

--- a/src/Proto.Cluster.Kubernetes/KubernetesClusterMonitor.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesClusterMonitor.cs
@@ -151,8 +151,6 @@ namespace Proto.Cluster.Kubernetes
                 .ToList();
 
             _cluster.MemberList.UpdateClusterTopology(memberStatuses, 0ul);
-            var topology = new ClusterTopologyEvent(memberStatuses);
-            _cluster.System.EventStream.Publish(topology);
         }
     }
 }

--- a/src/Proto.Cluster/Events/ClusterTopologyEvent.cs
+++ b/src/Proto.Cluster/Events/ClusterTopologyEvent.cs
@@ -9,10 +9,10 @@ using System.Linq;
 
 namespace Proto.Cluster.Events
 {
-    public class ClusterTopologyEvent
-    {
-        public ClusterTopologyEvent(IEnumerable<Member> members) => Members = members?.ToArray() ?? throw new ArgumentNullException(nameof(members));
-
-        public IReadOnlyCollection<Member> Members { get; }
-    }
+    // public class ClusterTopologyEvent
+    // {
+    //     public ClusterTopologyEvent(IEnumerable<Member> members) => Members = members?.ToArray() ?? throw new ArgumentNullException(nameof(members));
+    //
+    //     public IReadOnlyCollection<Member> Members { get; }
+    // }
 }

--- a/src/Proto.Cluster/Messages/Messages.cs
+++ b/src/Proto.Cluster/Messages/Messages.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 // ReSharper disable once CheckNamespace
+using System.Collections.Generic;
 using System.Linq;
 using Google.Protobuf;
 
@@ -37,9 +38,14 @@ namespace Proto.Cluster
 
     public partial class ClusterTopology
     {
-        public uint GetMembershipHashCode()
+        //this ignores joined and left members, only the actual members are relevant
+        public uint GetMembershipHashCode() => Member.GetMembershipHashCode(Members);
+    }
+
+    public partial class Member
+    {
+        public static uint GetMembershipHashCode(IEnumerable<Member> members)
         {
-            var members = Members;
             var x = members.Select(m => m.Id).OrderBy(i => i).ToArray();
             var key = string.Join("", x);
             var hash = MurmurHash2.Hash(key);


### PR DESCRIPTION
This fix leverages the new topology membership hashcode feature (Murmur hash on member ids)
We simply compare if the new cluster topology update reported by the cluster provider has the same hashcode as the last update. if so, we ignore and bailout.

