### PR TITLE
Deadletter request logging

### DIFF
--- a/benchmarks/ClusterBenchmark/Configuration.cs
+++ b/benchmarks/ClusterBenchmark/Configuration.cs
@@ -41,7 +41,8 @@ namespace ClusterExperiment1
             var remoteConfig = GrpcCoreRemoteConfig
                 .BindTo(host, port)
                 .WithAdvertisedHost(advertisedHost)
-                .WithProtoMessages(MessagesReflection.Descriptor);
+                .WithProtoMessages(MessagesReflection.Descriptor)
+                .WithEndpointWriterMaxRetries(2);
 
             var clusterConfig = ClusterConfig
                 .Setup("mycluster", clusterProvider, identityLookup);
@@ -102,6 +103,7 @@ namespace ClusterExperiment1
         {
             var system = new ActorSystem(new ActorSystemConfig().WithDeadLetterThrottleCount(3)
                 .WithDeadLetterThrottleInterval(TimeSpan.FromSeconds(1))
+                .WithDeadLetterRequestLogging(false)
             );
             var clusterProvider = ClusterProvider();
             var identity = GetIdentityLookup();
@@ -119,6 +121,7 @@ namespace ClusterExperiment1
         {
             var system = new ActorSystem(new ActorSystemConfig().WithDeadLetterThrottleCount(3)
                 .WithDeadLetterThrottleInterval(TimeSpan.FromSeconds(1))
+                .WithDeadLetterRequestLogging(false)
             );
             system.EventStream.Subscribe<ClusterTopology>(e => { Console.Write("CT" + e.GetMembershipHashCode()); }
             );

--- a/src/Proto.Actor/ActorSystem.cs
+++ b/src/Proto.Actor/ActorSystem.cs
@@ -33,7 +33,7 @@ namespace Proto
             Root = new RootContext(this);
             DeadLetter = new DeadLetterProcess(this);
             Guardians = new Guardians(this);
-            EventStream = new EventStream(config.DeadLetterThrottleInterval, config.DeadLetterThrottleCount, Shutdown);
+            EventStream = new EventStream(this);
             Metrics = new ProtoMetrics(config.MetricsProviders);
             ProcessRegistry.TryAdd("eventstream", new EventStreamProcess(this));
             Extensions = new ActorSystemExtensions(this);

--- a/src/Proto.Actor/Configuration/ActorSystemConfig.cs
+++ b/src/Proto.Actor/Configuration/ActorSystemConfig.cs
@@ -24,6 +24,8 @@ namespace Proto
 
         public IMetricsProvider[] MetricsProviders { get; init; } = {new NoMetricsProvider()};
         public int DeadLetterThrottleCount { get; init; }
+
+        public bool DeadLetterRequestLogging { get; set; } = true;
         public bool DeveloperSupervisionLogging { get; init; }
 
         public static ActorSystemConfig Setup() => new();
@@ -33,6 +35,8 @@ namespace Proto
 
         public ActorSystemConfig WithDeadLetterThrottleCount(int deadLetterThrottleCount) =>
             this with {DeadLetterThrottleCount = deadLetterThrottleCount};
+
+        public ActorSystemConfig WithDeadLetterRequestLogging(bool enabled) => this with {DeadLetterRequestLogging = enabled};
 
         public ActorSystemConfig WithDeveloperSupervisionLogging(bool enabled) => this with {DeveloperSupervisionLogging = enabled};
 

--- a/src/Proto.Actor/Extensions.cs
+++ b/src/Proto.Actor/Extensions.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2015-2020 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using JetBrains.Annotations;
@@ -13,6 +14,7 @@ namespace Proto
     public static class CancellationTokens
     {
         public static CancellationToken WithTimeout(int ms) => new CancellationTokenSource(ms).Token;
+        public static CancellationToken WithTimeout(TimeSpan timeSpan) => new CancellationTokenSource(timeSpan).Token;
     }
 
     public static class UtilExtensions

--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -19,7 +19,7 @@ namespace Proto.Cluster.Partition
     class PartitionIdentityActor : IActor
     {
         //for how long do we wait when performing a identity handover?
-        private static readonly TimeSpan HandoverTimeout = TimeSpan.FromSeconds(3);
+        private static readonly TimeSpan HandoverTimeout = TimeSpan.FromSeconds(1);
         
         private readonly Cluster _cluster;
         private readonly ILogger _logger;

--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -19,7 +19,7 @@ namespace Proto.Cluster.Partition
     class PartitionIdentityActor : IActor
     {
         //for how long do we wait when performing a identity handover?
-        private static readonly TimeSpan HandoverTimeout = TimeSpan.FromSeconds(1);
+       
         
         private readonly Cluster _cluster;
         private readonly ILogger _logger;
@@ -32,13 +32,14 @@ namespace Proto.Cluster.Partition
         private readonly Dictionary<ClusterIdentity, Task<ActivationResponse>> _spawns = new();
 
         private ulong _eventId;
-        
-        public PartitionIdentityActor(Cluster cluster)
+        private readonly TimeSpan _identityHandoverTimeout;
+
+        public PartitionIdentityActor(Cluster cluster, TimeSpan identityHandoverTimeout)
         {
             _logger = Log.CreateLogger($"{nameof(PartitionIdentityActor)}-{cluster.LoggerId}");
             _cluster = cluster;
             _myAddress = cluster.System.Address;
-            
+            _identityHandoverTimeout = identityHandoverTimeout;
         }
         
         public Task ReceiveAsync(IContext context) =>
@@ -83,7 +84,7 @@ namespace Proto.Cluster.Partition
             {
                 var activatorPid = PartitionManager.RemotePartitionPlacementActor(member.Address);
                 var request =
-                    context.RequestAsync<IdentityHandoverResponse>(activatorPid, requestMsg, HandoverTimeout);
+                    context.RequestAsync<IdentityHandoverResponse>(activatorPid, requestMsg, CancellationTokens.WithTimeout(_identityHandoverTimeout));
                 requests.Add(request);
             }
 

--- a/src/Proto.Cluster/Partition/PartitionIdentityLookup.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityLookup.cs
@@ -16,6 +16,16 @@ namespace Proto.Cluster.Partition
         private Cluster _cluster = null!;
         private ILogger _logger = null!;
         private PartitionManager _partitionManager = null!;
+        private readonly TimeSpan _identityHandoverTimeout;
+
+        public PartitionIdentityLookup() : this(TimeSpan.FromMilliseconds(3))
+        {
+        }
+        
+        public PartitionIdentityLookup(TimeSpan identityHandoverTimeout)
+        {
+            _identityHandoverTimeout = identityHandoverTimeout;
+        }
 
         public async Task<PID?> GetAsync(ClusterIdentity clusterIdentity, CancellationToken ct)
         {
@@ -77,7 +87,7 @@ namespace Proto.Cluster.Partition
         public Task SetupAsync(Cluster cluster, string[] kinds, bool isClient)
         {
             _cluster = cluster;
-            _partitionManager = new PartitionManager(cluster, isClient);
+            _partitionManager = new PartitionManager(cluster, isClient, _identityHandoverTimeout);
             _logger = Log.CreateLogger(nameof(PartitionIdentityLookup) + "-" + _cluster.LoggerId);
             _partitionManager.Setup();
             return Task.CompletedTask;

--- a/src/Proto.Cluster/Partition/PartitionManager.cs
+++ b/src/Proto.Cluster/Partition/PartitionManager.cs
@@ -20,13 +20,15 @@ namespace Proto.Cluster.Partition
         private readonly ActorSystem _system;
         private PID _partitionPlacementActor = null!;
         private PID _partitionIdentityActor = null!;
+        private readonly TimeSpan _identityHandoverTimeout;
 
-        internal PartitionManager(Cluster cluster, bool isClient)
+        internal PartitionManager(Cluster cluster, bool isClient, TimeSpan identityHandoverTimeout)
         {
             _cluster = cluster;
             _system = cluster.System;
             _context = _system.Root;
             _isClient = isClient;
+            _identityHandoverTimeout = identityHandoverTimeout;
         }
 
         internal PartitionMemberSelector Selector { get; } = new();
@@ -48,7 +50,7 @@ namespace Proto.Cluster.Partition
             else
             {
                 var partitionActorProps = Props
-                    .FromProducer(() => new PartitionIdentityActor(_cluster))
+                    .FromProducer(() => new PartitionIdentityActor(_cluster, _identityHandoverTimeout))
                     .WithGuardianSupervisorStrategy(Supervision.AlwaysRestartStrategy);
                 _partitionIdentityActor = _context.SpawnNamed(partitionActorProps, PartitionIdentityActorName);
 

--- a/src/Proto.Remote/Endpoints/EndpointSupervisorStrategy.cs
+++ b/src/Proto.Remote/Endpoints/EndpointSupervisorStrategy.cs
@@ -44,7 +44,7 @@ namespace Proto.Remote
             if (ShouldStop(rs))
             {
                 Logger.LogError(
-                    "Stopping connection to address {Address} after retries expired because of {Reason}",
+                    "[EndpointSupervisor] Stopping connection to address {Address} after retries expired because of {Reason}",
                     _address, reason.GetType().Name
                 );
                 _cancelFutureRetries.Cancel();
@@ -63,14 +63,14 @@ namespace Proto.Remote
                         if (reason is RpcException rpc && rpc.StatusCode == StatusCode.Unavailable)
                         {
                             Logger.LogWarning(
-                                "Restarting {Actor} after {Duration} because endpoint is unavailable",
+                                "[EndpointSupervisor] Restarting {Actor} after {Duration} because endpoint is unavailable",
                                 child, duration
                             );
                         }
                         else
                         {
                             Logger.LogWarning(reason,
-                                "Restarting {Actor} after {Duration} because of {Reason}",
+                                "[EndpointSupervisor] Restarting {Actor} after {Duration} because of {Reason}",
                                 child, duration, reason.GetType().Name
                             );
                         }

--- a/tests/Proto.Actor.Tests/EventStreamTests.cs
+++ b/tests/Proto.Actor.Tests/EventStreamTests.cs
@@ -9,8 +9,10 @@ namespace Proto.Tests
         [Fact]
         public void EventStream_CanSubscribeToSpecificEventTypes()
         {
+            var system = new ActorSystem();
+            var eventStream = system.EventStream;
             var received = "";
-            var eventStream = new EventStream();
+
             eventStream.Subscribe<string>(theString => received = theString);
             eventStream.Publish("hello");
             Assert.Equal("hello", received);
@@ -19,8 +21,10 @@ namespace Proto.Tests
         [Fact]
         public void EventStream_CanSubscribeToAllEventTypes()
         {
+            var system = new ActorSystem();
+            var eventStream = system.EventStream;
             var receivedEvents = new List<object>();
-            var eventStream = new EventStream();
+            
             eventStream.Subscribe(@event => receivedEvents.Add(@event));
             eventStream.Publish("hello");
             eventStream.Publish(1);
@@ -31,8 +35,9 @@ namespace Proto.Tests
         [Fact]
         public void EventStream_CanUnsubscribeFromEvents()
         {
+            var system = new ActorSystem();
+            var eventStream = system.EventStream;
             var receivedEvents = new List<object>();
-            var eventStream = new EventStream();
             var subscription = eventStream.Subscribe<string>(@event => receivedEvents.Add(@event));
             eventStream.Publish("first message");
             subscription.Unsubscribe();
@@ -43,8 +48,10 @@ namespace Proto.Tests
         [Fact]
         public void EventStream_OnlyReceiveSubscribedToEventTypes()
         {
+            var system = new ActorSystem();
+            var eventStream = system.EventStream;
+            
             var eventsReceived = new List<object>();
-            var eventStream = new EventStream();
             eventStream.Subscribe<int>(@event => eventsReceived.Add(@event));
             eventStream.Publish("not an int");
             Assert.Empty(eventsReceived);
@@ -53,8 +60,10 @@ namespace Proto.Tests
         [Fact]
         public void EventStream_CanSubscribeToSpecificEventTypes_Async()
         {
+            var system = new ActorSystem();
+            var eventStream = system.EventStream;
+            
             string received;
-            var eventStream = new EventStream();
             eventStream.Subscribe<string>(theString => {
                     received = theString;
                     Assert.Equal("hello", received);


### PR DESCRIPTION
Option to ActorSystemConfig to disable DeadLetter logging for dead letters that have a sender.
The idea is that dead letters with Sender set, were sent from some Request/RequestAync, and thus, the sender side is responsible for keeping track of the outcome.

The default is to log all dead letters, but you now have the option to silence that for requests

```csharp
var config = new ActorSystemConfig().WithDeadLetterLogging(false);
```