### PR TITLE
Support for using multiple Serializer instances.

### DIFF
--- a/src/Proto.Cluster/Grain/GrainRequest.cs
+++ b/src/Proto.Cluster/Grain/GrainRequest.cs
@@ -14,7 +14,7 @@ namespace Proto.Cluster
         public IRootSerializable Deserialize(ActorSystem system)
         {
             var ser = system.Serialization();
-            var message = ser.Deserialize(MessageTypeName, MessageData, ser.DefaultSerializerId);
+            var message = ser.Deserialize(MessageTypeName, MessageData, Serialization.SERIALIZER_ID_PROTOBUF);
             return new GrainRequestMessage(MethodIndex, (IMessage)message);
         }
     }

--- a/src/Proto.Cluster/Grain/GrainRequestMessage.cs
+++ b/src/Proto.Cluster/Grain/GrainRequestMessage.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2015-2021 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
+using System;
 using Google.Protobuf;
 using Proto.Remote;
 
@@ -15,8 +16,11 @@ namespace Proto.Cluster
         public IRootSerialized Serialize(ActorSystem system)
         {
             var ser = system.Serialization();
-            var typeName = ser.GetTypeName(RequestMessage, ser.DefaultSerializerId);
-            var data = ser.Serialize(RequestMessage, ser.DefaultSerializerId);
+            var (data, typeName, serializerId) = ser.Serialize(RequestMessage);
+#if DEBUG
+            if (serializerId != Serialization.SERIALIZER_ID_PROTOBUF)
+                throw new Exception($"Grains must use ProtoBuf types: {RequestMessage.GetType().FullName}");
+#endif
             return new GrainRequest
             {
                 MethodIndex = MethodIndex,

--- a/src/Proto.Cluster/Grain/GrainResponse.cs
+++ b/src/Proto.Cluster/Grain/GrainResponse.cs
@@ -14,7 +14,7 @@ namespace Proto.Cluster
         public IRootSerializable Deserialize(ActorSystem system)
         {
             var ser = system.Serialization();
-            var message = ser.Deserialize(MessageTypeName, MessageData, ser.DefaultSerializerId);
+            var message = ser.Deserialize(MessageTypeName, MessageData, Serialization.SERIALIZER_ID_PROTOBUF);
             return new GrainResponseMessage((IMessage)message);
         }
     }

--- a/src/Proto.Cluster/Grain/GrainResponseMessage.cs
+++ b/src/Proto.Cluster/Grain/GrainResponseMessage.cs
@@ -14,8 +14,11 @@ namespace Proto.Cluster
         public IRootSerialized Serialize(ActorSystem system)
         {
             var ser = system.Serialization();
-            var typeName = ser.GetTypeName(ResponseMessage, ser.DefaultSerializerId);
-            var data = ser.Serialize(ResponseMessage, ser.DefaultSerializerId);
+            var (data, typeName, serializerId) = ser.Serialize(ResponseMessage);
+#if DEBUG
+            if (serializerId != Serialization.SERIALIZER_ID_PROTOBUF)
+                throw new Exception($"Grains must use ProtoBuf types: {RequestMessage.GetType().FullName}");
+#endif
             return new GrainResponse
             {
                 MessageData = data,

--- a/src/Proto.Cluster/PubSub/ProducerBatchMessage.cs
+++ b/src/Proto.Cluster/PubSub/ProducerBatchMessage.cs
@@ -24,8 +24,7 @@ namespace Proto.Cluster
             var batch = new ProducerBatch();
             foreach (var message in Envelopes)
             {
-                var typeName = s.GetTypeName(message, s.DefaultSerializerId);
-                var messageData = s.Serialize(message, s.DefaultSerializerId);
+                var (messageData, typeName, serializerId) = s.Serialize(message);
                 var typeIndex = batch.TypeNames.IndexOf(typeName);
 
                 if (typeIndex == -1)
@@ -55,7 +54,7 @@ namespace Proto.Cluster
             //deserialize messages in the envelope
             var messages = Envelopes
                 .Select(e => ser
-                    .Deserialize(TypeNames[e.TypeId], e.MessageData, ser.DefaultSerializerId))
+                    .Deserialize(TypeNames[e.TypeId], e.MessageData, e.SerializerId))
                 .ToList();
 
             var res = new ProducerBatchMessage();

--- a/src/Proto.Cluster/PubSub/TopicBatchMessage.cs
+++ b/src/Proto.Cluster/PubSub/TopicBatchMessage.cs
@@ -23,8 +23,7 @@ namespace Proto.Cluster
             foreach (var message in Envelopes)
             {
                 
-                var typeName = s.GetTypeName(message, s.DefaultSerializerId);
-                var messageData = s.Serialize(message, s.DefaultSerializerId);
+                var (messageData, typeName, serializerId) = s.Serialize(message);
                 var typeIndex = batch.TypeNames.IndexOf(typeName);
 
                 if (typeIndex == -1)
@@ -37,6 +36,7 @@ namespace Proto.Cluster
                 {
                     MessageData = messageData,
                     TypeId = typeIndex,
+                    SerializerId = serializerId,
                 };
                 
                 batch.Envelopes.Add(topicEnvelope);
@@ -54,7 +54,7 @@ namespace Proto.Cluster
             //deserialize messages in the envelope
             var messages = Envelopes
                 .Select(e => ser
-                    .Deserialize(TypeNames[e.TypeId], e.MessageData, ser.DefaultSerializerId))
+                    .Deserialize(TypeNames[e.TypeId], e.MessageData, e.SerializerId))
                 .ToList();
 
             return new TopicBatchMessage(messages);

--- a/src/Proto.Remote/Endpoints/EndpointReader.cs
+++ b/src/Proto.Remote/Endpoints/EndpointReader.cs
@@ -49,7 +49,9 @@ namespace Proto.Remote
             return Task.FromResult(
                 new ConnectResponse
                 {
-                    DefaultSerializerId = _serialization.DefaultSerializerId
+                    // NOTE: This is here for backward compatibility. Current version of Serialization
+                    // implementation doesn't utilize the default serializer idea.
+                    DefaultSerializerId = Serialization.SERIALIZER_ID_PROTOBUF,
                 }
             );
         }

--- a/src/Proto.Remote/Messages.cs
+++ b/src/Proto.Remote/Messages.cs
@@ -32,7 +32,7 @@ namespace Proto.Remote
 
     public sealed record RemoteUnwatch(PID Watcher, PID Watchee);
 
-    public sealed record RemoteDeliver (Proto.MessageHeader Header, object Message, PID Target, PID Sender, int SerializerId);
+    public sealed record RemoteDeliver (Proto.MessageHeader Header, object Message, PID Target, PID Sender);
 
     public class JsonMessage
     {

--- a/src/Proto.Remote/RemoteConfigExtensions.cs
+++ b/src/Proto.Remote/RemoteConfigExtensions.cs
@@ -101,10 +101,10 @@ namespace Proto.Remote
                 remoteConfig.RemoteKinds.AddRange(knownKinds.Select(kk => new KeyValuePair<string, Props>(kk.kind, kk.prop)))
             };
 
-        public static TRemoteConfig WithSerializer<TRemoteConfig>(this TRemoteConfig remoteConfig, ISerializer serializer, bool makeDefault = false)
+        public static TRemoteConfig WithSerializer<TRemoteConfig>(this TRemoteConfig remoteConfig, int serializerId, int priority, ISerializer serializer)
             where TRemoteConfig : RemoteConfigBase
         {
-            remoteConfig.Serialization.RegisterSerializer(serializer, makeDefault);
+            remoteConfig.Serialization.RegisterSerializer(serializerId, priority, serializer);
             return remoteConfig;
         }
 

--- a/src/Proto.Remote/RemoteProcess.cs
+++ b/src/Proto.Remote/RemoteProcess.cs
@@ -52,7 +52,7 @@ namespace Proto.Remote
                         return;
                     }
 
-                    message = new RemoteDeliver(header!, m, _pid, sender!, -1);
+                    message = new RemoteDeliver(header!, m, _pid, sender!);
                     break;
             }
 

