### PR TITLE
ClusterRequest overload using ClusterIdentity

### DIFF
--- a/ProtoActor.sln
+++ b/ProtoActor.sln
@@ -207,6 +207,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ClusterPubSub", "ClusterPub
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProtoGrainGenerator.Tests", "protobuf\ProtoGrainGenerator.Tests\ProtoGrainGenerator.Tests.csproj", "{1AD0DE77-6878-4213-B68C-B2148D7F0D2C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClusterMicroBenchmarks", "benchmarks\ClusterMicroBenchmarks\ClusterMicroBenchmarks.csproj", "{94C40B92-893D-4013-9FA7-5FFA24F24714}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -959,6 +961,18 @@ Global
 		{1AD0DE77-6878-4213-B68C-B2148D7F0D2C}.Release|x64.Build.0 = Release|Any CPU
 		{1AD0DE77-6878-4213-B68C-B2148D7F0D2C}.Release|x86.ActiveCfg = Release|Any CPU
 		{1AD0DE77-6878-4213-B68C-B2148D7F0D2C}.Release|x86.Build.0 = Release|Any CPU
+		{94C40B92-893D-4013-9FA7-5FFA24F24714}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{94C40B92-893D-4013-9FA7-5FFA24F24714}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{94C40B92-893D-4013-9FA7-5FFA24F24714}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{94C40B92-893D-4013-9FA7-5FFA24F24714}.Debug|x64.Build.0 = Debug|Any CPU
+		{94C40B92-893D-4013-9FA7-5FFA24F24714}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{94C40B92-893D-4013-9FA7-5FFA24F24714}.Debug|x86.Build.0 = Debug|Any CPU
+		{94C40B92-893D-4013-9FA7-5FFA24F24714}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94C40B92-893D-4013-9FA7-5FFA24F24714}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94C40B92-893D-4013-9FA7-5FFA24F24714}.Release|x64.ActiveCfg = Release|Any CPU
+		{94C40B92-893D-4013-9FA7-5FFA24F24714}.Release|x64.Build.0 = Release|Any CPU
+		{94C40B92-893D-4013-9FA7-5FFA24F24714}.Release|x86.ActiveCfg = Release|Any CPU
+		{94C40B92-893D-4013-9FA7-5FFA24F24714}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1052,6 +1066,7 @@ Global
 		{8368C8CC-7418-4B9B-B9B3-2011C612CE42} = {59DCCC96-DDAF-469F-9E8E-9BC733285082}
 		{F94EA250-F52C-4FF6-A2ED-5B6B390C4A57} = {8368C8CC-7418-4B9B-B9B3-2011C612CE42}
 		{1AD0DE77-6878-4213-B68C-B2148D7F0D2C} = {6D996E5A-5A15-4A5D-97F6-C01F619E3177}
+		{94C40B92-893D-4013-9FA7-5FFA24F24714} = {0F3AB331-C042-4371-A2F0-0AFDFA13DC9F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD0D1E44-8118-4682-8793-6B20ABFA824C}

