### PR TITLE
SqlServerProvider - Create custom schema if `AutoCreateTables`=true

### DIFF
--- a/src/Proto.Persistence.SqlServer/SqlServerProvider.cs
+++ b/src/Proto.Persistence.SqlServer/SqlServerProvider.cs
@@ -234,6 +234,8 @@ namespace Proto.Persistence.SqlServer
 
             using var command = new SqlCommand(sql, connection);
 
+            connection.Open();
+
             command.ExecuteNonQuery();
         }
     }

--- a/src/Proto.Persistence.SqlServer/SqlServerProvider.cs
+++ b/src/Proto.Persistence.SqlServer/SqlServerProvider.cs
@@ -164,6 +164,11 @@ namespace Proto.Persistence.SqlServer
         private void CreateSnapshotTable()
         {
             var sql = $@"
+            IF NOT EXISTS ( SELECT * FROM sys.schemas WHERE name = N'{_tableSchema}' )
+            BEGIN
+                EXEC('CREATE SCHEMA [{_tableSchema}]');
+            END
+
             IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{_tableSchema}' AND TABLE_NAME = '{_tableSnapshots}')
             BEGIN
                 CREATE TABLE {_tableSchema}.{_tableSnapshots} (
@@ -185,6 +190,11 @@ namespace Proto.Persistence.SqlServer
         private void CreateEventTable()
         {
             var sql = $@"
+            IF NOT EXISTS ( SELECT * FROM sys.schemas WHERE name = N'{_tableSchema}' )
+            BEGIN
+                EXEC('CREATE SCHEMA [{_tableSchema}]');
+            END
+
             IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{_tableSchema}' AND TABLE_NAME = '{_tableEvents}')
             BEGIN
                 CREATE TABLE {_tableSchema}.{_tableEvents} (

--- a/tests/Proto.Persistence.Tests/InMemoryProvider.cs
+++ b/tests/Proto.Persistence.Tests/InMemoryProvider.cs
@@ -30,15 +30,17 @@ namespace Proto.Persistence.Tests
 
         public Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
         {
+            var lastIndex = 0l;
             if (_events.TryGetValue(actorName, out var events))
             {
                 foreach (var e in events.Where(e => e.Key >= indexStart && e.Key <= indexEnd))
                 {
+                    lastIndex = e.Key;
                     callback(e.Value);
                 }
             }
 
-            return Task.FromResult(0L);
+            return Task.FromResult(lastIndex);
         }
 
         public Task<long> PersistEventAsync(string actorName, long index, object @event)
@@ -47,7 +49,9 @@ namespace Proto.Persistence.Tests
 
             events.Add(index, @event);
 
-            return Task.FromResult(0L);
+            long max = events.Max(x => x.Key);
+
+            return Task.FromResult(max);
         }
 
         public Task PersistSnapshotAsync(string actorName, long index, object snapshot)
@@ -58,7 +62,7 @@ namespace Proto.Persistence.Tests
 
             snapshots.Add(index, copy);
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public Task DeleteEventsAsync(string actorName, long inclusiveToIndex)
@@ -72,7 +76,7 @@ namespace Proto.Persistence.Tests
 
             eventsToRemove.ForEach(key => events.Remove(key));
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public Task DeleteSnapshotsAsync(string actorName, long inclusiveToIndex)
@@ -86,7 +90,7 @@ namespace Proto.Persistence.Tests
 
             snapshotsToRemove.ForEach(key => snapshots.Remove(key));
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public Dictionary<long, object> GetSnapshots(string actorId) => _snapshots[actorId];


### PR DESCRIPTION
## Description

When the `SqlServerProvider` for data persistence is used it contains an option to create the database tables needed for storage the first time it is used. However, if you specify that the tables should be located in a _schema_ that does not already exist in the database then the provider will throw an exception because it cannot create the table if the schema is not present.

In this pull request, I have added a new method to the startup code for the `SqlServerProvider` class that will create the requested schema if it does not already exist in the database.

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