--- a/src/Proto.Remote/Serialization/ISerializer.cs
+++ b/src/Proto.Remote/Serialization/ISerializer.cs
@@ -14,5 +14,7 @@ namespace Proto.Remote
         object Deserialize(ByteString bytes, string typeName);
 
         string GetTypeName(object message);
+
+        bool CanSerialize(object obj);
     }
 }

--- a/src/Proto.Remote/Serialization/JsonSerializer.cs
+++ b/src/Proto.Remote/Serialization/JsonSerializer.cs
@@ -42,5 +42,7 @@ namespace Proto.Remote
 
             throw new ArgumentException("obj must be of type IMessage", nameof(obj));
         }
+
+        public bool CanSerialize(object obj) => true;
     }
 }

--- a/src/Proto.Remote/Serialization/ProtobufSerializer.cs
+++ b/src/Proto.Remote/Serialization/ProtobufSerializer.cs
@@ -34,5 +34,7 @@ namespace Proto.Remote
 
             throw new ArgumentException("obj must be of type IMessage", nameof(obj));
         }
+
+        public bool CanSerialize(object obj) => obj is IMessage;
     }
 }

--- a/src/Proto.Remote/Serialization/Serialization.cs
+++ b/src/Proto.Remote/Serialization/Serialization.cs
@@ -4,7 +4,10 @@
 //   </copyright>
 // -----------------------------------------------------------------------
 
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Proto.Extensions;
@@ -13,23 +16,65 @@ namespace Proto.Remote
 {
     public class Serialization : IActorSystemExtension<Serialization>
     {
-        private readonly List<ISerializer> _serializers = new();
+        struct SerializerItem
+        {
+            public int SerializerId;
+            public int PriorityValue;
+            public ISerializer Serializer;
+        }
+
+        struct TypeSerializerItem
+        {
+            public ISerializer Serializer;
+            public int SerializerId;
+        }
+
+        private List<SerializerItem> _serializers = new();
+        private readonly ConcurrentDictionary<Type, TypeSerializerItem> _serializerLookup = new();
         internal readonly Dictionary<string, MessageParser> TypeLookup = new();
+
+        public const int SERIALIZER_ID_PROTOBUF = 0;
+        public const int SERIALIZER_ID_JSON = 1;
 
         public Serialization()
         {
             RegisterFileDescriptor(Proto.ProtosReflection.Descriptor);
             RegisterFileDescriptor(ProtosReflection.Descriptor);
-            RegisterSerializer(new ProtobufSerializer(this), true);
-            RegisterSerializer(new JsonSerializer(this));
+            RegisterSerializer(
+                SERIALIZER_ID_PROTOBUF,
+                priority: 0,
+                new ProtobufSerializer(this));
+            RegisterSerializer(
+                SERIALIZER_ID_JSON,
+                priority: -1000,
+                new JsonSerializer(this));
         }
 
-        public int DefaultSerializerId { get; set; }
-
-        public void RegisterSerializer(ISerializer serializer, bool makeDefault = false)
+        /// <summary>
+        /// Registers a new serializer with this Serialization instance.
+        /// SerializerId must correspond to the same serializer on all remote nodes (cluster members).
+        /// ProtoBufSerializer's id is 0, JsonSerializer's is 1 by default.
+        /// Priority defined in which order Serializers should be considered to be the serializer for a given type.
+        /// ProtoBufSerializer has priority of 0, and JsonSerializer has priority of -1000.
+        /// </summary>
+        public void RegisterSerializer(
+            int serializerId,
+            int priority,
+            ISerializer serializer)
         {
-            _serializers.Add(serializer);
-            if (makeDefault) DefaultSerializerId = _serializers.Count - 1;
+            if (_serializers.Any(v => v.SerializerId == serializerId))
+                throw new Exception($"Already registered serializer id: {serializerId} = {_serializers[serializerId].GetType()}");
+
+            _serializers.Add(new SerializerItem()
+            {
+                SerializerId = serializerId,
+                PriorityValue = priority,
+                Serializer = serializer,
+            });
+            // Sort by PriorityValue, from highest to lowest.
+            _serializers = _serializers
+                .OrderByDescending(v => v.PriorityValue)
+                .ToList();
         }
 
         public void RegisterFileDescriptor(FileDescriptor fd)
@@ -40,11 +85,47 @@ namespace Proto.Remote
             }
         }
 
