### PR TITLE
Task clock

### DIFF
--- a/benchmarks/ClusterBenchmark/ClusterBenchmark.csproj
+++ b/benchmarks/ClusterBenchmark/ClusterBenchmark.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <OutputType>Exe</OutputType>
-        <LangVersion>8</LangVersion>
+        <LangVersion>9</LangVersion>
         <RootNamespace>ClusterExperiment1</RootNamespace>
     </PropertyGroup>
 

--- a/benchmarks/ClusterBenchmark/Configuration.cs
+++ b/benchmarks/ClusterBenchmark/Configuration.cs
@@ -155,11 +155,11 @@ namespace ClusterExperiment1
         public static void SetupLogger()
         {
             Log.Logger = new LoggerConfiguration()
-                .WriteTo.Console(LogEventLevel.Information)
+                .WriteTo.Console(LogEventLevel.Error)
                 .CreateLogger();
             
             Proto.Log.SetLoggerFactory(LoggerFactory.Create(l =>
-                    l.AddSerilog().SetMinimumLevel(LogLevel.Information)
+                    l.AddSerilog().SetMinimumLevel(LogLevel.Error)
                 )
             );
         }

--- a/src/Proto.Actor/Utils/TaskClock.cs
+++ b/src/Proto.Actor/Utils/TaskClock.cs
@@ -1,0 +1,38 @@
+// -----------------------------------------------------------------------
+// <copyright file="TaskClock.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Proto.Utils
+{
+    public class TaskClock
+    {
+        private readonly TimeSpan _bucketSize;
+        private readonly TimeSpan _updateInterval;
+        private readonly CancellationToken _ct;
+        public Task CurrentBucket { get; private set; }
+        public TaskClock(TimeSpan bucketSize, TimeSpan updateInterval, CancellationToken ct)
+        {
+            _bucketSize = bucketSize;
+            _updateInterval = updateInterval;
+            _ct = ct;
+        }
+
+        public void Start()
+        {
+            CurrentBucket = Task.Delay(_bucketSize,_ct);
+            _ = SafeTask.Run(async () => {
+                    while (!_ct.IsCancellationRequested)
+                    {
+                        CurrentBucket = Task.Delay(_bucketSize,_ct);
+                        await Task.Delay(_updateInterval,_ct);
+                    }
+                }
+            );
+        }
+    }
+}

--- a/src/Proto.Actor/Utils/TaskClock.cs
+++ b/src/Proto.Actor/Utils/TaskClock.cs
@@ -15,9 +15,9 @@ namespace Proto.Utils
         private readonly TimeSpan _updateInterval;
         private readonly CancellationToken _ct;
         public Task CurrentBucket { get; private set; }
-        public TaskClock(TimeSpan bucketSize, TimeSpan updateInterval, CancellationToken ct)
+        public TaskClock(TimeSpan timeout, TimeSpan updateInterval, CancellationToken ct)
         {
-            _bucketSize = bucketSize;
+            _bucketSize = timeout + updateInterval;
             _updateInterval = updateInterval;
             _ct = ct;
         }

--- a/src/Proto.Cluster/ClusterConfig.cs
+++ b/src/Proto.Cluster/ClusterConfig.cs
@@ -50,7 +50,7 @@ namespace Proto.Cluster
         public TimeSpan ClusterRequestDeDuplicationWindow { get; init; }
 
         public Func<Cluster, IClusterContext> ClusterContextProducer { get; init; } =
-            c => new DefaultClusterContext(c.IdentityLookup, c.PidCache, c.Logger, c.Config.ToClusterContextConfig());
+            c => new DefaultClusterContext(c.IdentityLookup, c.PidCache, c.Logger, c.Config.ToClusterContextConfig(),c.System.Shutdown);
 
         public ClusterConfig WithTimeout(TimeSpan timeSpan) =>
             this with {TimeoutTimespan = timeSpan};

--- a/tests/Proto.Cluster.Tests/PidCacheTests.cs
+++ b/tests/Proto.Cluster.Tests/PidCacheTests.cs
@@ -42,7 +42,7 @@ namespace Proto.Cluster.Tests
             var logger = Log.CreateLogger("dummylog");
             var clusterIdentity = new ClusterIdentity {Identity = "identity", Kind = "kind"};
             pidCache.TryAdd(clusterIdentity, deadPid);
-            var requestAsyncStrategy = new DefaultClusterContext(dummyIdentityLookup, pidCache, logger, new ClusterContextConfig());
+            var requestAsyncStrategy = new DefaultClusterContext(dummyIdentityLookup, pidCache, logger, new ClusterContextConfig(), system.Shutdown);
 
             var res = await requestAsyncStrategy.RequestAsync<Pong>(clusterIdentity, new Ping {Message = "msg"}, system.Root,
                 new CancellationTokenSource(6000).Token


### PR DESCRIPTION
Instead of creating cancellation token sources for every request, we can use a shared clock that pulses out a new task every x seconds. consumers can then pick up the current task from the clock and use that as a shared timeout.

e.g.
we can pulse every 1 sec and emit a task that delays for 5 seconds.
the next second, it pulses another 5 sec task.

meaning that we have ~5 delay tasks scheduled at any given point in time.

```
|----
 |----
  |----
   |----
    |----
     |---- when this starts the first task is done
```