### PR TITLE
Refactored ClusterInit, receiver per kind instead of per activation

### DIFF
--- a/src/Proto.Cluster/ActivatedClusterKind.cs
+++ b/src/Proto.Cluster/ActivatedClusterKind.cs
@@ -7,9 +7,21 @@ using System.Threading;
 
 namespace Proto.Cluster
 {
-    public record ActivatedClusterKind(string Name, Props Props, IMemberStrategy? Strategy)
+    public record ActivatedClusterKind
     {
+        
         private int _count;
+
+        internal ActivatedClusterKind(string name, Props props, IMemberStrategy? strategy)
+        {
+            Name = name;
+            Props = props.WithClusterKind(this);
+            Strategy = strategy;
+        }
+
+        public string Name { get; }
+        public Props Props { get; }
+        public IMemberStrategy? Strategy { get; }
 
         internal int Inc() => Interlocked.Increment(ref _count);
         internal int Dec() => Interlocked.Decrement(ref _count);

--- a/src/Proto.Cluster/Identity/IdentityActivatorProxy.cs
+++ b/src/Proto.Cluster/Identity/IdentityActivatorProxy.cs
@@ -7,7 +7,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Proto.Logging;
 
 namespace Proto.Cluster.Identity
 {

--- a/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
+++ b/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
@@ -98,7 +98,7 @@ namespace Proto.Cluster.Identity
                     //spawn and remember this actor
                     //as this id is unique for this activation (id+counter)
                     //we cannot get ProcessNameAlreadyExists exception here
-                    var clusterProps = clusterKind.Props.WithClusterInit(_cluster, msg.ClusterIdentity, clusterKind);
+                    var clusterProps = clusterKind.Props.WithClusterIdentity(msg.ClusterIdentity);
 
                     var sw = Stopwatch.StartNew();
                     var pid = context.SpawnPrefix(clusterProps, msg.ClusterIdentity.ToString());

--- a/src/Proto.Cluster/Member/LocalAffinityExtensions.cs
+++ b/src/Proto.Cluster/Member/LocalAffinityExtensions.cs
@@ -7,7 +7,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Proto.Cluster.Identity;
-using Proto.Mailbox;
 using Proto.Utils;
 
 namespace Proto.Cluster

--- a/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
@@ -17,7 +17,7 @@ namespace Proto.Cluster.Partition
 
         //pid -> the actor that we have created here
         //kind -> the actor kind
-        private readonly Dictionary<ClusterIdentity, PID > _myActors = new();
+        private readonly Dictionary<ClusterIdentity, PID> _myActors = new();
 
         public PartitionPlacementActor(Cluster cluster)
         {
@@ -44,7 +44,7 @@ namespace Proto.Cluster.Partition
                 Pid = pid,
                 ClusterIdentity = clusterIdentity,
             };
-            
+
             _cluster.MemberList.BroadcastEvent(activationTerminated);
 
             // var ownerAddress = _rdv.GetOwnerMemberByIdentity(clusterIdentity.Identity);
@@ -54,8 +54,6 @@ namespace Proto.Cluster.Partition
             _myActors.Remove(clusterIdentity);
             return Task.CompletedTask;
         }
-
-
 
         //this is pure, we do not change any state or actually move anything
         //the requester also provide its own view of the world in terms of members
@@ -116,7 +114,7 @@ namespace Proto.Cluster.Partition
                     //as this id is unique for this activation (id+counter)
                     //we cannot get ProcessNameAlreadyExists exception here
 
-                    var clusterProps = clusterKind.Props.WithClusterInit(_cluster, msg.ClusterIdentity, clusterKind);
+                    var clusterProps = clusterKind.Props.WithClusterIdentity(msg.ClusterIdentity);
 
                     var pid = context.SpawnPrefix(clusterProps, msg.ClusterIdentity.Identity);
 


### PR DESCRIPTION
Identity will now be retrieved from the actor-local context store, eliminating the need for a specific receiver per identity.