-        public ByteString Serialize(object message, int serializerId) => _serializers[serializerId].Serialize(message);
+        public (ByteString bytes, string typename, int serializerId) Serialize(object message)
+        {
+            var serializer = FindSerializerToUse(message);
+            var typename = serializer.Serializer.GetTypeName(message);
+            var serializerId = serializer.SerializerId;
+            var bytes = serializer.Serializer.Serialize(message);
+            return (bytes, typename, serializerId);
+        }
 
-        public string GetTypeName(object message, int serializerId) => _serializers[serializerId].GetTypeName(message);
+        TypeSerializerItem FindSerializerToUse(object message)
+        {
+            var type = message.GetType();
+            TypeSerializerItem serializer;
+            if (_serializerLookup.TryGetValue(type, out serializer))
+                return serializer;
 
-        public object Deserialize(string typeName, ByteString bytes, int serializerId) =>
-            _serializers[serializerId].Deserialize(bytes, typeName);
+            // Determine which serializer can serialize this object type.
+            foreach (var serializerItem in _serializers)
+            {
+                if (serializerItem.Serializer.CanSerialize(message))
+                {
+                    var item = new TypeSerializerItem()
+                    {
+                        Serializer = serializerItem.Serializer,
+                        SerializerId = serializerItem.SerializerId,
+                    };
+                    _serializerLookup[type] = item;
+                    return item;
+                }
+            }
+            throw new Exception($"Couldn't find a serializer for {message.GetType()}");
+        }
+
+        public object Deserialize(string typeName, ByteString bytes, int serializerId)
+        {
+            foreach (var serializerItem in _serializers)
+                if (serializerItem.SerializerId == serializerId)
+                    return serializerItem.Serializer.Deserialize(
+                        bytes,
+                        typeName);
+            throw new Exception($"Couldn't find serializerId: {serializerId} for typeName: {typeName}");
+        }
     }
 }

