### PR TITLE
Isolate cancellation code for futures

### DIFF
--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -215,7 +215,8 @@ namespace Proto.Context
 
             pid.SendSystemMessage(System, new Watch(future.Pid));
             Stop(pid);
-            return future.Task;
+            // ReSharper disable once MethodSupportsCancellation
+            return future.GetTask();
         }
 
         public void Poison(PID pid) => pid.SendUserMessage(System, PoisonPill.Instance);

--- a/src/Proto.Actor/Context/ISenderContext.cs
+++ b/src/Proto.Actor/Context/ISenderContext.cs
@@ -84,10 +84,10 @@ namespace Proto
 
         internal static async Task<T> RequestAsync<T>(this ISenderContext self,  PID target, object message, CancellationToken cancellationToken)
         {
-            using var future = new FutureProcess(self.System, cancellationToken);
+            using var future = new FutureProcess(self.System);
             var messageEnvelope = new MessageEnvelope(message, future.Pid);
             self.Send(target, messageEnvelope);
-            var result = await future.Task;
+            var result = await future.GetTask(cancellationToken);
 
             switch (result)
             {

--- a/src/Proto.Actor/Context/RootContext.cs
+++ b/src/Proto.Actor/Context/RootContext.cs
@@ -90,7 +90,7 @@ namespace Proto
             pid.SendSystemMessage(System, new Watch(future.Pid));
             Stop(pid);
 
-            return future.Task;
+            return future.GetTask();
         }
 
         public void Poison(PID pid) => pid.SendUserMessage(System, PoisonPill.Instance);

--- a/src/Proto.Actor/Future/Futures.cs
+++ b/src/Proto.Actor/Future/Futures.cs
@@ -89,7 +89,7 @@ namespace Proto.Future
                 return;
             }
 
-            if (_ct.IsCancellationRequested) _tcs.TrySetResult(default!);
+            if (!_ct.IsCancellationRequested) _tcs.TrySetResult(default!);
 
             if (!_system.Metrics.IsNoop)
             {

--- a/src/Proto.Cluster/DefaultClusterContext.cs
+++ b/src/Proto.Cluster/DefaultClusterContext.cs
@@ -177,14 +177,13 @@ namespace Proto.Cluster
 
             try
             {
-                if (future.Task.IsCompleted) return ToResult<T>(source, context, future.Task.Result);
-
                 context.Send(pid, new MessageEnvelope(message, future.Pid));
-                await Task.WhenAny(future.Task, _clock.CurrentBucket);
+                var task = future.GetTask();
+                await Task.WhenAny(task, _clock.CurrentBucket);
 
-                if (future.Task.IsCompleted)
+                if (task.IsCompleted)
                 {
-                    var res = future.Task.Result;
+                    var res = task.Result;
 
                     return ToResult<T>(source, context, res);
                 }

--- a/src/Proto.Cluster/DefaultClusterContext.cs
+++ b/src/Proto.Cluster/DefaultClusterContext.cs
@@ -177,7 +177,7 @@ namespace Proto.Cluster
 
             try
             {
-                context.Send(pid, new MessageEnvelope(message, future.Pid));
+                context.Request(pid, message, future.Pid);
                 var task = future.GetTask();
                 await Task.WhenAny(task, _clock.CurrentBucket);
 


### PR DESCRIPTION
I believe this might be slower than the current code, but having the cancellation code nicely captured in a method with using removes any chance of memory leaks or unexpected behaviors