### PR TITLE
Rewrite of PidCacheInvalidation.

### DIFF
--- a/src/Proto.Cluster/Cache/ClusterCacheInvalidation.cs
+++ b/src/Proto.Cluster/Cache/ClusterCacheInvalidation.cs
@@ -3,7 +3,6 @@
 //      Copyright (C) 2015-2020 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
-using System;
 using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,6 +10,8 @@ using Proto.Extensions;
 
 namespace Proto.Cluster.Cache
 {
+    delegate void PidCacheInvalidator(MessageEnvelope envelope);
+    
     public class ClusterCacheInvalidation : IActorSystemExtension<ClusterCacheInvalidation>
     {
         private const string ActorName = "$invalidator";
@@ -63,7 +64,7 @@ namespace Proto.Cluster.Cache
             }
         }
 
-        internal Action<MessageEnvelope> ForActor(ClusterIdentity identity, PID activation)
+        internal PidCacheInvalidator GetInvalidator(ClusterIdentity identity, PID activation)
         {
             var activeRemotes = new BitArray(16);
             return envelope => {

--- a/tests/Proto.Cluster.Tests/ClusterFixture.cs
+++ b/tests/Proto.Cluster.Tests/ClusterFixture.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using ClusterTest.Messages;
 using Microsoft.Extensions.Logging;
+using Proto.Cluster.Cache;
 using Proto.Cluster.Identity;
 using Proto.Cluster.Partition;
 using Proto.Cluster.Testing;
@@ -165,5 +166,22 @@ namespace Proto.Cluster.Tests
         }
 
         protected override ActorSystemConfig GetActorSystemConfig() => ActorSystemConfig.Setup().WithSharedFutures();
+    }
+
+    public class InMemoryPidCacheInvalidationClusterFixture : BaseInMemoryClusterFixture
+    {
+        public InMemoryPidCacheInvalidationClusterFixture() : base(3, config => config
+            .WithActorRequestTimeout(TimeSpan.FromSeconds(4))
+        )
+        {
+        }
+
+        protected override ClusterKind[] ClusterKinds => base.ClusterKinds.Select(ck => ck.WithPidCacheInvalidation()).ToArray();
+
+        protected override async Task<Cluster> SpawnClusterMember(Func<ClusterConfig, ClusterConfig> configure)
+        {
+            var cluster = await base.SpawnClusterMember(configure);
+            return cluster.WithPidCacheInvalidation();
+        }
     }
 }

--- a/tests/Proto.Cluster.Tests/ClusterTests.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTests.cs
@@ -74,29 +74,29 @@ namespace Proto.Cluster.Tests
             _testOutputHelper.WriteLine("All responses OK. Terminating fixture");
         }
 
-        [Fact]
-        public async Task HandlesLosingANodeWhileProcessing()
-        {
-            var ingressNodes = new[] {Members[0], Members[1]};
-            var victim = Members[2];
-            var ids = Enumerable.Range(1, 200).Select(id => id.ToString()).ToList();
-        
-            var cts = new CancellationTokenSource();
-        
-            var worker = Task.Run(async () => {
-                    while (!cts.IsCancellationRequested)
-                    {
-                        await CanGetResponseFromAllIdsOnAllNodes(ids, ingressNodes, 10000);
-                    }
-                }
-            );
-            await Task.Delay(200);
-            await ClusterFixture.RemoveNode(victim);
-            await ClusterFixture.SpawnNode();
-            await Task.Delay(1000);
-            cts.Cancel();
-            await worker;
-        }
+        // [Fact]
+        // public async Task HandlesLosingANodeWhileProcessing()
+        // {
+        //     var ingressNodes = new[] {Members[0], Members[1]};
+        //     var victim = Members[2];
+        //     var ids = Enumerable.Range(1, 200).Select(id => id.ToString()).ToList();
+        //
+        //     var cts = new CancellationTokenSource();
+        //
+        //     var worker = Task.Run(async () => {
+        //             while (!cts.IsCancellationRequested)
+        //             {
+        //                 await CanGetResponseFromAllIdsOnAllNodes(ids, ingressNodes, 10000);
+        //             }
+        //         }
+        //     );
+        //     await Task.Delay(200);
+        //     await ClusterFixture.RemoveNode(victim);
+        //     await ClusterFixture.SpawnNode();
+        //     await Task.Delay(1000);
+        //     cts.Cancel();
+        //     await worker;
+        // }
 
         private async Task CanGetResponseFromAllIdsOnAllNodes(IEnumerable<string> actorIds, IList<Cluster> nodes, int timeoutMs)
         {

--- a/tests/Proto.Cluster.Tests/ClusterTests.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTests.cs
@@ -74,31 +74,29 @@ namespace Proto.Cluster.Tests
             _testOutputHelper.WriteLine("All responses OK. Terminating fixture");
         }
 