--- a/tests/Proto.Remote.Tests/RemoteTests/HostedGrpcNetWithCustomeSerializerTests.cs
+++ b/tests/Proto.Remote.Tests/RemoteTests/HostedGrpcNetWithCustomeSerializerTests.cs
@@ -30,6 +30,8 @@ namespace Proto.Remote.Tests
 
             public ByteString Serialize(object obj) =>
                 ByteString.CopyFromUtf8(System.Text.Json.JsonSerializer.Serialize(obj));
+
+            public bool CanSerialize(object obj) => true;
         }
 
         public class Fixture : RemoteFixture
@@ -40,10 +42,10 @@ namespace Proto.Remote.Tests
             public Fixture()
             {
                 var clientConfig = ConfigureClientRemoteConfig(GrpcNetRemoteConfig.BindToLocalhost())
-                    .WithSerializer(new CustomSerializer(), true);
+                    .WithSerializer(serializerId: 2, priority: 1000, new CustomSerializer());
                 (_clientHost, Remote) = GetHostedGrpcNetRemote(clientConfig);
                 var serverConfig = ConfigureServerRemoteConfig(GrpcNetRemoteConfig.BindToLocalhost())
-                    .WithSerializer(new CustomSerializer(), true);
+                    .WithSerializer(serializerId: 2, priority: 1000, new CustomSerializer());
                 (_serverHost, ServerRemote) = GetHostedGrpcNetRemote(serverConfig);
             }
 

--- a/tests/Proto.Remote.Tests/SerializationTests.cs
+++ b/tests/Proto.Remote.Tests/SerializationTests.cs
@@ -1,3 +1,4 @@
+using Google.Protobuf;
 using Proto.Remote.Tests.Messages;
 using Xunit;
 
