### PR TITLE
Serializer surrogate support

### DIFF
--- a/src/Proto.Cluster/Grain/GrainRequest.cs
+++ b/src/Proto.Cluster/Grain/GrainRequest.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+// <copyright file="GrainRequest.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using Google.Protobuf;
+using Proto.Remote;
+
+namespace Proto.Cluster
+{
+    public partial class GrainRequest : IRootSerialized
+    {
+        //deserialize into the in-process message type that the grain actors understands
+        public IRootSerializable Deserialize(ActorSystem system)
+        {
+            var ser = system.Serialization();
+            var message = ser.Deserialize(MessageTypeName, MessageData, ser.DefaultSerializerId);
+            return new GrainRequestMessage(MethodIndex, (IMessage)message);
+        }
+    }
+}

--- a/src/Proto.Cluster/Grain/GrainRequestMessage.cs
+++ b/src/Proto.Cluster/Grain/GrainRequestMessage.cs
@@ -1,0 +1,28 @@
+// -----------------------------------------------------------------------
+// <copyright file="Extensions.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using Google.Protobuf;
+using Proto.Remote;
+
+namespace Proto.Cluster
+{
+    public record GrainRequestMessage(int MethodIndex, IMessage RequestMessage) : IRootSerializable
+    {
+
+        //serialize into the on-the-wire format
+        public IRootSerialized Serialize(ActorSystem system)
+        {
+            var ser = system.Serialization();
+            var typeName = ser.GetTypeName(RequestMessage, ser.DefaultSerializerId);
+            var data = ser.Serialize(RequestMessage, ser.DefaultSerializerId);
+            return new GrainRequest
+            {
+                MethodIndex = MethodIndex,
+                MessageData = data,
+                MessageTypeName = typeName,
+            };
+        }
+    }
+}

--- a/src/Proto.Cluster/Protos.proto
+++ b/src/Proto.Cluster/Protos.proto
@@ -1,7 +1,6 @@
 ﻿syntax = "proto3";
 package cluster;
 option csharp_namespace = "Proto.Cluster";
-
 import "Proto.Actor/Protos.proto";
 
 //request response call from Identity actor sent to each member
@@ -45,10 +44,12 @@ message ActivationResponse {
 message GrainRequest {
     int32 method_index = 1;
     bytes message_data = 2;
+    string message_type_name = 3;
 }
 
 message GrainResponse {
-    bytes message_data = 1;
+  bytes message_data = 1;
+  string message_type_name = 2;
 }
 
 message GrainErrorResponse {

--- a/src/Proto.Remote/Endpoints/EndpointActor.cs
+++ b/src/Proto.Remote/Endpoints/EndpointActor.cs
@@ -238,7 +238,12 @@ namespace Proto.Remote
                     targetNameList.Add(targetName);
                 }
 
-                var typeName = _remoteConfig.Serialization.GetTypeName(rd.Message, serializerId);
+                var message = rd.Message;
+                //if the message can be translated to a serialization representation, we do this here
+                //this only apply to root level messages and never to nested child objects inside the message
+                if (message is IRootSerializable deserialized) message = deserialized.Serialize(context.System);
+
+                var typeName = _remoteConfig.Serialization.GetTypeName(message, serializerId);
 
                 if (!context.System.Metrics.IsNoop) counter.Inc(new[] {context.System.Id, context.System.Address, typeName});
 
@@ -256,7 +261,7 @@ namespace Proto.Remote
                     header.HeaderData.Add(rd.Header.ToDictionary());
                 }
 
-                var bytes = _remoteConfig.Serialization.Serialize(rd.Message, serializerId);
+                var bytes = _remoteConfig.Serialization.Serialize(message, serializerId);
 
                 var envelope = new MessageEnvelope
                 {

--- a/src/Proto.Remote/Endpoints/EndpointReader.cs
+++ b/src/Proto.Remote/Endpoints/EndpointReader.cs
@@ -114,6 +114,10 @@ namespace Proto.Remote
                     {
                         message =
                             _serialization.Deserialize(typeName, envelope.MessageData, envelope.SerializerId);
+
+                        //translate from on-the-wire representation to in-process representation
+                        //this only applies to root level messages, and never on nested child messages
+                        if (message is IRootSerialized serialized) message = serialized.Deserialize(_system);
                     }
                     catch (Exception)
                     {

--- a/src/Proto.Remote/Serialization/IMessageSurrogate.cs
+++ b/src/Proto.Remote/Serialization/IMessageSurrogate.cs
@@ -1,0 +1,37 @@
+// -----------------------------------------------------------------------
+// <copyright file="IMessageSurrogate.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Proto.Remote
+{
+    /// <summary>
+    /// The root level in-process representation of a message
+    /// </summary>
+    public interface IRootSerializable
+    {
+        /// <summary>
+        /// Returns the on-the-wire representation of the message
+        /// 
+        /// Message -> IRootSerialized -> ByteString
+        /// </summary>
+        /// <param name="system">The ActorSystem the message belongs to</param>
+        /// <returns></returns>
+        IRootSerialized Serialize(ActorSystem system);
+    }
+    
+    /// <summary>
+    /// The root level on-the-wire representation of a message
+    /// </summary>
+    public interface IRootSerialized
+    {
+        /// <summary>
+        /// Returns the in-process representation of a message
+        ///
+        /// ByteString -> IRootSerialized -> Message
+        /// </summary>
+        /// <param name="system">The ActorSystem the message belongs to</param>
+        /// <returns></returns>
+        IRootSerializable Deserialize(ActorSystem system);
+    }
+}


### PR DESCRIPTION
This PR makes it possible to use serializer surrogates, very similar to how I implemented in Akka NET, but on a root message level only.
Meaning, we will not support unwinding nested messages, which can only be supported at magic-serializer level, I will not go there again.

But, this at least allows us to have one representation of a root message in-process, and another on serialization level.

TLDR; we can have local GrainRequests and GrainResponses that does not need to serialize requests locally.