### PR TITLE
Fix serialization of message implementing IRootSerializable

### DIFF
--- a/src/Proto.Remote/Endpoints/EndpointActor.cs
+++ b/src/Proto.Remote/Endpoints/EndpointActor.cs
@@ -243,7 +243,7 @@ namespace Proto.Remote
                 //this only apply to root level messages and never to nested child objects inside the message
                 if (message is IRootSerializable deserialized) message = deserialized.Serialize(context.System);
 
-                (ByteString bytes, string typeName, int serializerId) = _remoteConfig.Serialization.Serialize(rd.Message);
+                (ByteString bytes, string typeName, int serializerId) = _remoteConfig.Serialization.Serialize(message);
 
                 if (!context.System.Metrics.IsNoop) counter.Inc(new[] {context.System.Id, context.System.Address, typeName});
 


### PR DESCRIPTION
## Description

Proto generator creates grain client with method proxy which wraps request in `GrainRequestMessage`. `GrainRequestMessage` includes inner serialization method however its outcome was never used in `EndpointActor`. Serialization of `GrainRequestMessage` with JsonSerializer resulted in serialization exception with message: "Serialization and deserialization of 'System.Type' instances are not supported and should be avoided since they can lead to security issues. Path: $.Columns.DataType."

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