@@ -5,14 +6,75 @@ namespace Proto.Remote.Tests
 {
     public class SerializationTests
     {
+        public class TestType1 { }
+        public class TestType2 { }
+
+        public class MockSerializer1 : ISerializer
+        {
+            public bool CanSerialize(object obj) => obj is TestType1;
+            public object Deserialize(ByteString bytes, string typeName) => new TestType1();
+            public string GetTypeName(object message) => $"MockSerializer1";
+            public ByteString Serialize(object obj) => ByteString.CopyFrom(new byte[0]);
+        }
+
+        public class MockSerializer2 : ISerializer
+        {
+            public bool CanSerialize(object obj) => obj is TestType1 || obj is TestType2;
+            public object Deserialize(ByteString bytes, string typeName) => new TestType1();
+            public string GetTypeName(object message) => $"MockSerializer2";
+            public ByteString Serialize(object obj) => ByteString.CopyFrom(new byte[0]);
+        }
+
+        [Fact]
+        public void CanUtilizeMultipleSerializers()
+        {
+            var serialization = new Serialization();
+            serialization.RegisterSerializer(
+                serializerId: 2,
+                priority: 100,
+                serializer: new MockSerializer1());
+            serialization.RegisterSerializer(
+                serializerId: 3,
+                priority: 50,
+                serializer: new MockSerializer2());
+
+            // Check if we Serialization uses the MockSerializer1 when given the TestType1.
+            {
+                var (bytes, typeName, serializerId) = serialization.Serialize(new TestType1());
+                Assert.Equal("MockSerializer1", typeName);
+                Assert.Equal(2, serializerId);
+                var deserialized = serialization.Deserialize(typeName, bytes, serializerId);
+                Assert.True(deserialized is TestType1);
+            }
+
+            // Check if we Serialization uses the MockSerializer2 when given the TestType2.
+            {
+                var (bytes, typeName, serializerId) = serialization.Serialize(new TestType2());
+                Assert.Equal("MockSerializer2", typeName);
+                Assert.Equal(3, serializerId);
+            }
+
+            // Check if we fallback to JSON.
+            {
+                var json = new JsonMessage(
+                    "actor.PID",
+                    "{ \"Address\":\"123\", \"Id\":\"456\"}");
+                var (bytes, typeName, serializerId) = serialization.Serialize(json);
+                var deserialized = serialization.Deserialize(typeName, bytes, serializerId) as PID;
+                Assert.NotNull(deserialized);
+                Assert.Equal("123", deserialized.Address);
+            }
+        }
+
         [Fact]
         public void CanSerializeAndDeserializeJsonPid()
         {
             var serialization = new Serialization();
-            const string typeName = "actor.PID";
-            var json = new JsonMessage(typeName, "{ \"Address\":\"123\", \"Id\":\"456\"}");
-            var bytes = serialization.Serialize(json, 1);
-            var deserialized = serialization.Deserialize(typeName, bytes, 1) as PID;
+            var json = new JsonMessage(
+                "actor.PID",
+                "{ \"Address\":\"123\", \"Id\":\"456\"}");
+            var (bytes, typeName, serializerId) = serialization.Serialize(json);
+            var deserialized = serialization.Deserialize(typeName, bytes, serializerId) as PID;
             Assert.NotNull(deserialized);
             Assert.Equal("123", deserialized.Address);
             Assert.Equal("456", deserialized.Id);
@@ -23,10 +85,11 @@ namespace Proto.Remote.Tests
         {
             var serialization = new Serialization();
             serialization.RegisterFileDescriptor(Messages.ProtosReflection.Descriptor);
-            const string typeName = "remote_test_messages.Ping";
-            var json = new JsonMessage(typeName, "{ \"message\":\"Hello\"}");
-            var bytes = serialization.Serialize(json, 1);
-            var deserialized = serialization.Deserialize(typeName, bytes, 1) as Ping;
+            var json = new JsonMessage(
+                "remote_test_messages.Ping",
+                "{ \"message\":\"Hello\"}");
+            var (bytes, typeName, serializerId) = serialization.Serialize(json);
+            var deserialized = serialization.Deserialize(typeName, bytes, serializerId) as Ping;
             Assert.NotNull(deserialized);
             Assert.Equal("Hello", deserialized.Message);
         }


### PR DESCRIPTION
Serialization class supports having multiple Serializer instances with different priorities now.

## Description

It allows multiple Serializer classes to be used together with each handling different types.
This PR was discussed in detail on proto.actor Slack channel today (22/4/2021).

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
