### PR TITLE
store member index outside of the member object

### DIFF
--- a/src/Proto.Cluster/Cache/ClusterCacheInvalidation.cs
+++ b/src/Proto.Cluster/Cache/ClusterCacheInvalidation.cs
@@ -43,8 +43,9 @@ namespace Proto.Cluster.Cache
                 Pid = activation
             };
             var remotesToInvalidate = Cluster.MemberList.GetAllMembers()
-                .Where(member => activeRemotes.Length > member.Index && activeRemotes[member.Index])
-                .Select(member => member.Address);
+                .Select(m => (member: m, index: Cluster.MemberList.GetIndexByMemberId(m.Id)))
+                .Where(t => activeRemotes.Length > t.index && activeRemotes[t.index])
+                .Select(t => t.member.Address);
 
             foreach (var address in remotesToInvalidate)
             {

--- a/src/Proto.Cluster/Cache/ClusterCacheInvalidation.cs
+++ b/src/Proto.Cluster/Cache/ClusterCacheInvalidation.cs
@@ -43,9 +43,9 @@ namespace Proto.Cluster.Cache
                 Pid = activation
             };
             var remotesToInvalidate = Cluster.MemberList.GetAllMembers()
-                .Select(m => (member: m, index: Cluster.MemberList.GetIndexByMemberId(m.Id)))
-                .Where(t => activeRemotes.Length > t.index && activeRemotes[t.index])
-                .Select(t => t.member.Address);
+                .Select(m => Cluster.MemberList.GetMetaMember(m.Id))
+                .Where(m => activeRemotes.Length > m.Index && activeRemotes[m.Index])
+                .Select(m => m.Member.Address);
 
             foreach (var address in remotesToInvalidate)
             {

--- a/src/Proto.Cluster/Member.cs
+++ b/src/Proto.Cluster/Member.cs
@@ -12,11 +12,6 @@ namespace Proto.Cluster
     {
         public string Address => Host + ":" + Port;
 
-        /// <summary>
-        ///     Node local index
-        /// </summary>
-        public int Index { get; internal set; }
-
         public string ToLogString() => $"Member Address:{Address} ID:{Id}";
     }
 }

--- a/src/Proto.Cluster/Member/MemberList.cs
+++ b/src/Proto.Cluster/Member/MemberList.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using Proto.Remote;
-using Proto.Utils;
 
 namespace Proto.Cluster
 {
@@ -31,7 +30,7 @@ namespace Proto.Cluster
         private ImmutableDictionary<string, int> _indexByAddress = ImmutableDictionary<string, int>.Empty;
         private ImmutableDictionary<string, ClusterTopologyNotification> _memberState = ImmutableDictionary<string, ClusterTopologyNotification>.Empty;
         private TaskCompletionSource<bool> _topologyConsensus = new ();
-        private ImmutableDictionary<string,int> _indexById = ImmutableDictionary<string, int>.Empty;
+        private ImmutableDictionary<string,MetaMember> _metaMembers = ImmutableDictionary<string, MetaMember>.Empty;
 
         private Member? _leader;
 
@@ -185,9 +184,9 @@ namespace Proto.Cluster
                     }
                 }
 
-                if (_indexById.TryGetValue(memberThatLeft.Id, out var index))
+                if (_metaMembers.TryGetValue(memberThatLeft.Id, out var meta))
                 {
-                    _membersByIndex = _membersByIndex.Remove(index);
+                    _membersByIndex = _membersByIndex.Remove(meta.Index);
 
                     if (_indexByAddress.TryGetValue(memberThatLeft.Address, out _))
                         _indexByAddress = _indexByAddress.Remove(memberThatLeft.Address);
@@ -201,7 +200,7 @@ namespace Proto.Cluster
             void MemberJoin(Member newMember)
             {
                 var index = _nextMemberIndex++;
-                _indexById = _indexById.Add(newMember.Id, index);
+                _metaMembers = _metaMembers.Add(newMember.Id, new MetaMember(newMember, index));
                 _membersByIndex = _membersByIndex.Add(index, newMember);
                 _indexByAddress = _indexByAddress.Add(newMember.Address, index);
 
@@ -217,10 +216,10 @@ namespace Proto.Cluster
             }
         }
 
-        public int GetIndexByMemberId(string memberId)
+        public MetaMember? GetMetaMember(string memberId)
         {
-            _indexById.TryGetValue(memberId, out var index);
-            return index;
+            _metaMembers.TryGetValue(memberId, out var meta);
+            return meta;
         }
 
         private void BroadcastTopologyChanges(ClusterTopology topology)

--- a/src/Proto.Cluster/Member/MetaMember.cs
+++ b/src/Proto.Cluster/Member/MetaMember.cs
@@ -1,0 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="MetaMember.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Proto.Cluster
+{
+    public record MetaMember(Member Member, int Index);
+}


### PR DESCRIPTION
Store member index outside of the member object

After working with the memberlist logic, adding and removing members. it became unclear when the members were replaced with copies from the cluster provider.

Therefore I decided to store the index in a lookup based on memberId, separating the data that comes from cluster provider vs the data we create ourselves.