--- a/benchmarks/ClusterMicroBenchmarks/ClusterMicroBenchmarks.csproj
+++ b/benchmarks/ClusterMicroBenchmarks/ClusterMicroBenchmarks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net5.0</TargetFramework>
+        <LangVersion>9</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    </ItemGroup>
+    
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Proto.Cluster.TestProvider\Proto.Cluster.TestProvider.csproj" />
+      <ProjectReference Include="..\..\src\Proto.Cluster\Proto.Cluster.csproj" />
+      <ProjectReference Include="..\..\src\Proto.Remote.GrpcNet\Proto.Remote.GrpcNet.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/benchmarks/ClusterMicroBenchmarks/InProcessClusterRequestBenchmark.cs
+++ b/benchmarks/ClusterMicroBenchmarks/InProcessClusterRequestBenchmark.cs
@@ -1,0 +1,78 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="PidCacheBenchmark.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Proto;
+using Proto.Cluster;
+using Proto.Cluster.Partition;
+using Proto.Cluster.Testing;
+using Proto.Remote.GrpcNet;
+
+namespace ClusterMicroBenchmarks
+{
+    [MemoryDiagnoser, InProcess]
+    public class InProcessClusterRequestBenchmark
+    {
+        private Cluster _cluster;
+        private const string Kind = "echo";
+
+        private ClusterIdentity _id;
+
+        [Params(true, false)]
+        public bool LocalAffinity { get; set; }
+
+        [Params(true, false)]
+        public bool RequestDeduplication { get; set; }
+
+        [GlobalSetup]
+        public async Task Setup()
+        {
+            var echoProps = Props.FromFunc(ctx => {
+                    if (ctx.Sender is not null) ctx.Respond(ctx.Message!);
+                    return Task.CompletedTask;
+                }
+            );
+
+            if (RequestDeduplication)
+            {
+                echoProps = echoProps.WithClusterRequestDeduplication(TimeSpan.FromSeconds(30));
+            }
+
+            var echoKind = new ClusterKind(Kind, echoProps);
+
+            if (LocalAffinity)
+            {
+                echoKind.WithLocalAffinityRelocationStrategy();
+            }
+
+            var sys = new ActorSystem(new ActorSystemConfig())
+                .WithRemote(GrpcNetRemoteConfig.BindToLocalhost(9090))
+                .WithCluster(ClusterConfig().WithClusterKind(echoKind));
+
+            _cluster = sys.Cluster();
+            await _cluster.StartMemberAsync();
+
+            _id = ClusterIdentity.Create("1", Kind);
+            await _cluster.RequestAsync<int>(_id.Identity, _id.Kind, 1, CancellationToken.None);
+        }
+
+        private static ClusterConfig ClusterConfig() => Proto.Cluster.ClusterConfig.Setup("testcluster",
+            new TestProvider(new TestProviderOptions(), new InMemAgent()),
+            new PartitionIdentityLookup()
+        );
+
+        [GlobalCleanup]
+        public Task Cleanup() => _cluster.ShutdownAsync();
+
+        [Benchmark]
+        public Task ClusterRequestAsync() => _cluster.RequestAsync<int>(_id.Identity, _id.Kind, 1, CancellationToken.None);
+
+        [Benchmark]
+        public Task ClusterIdentityRequestAsync() => _cluster.RequestAsync<int>(_id, 1, CancellationToken.None);
+    }
+}

--- a/benchmarks/ClusterMicroBenchmarks/Program.cs
+++ b/benchmarks/ClusterMicroBenchmarks/Program.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using BenchmarkDotNet.Running;
+
+namespace ClusterMicroBenchmarks
+{
+    class Program
+    {
+        static void Main() => BenchmarkRunner.Run<InProcessClusterRequestBenchmark>();
+    }
+}

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -148,6 +148,12 @@ namespace Proto.Cluster
 
         public Task<T> RequestAsync<T>(string identity, string kind, object message, ISenderContext context, CancellationToken ct) =>
             ClusterContext.RequestAsync<T>(new ClusterIdentity {Identity = identity, Kind = kind}, message, context, ct)!;
+        
+        public Task<T> RequestAsync<T>(ClusterIdentity clusterIdentity, object message, CancellationToken ct) =>
+            ClusterContext.RequestAsync<T>(clusterIdentity, message, System.Root, ct)!;
+        
+        public Task<T> RequestAsync<T>(ClusterIdentity clusterIdentity, object message, ISenderContext context, CancellationToken ct) =>
+            ClusterContext.RequestAsync<T>(clusterIdentity, message, context, ct)!;
 
         public ActivatedClusterKind GetClusterKind(string kind)
         {

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -140,18 +140,8 @@ namespace Proto.Cluster
             Logger.LogInformation("Stopped Cluster {Id}", System.Id);
         }
 
-        public Task<PID?> GetAsync(string identity, string kind, CancellationToken ct) =>
-            IdentityLookup!.GetAsync(new ClusterIdentity {Identity = identity, Kind = kind}, ct);
+        public Task<PID?> GetAsync(ClusterIdentity clusterIdentity, CancellationToken ct) => IdentityLookup!.GetAsync(clusterIdentity, ct);
 