-        // [Fact]
-        // public async Task HandlesLosingANodeWhileProcessing()
-        // {
-        //     var ingressNodes = new[] {Members[0], Members[1]};
-        //     var victim = Members[2];
-        //     var ids = Enumerable.Range(1, 200).Select(id => id.ToString()).ToList();
-        //
-        //     var cts = new CancellationTokenSource();
-        //
-        //     var worker = Task.Run(async () => {
-        //             while (!cts.IsCancellationRequested)
-        //             {
-        //                 await CanGetResponseFromAllIdsOnAllNodes(ids, ingressNodes, 10000);
-        //             }
-        //         }
-        //     );
-        //     await Task.Delay(200);
-        //     await ClusterFixture.RemoveNode(victim);
-        //     await ClusterFixture.SpawnNode();
-        //     await Task.Delay(1000);
-        //     cts.Cancel();
-        //     await worker;
-        //
-        //     //Repair cluster..
-        // }
+        [Fact]
+        public async Task HandlesLosingANodeWhileProcessing()
+        {
+            var ingressNodes = new[] {Members[0], Members[1]};
+            var victim = Members[2];
+            var ids = Enumerable.Range(1, 200).Select(id => id.ToString()).ToList();
+        
+            var cts = new CancellationTokenSource();
+        
+            var worker = Task.Run(async () => {
+                    while (!cts.IsCancellationRequested)
+                    {
+                        await CanGetResponseFromAllIdsOnAllNodes(ids, ingressNodes, 10000);
+                    }
+                }
+            );
+            await Task.Delay(200);
+            await ClusterFixture.RemoveNode(victim);
+            await ClusterFixture.SpawnNode();
+            await Task.Delay(1000);
+            cts.Cancel();
+            await worker;
+        }
 
         private async Task CanGetResponseFromAllIdsOnAllNodes(IEnumerable<string> actorIds, IList<Cluster> nodes, int timeoutMs)
         {
@@ -320,6 +318,17 @@ namespace Proto.Cluster.Tests
     {
         // ReSharper disable once SuggestBaseTypeForParameter
         public InMemoryClusterTestsSharedFutures(ITestOutputHelper testOutputHelper, InMemoryClusterFixtureSharedFutures clusterFixture) : base(
+            testOutputHelper, clusterFixture
+        )
+        {
+        }
+    }
+    
+    // ReSharper disable once UnusedType.Global
+    public class InMemoryClusterTestsPidCacheInvalidation : ClusterTests, IClassFixture<InMemoryPidCacheInvalidationClusterFixture>
+    {
+        // ReSharper disable once SuggestBaseTypeForParameter
+        public InMemoryClusterTestsPidCacheInvalidation(ITestOutputHelper testOutputHelper, InMemoryPidCacheInvalidationClusterFixture clusterFixture) : base(
             testOutputHelper, clusterFixture
         )
         {

--- a/tests/Proto.Cluster.Tests/PidCacheInvalidationTests.cs
+++ b/tests/Proto.Cluster.Tests/PidCacheInvalidationTests.cs
@@ -1,0 +1,67 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="PidCacheInvalidationTests.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClusterTest.Messages;
+using FluentAssertions;
+using Xunit;
+
+namespace Proto.Cluster.Tests
+{
+    public class PidCacheInvalidationTests : IClassFixture<InMemoryPidCacheInvalidationClusterFixture>
+    {
+        private InMemoryPidCacheInvalidationClusterFixture ClusterFixture { get; }
+
+        private IList<Cluster> Members => ClusterFixture.Members;
+
+        public PidCacheInvalidationTests(InMemoryPidCacheInvalidationClusterFixture clusterFixture) => ClusterFixture = clusterFixture;
+
+        [Fact]
+        public async Task PidCacheInvalidatesCorrectly()
+        {
+            const string id = "1";
+
+            var remoteMember = await GetRemoteMemberFromActivation(id);
+            var cachedPid = GetFromPidCache(remoteMember, id);
+
+            cachedPid.Should().NotBeNull();
+            await remoteMember.RequestAsync<object>(id, EchoActor.Kind, new Die(), CancellationToken.None);
+
+            await Task.Delay(1000); // PidCache is asynchronously cleared, allow the system to purge it
+
+            var cachedPidAfterStopping = GetFromPidCache(remoteMember, id);
+
+            cachedPidAfterStopping.Should().BeNull();
+        }
+
+        private static PID GetFromPidCache(Cluster remoteMember, string id)
+        {
+            remoteMember.PidCache.TryGet(new ClusterIdentity
+                {
+                    Identity = id,
+                    Kind = EchoActor.Kind
+                }, out var activation
+            );
+            return activation;
+        }
+
+        private async Task<Cluster> GetRemoteMemberFromActivation(string id)
+        {
+            foreach (var member in Members)
+            {
+                var response = await member.RequestAsync<HereIAm>(id, EchoActor.Kind, new WhereAreYou(), CancellationToken.None);
+
+                // Get the first member which does not have the activation local to it.
+                if (!response.Address.Equals(member.System.Address)) return member;
+            }
+
+            throw new Exception("Something wrong here..");
+        }
+    }
+}


### PR DESCRIPTION
Removes the need for context decorators.

Moved PidCacheInvalidation-extensions to ClusterKind, no longer possible to incorrectly enable for non-clustered actors.

Closes #1000 