### PR TITLE
Receive AutoRespond messages

### DIFF
--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -398,9 +398,13 @@ namespace Proto.Context
 
         private Task HandleAutoRespond(IAutoRespond autoRespond)
         {
+            // receive normally
+            var res =  Actor!.ReceiveAsync(_props.ContextDecoratorChain is not null ? EnsureExtras().Context : this);
+            //then respond automatically
             var response = autoRespond.GetAutoResponse();
             Respond(response);
-            return Task.CompletedTask;
+            //return task from receive
+            return res;
         }
 
         private Task HandlePoisonPill()


### PR DESCRIPTION
Allowing actors to user Receive AutoRespond messages, allows us to use AutoRespondMessage as a commit checkpoint for persistence.

e.g. If we send 1000 messages in a batch and make the batch autorespond, we get a single Ack for that batch.
And the actors can act on this and commit any state to a database at that point.
Meaning 1000 times fewer writes to DB.