-        public Task<T> RequestAsync<T>(string identity, string kind, object message, CancellationToken ct) =>
-            ClusterContext.RequestAsync<T>(new ClusterIdentity {Identity = identity, Kind = kind}, message, System.Root, ct)!;
-
-        public Task<T> RequestAsync<T>(string identity, string kind, object message, ISenderContext context, CancellationToken ct) =>
-            ClusterContext.RequestAsync<T>(new ClusterIdentity {Identity = identity, Kind = kind}, message, context, ct)!;
-        
-        public Task<T> RequestAsync<T>(ClusterIdentity clusterIdentity, object message, CancellationToken ct) =>
-            ClusterContext.RequestAsync<T>(clusterIdentity, message, System.Root, ct)!;
-        
         public Task<T> RequestAsync<T>(ClusterIdentity clusterIdentity, object message, ISenderContext context, CancellationToken ct) =>
             ClusterContext.RequestAsync<T>(clusterIdentity, message, context, ct)!;
 

--- a/src/Proto.Cluster/ClusterExtensions.cs
+++ b/src/Proto.Cluster/ClusterExtensions.cs
@@ -1,0 +1,24 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ClusterExtensions.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Proto.Cluster
+{
+    public static class ClusterExtensions
+    {
+        public static Task<PID?> GetAsync(this Cluster cluster, string identity, string kind, CancellationToken ct) =>
+            cluster.GetAsync(new ClusterIdentity {Identity = identity, Kind = kind}, ct);
+        public static Task<T> RequestAsync<T>(this Cluster cluster, string identity, string kind, object message, CancellationToken ct)
+            => cluster.RequestAsync<T>(new ClusterIdentity {Identity = identity, Kind = kind}, message, cluster.System.Root, ct);
+
+        public static Task<T> RequestAsync<T>(this Cluster cluster, string identity, string kind, object message, ISenderContext context, CancellationToken ct) =>
+            cluster.RequestAsync<T>(new ClusterIdentity {Identity = identity, Kind = kind}, message, context, ct)!;
+        
+        public static Task<T> RequestAsync<T>(this Cluster cluster, ClusterIdentity clusterIdentity, object message, CancellationToken ct) =>
+            cluster.RequestAsync<T>(clusterIdentity, message, cluster.System.Root, ct)!;
+    }
+}

--- a/src/Proto.Cluster/DefaultClusterContext.cs
+++ b/src/Proto.Cluster/DefaultClusterContext.cs
@@ -25,6 +25,7 @@ namespace Proto.Cluster
         private readonly ShouldThrottle _requestLogThrottle;
         private readonly TaskClock _clock;
         private static readonly ILogger Logger = Log.CreateLogger<DefaultClusterContext>();
+
         public DefaultClusterContext(IIdentityLookup identityLookup, PidCache pidCache, ClusterContextConfig config, CancellationToken killSwitch)
         {
             _identityLookup = identityLookup;
@@ -41,7 +42,6 @@ namespace Proto.Cluster
 
         public async Task<T?> RequestAsync<T>(ClusterIdentity clusterIdentity, object message, ISenderContext context, CancellationToken ct)
         {
-            
             var start = DateTime.UtcNow;
             Logger.LogDebug("Requesting {ClusterIdentity} Message {Message}", clusterIdentity, message);
             var i = 0;
@@ -174,6 +174,7 @@ namespace Proto.Cluster
         )
         {
             var t = DateTimeOffset.UtcNow;
+
             try
             {
                 if (future.Task.IsCompleted) return ToResult<T>(source, context, future.Task.Result);
@@ -211,14 +212,15 @@ namespace Proto.Cluster
                 {
                     var elapsed = DateTimeOffset.UtcNow - t;
                     context.System.Metrics.Get<ClusterMetrics>().ClusterRequestHistogram
-                        .Observe(elapsed, new []{context.System.Id, context.System.Address, clusterIdentity.Kind, message.GetType().Name,
-                            source == PidSource.Cache ? "PidCache" : "IIdentityLookup"
-                        });
+                        .Observe(elapsed, new[]
+                            {
+                                context.System.Id, context.System.Address, clusterIdentity.Kind, message.GetType().Name,
+                                source == PidSource.Cache ? "PidCache" : "IIdentityLookup"
+                            }
+                        );
                 }
             }
-
         }
-    
 
         private (ResponseStatus Ok, T?) ToResult<T>(PidSource source, ISenderContext context, object result)
         {


### PR DESCRIPTION
Added ClusterIdentity overload to Cluster-request. Slightly more efficient, but allows for later optimizations with direct references to kind and cached Pid.

Added Cluster-request microbenchmarks