### PR TITLE
MemberList Consensus

### DIFF
--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -63,6 +63,7 @@ namespace Proto.Cluster.Partition
 
         private async Task OnClusterTopology(ClusterTopology msg, IContext context)
         {
+            await _cluster.MemberList.ConsensusAsync();
             if (_eventId == msg.EventId) return;
 
             _eventId = msg.EventId;

--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -155,9 +155,6 @@ namespace Proto.Cluster.Partition
 
         private async Task OnActivationRequest(ActivationRequest msg, IContext context)
         {
-            //only activate members when we are all in sync
-            await _cluster.MemberList.ConsensusAsync();
-            
             var ownerAddress = _rdv.GetOwnerMemberByIdentity(msg.Identity);
 
             if (ownerAddress != _myAddress)
@@ -179,6 +176,9 @@ namespace Proto.Cluster.Partition
                 context.Respond(new ActivationResponse {Pid = pid});
                 return;
             }
+            
+            //only activate members when we are all in sync
+            await _cluster.MemberList.ConsensusAsync();
 
             //Get activator
             var activatorAddress = _cluster.MemberList.GetActivator(msg.Kind, context.Sender.Address)?.Address;

--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -63,7 +63,7 @@ namespace Proto.Cluster.Partition
 
         private async Task OnClusterTopology(ClusterTopology msg, IContext context)
         {
-            await _cluster.MemberList.ConsensusAsync();
+            await _cluster.MemberList.TopologyConsensus();
             if (_eventId == msg.EventId) return;
 
             _eventId = msg.EventId;
@@ -178,7 +178,7 @@ namespace Proto.Cluster.Partition
             }
             
             //only activate members when we are all in sync
-            await _cluster.MemberList.ConsensusAsync();
+            await _cluster.MemberList.TopologyConsensus();
 
             //Get activator
             var activatorAddress = _cluster.MemberList.GetActivator(msg.Kind, context.Sender.Address)?.Address;


### PR DESCRIPTION
Consensus is the wrong word here as that often refers to some form of voting strategy.
This PR introduces the ConsensusAsync task on MemberList.

Meaning you can await this method inside an actor. and that actor will only continue when the cluster agrees on the current topology.

e.g. the PartitionIdentityActor can await this before doing handover requests.
(I added it to activation requests also here, maybe that is wrong, maybe its right)