### PR TITLE
Kubernetes timeout and config

### DIFF
--- a/benchmarks/KubernetesDiagnostics/.vscode/launch.json
+++ b/benchmarks/KubernetesDiagnostics/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/bin/Debug/net5.0/KubernetesDiagnostics.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/benchmarks/KubernetesDiagnostics/.vscode/tasks.json
+++ b/benchmarks/KubernetesDiagnostics/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/KubernetesDiagnostics.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/KubernetesDiagnostics.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/KubernetesDiagnostics.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/benchmarks/KubernetesDiagnostics/Dockerfile
+++ b/benchmarks/KubernetesDiagnostics/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:5.0-focal-amd64 AS base
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build

--- a/benchmarks/KubernetesDiagnostics/service.yaml
+++ b/benchmarks/KubernetesDiagnostics/service.yaml
@@ -1,4 +1,41 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: somenamespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "somerole"
+  namespace: somenamespace
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - ""
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: role-binding
+  namespace: somenamespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: somerole
+subjects:
+  - kind: ServiceAccount
+    name: somesa
+    namespace: somenamespace
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: testing
@@ -6,8 +43,8 @@ metadata:
     app: kubdiag
 spec:
   ports:
-  - port: 8080
-    name: protoactor
+    - port: 8080
+      name: protoactor
   selector:
     app: kubdiag
 ---
@@ -26,20 +63,26 @@ spec:
         app: kubdiag
         version: v1
     spec:
+      serviceAccountName: somesa
+      automountServiceAccountToken: false
       containers:
-      - name: kubdiag
-        image: rogeralsing/kubdiagg
-        imagePullPolicy: Never
-        ports:
-        - containerPort: 8080   
-        env:
-          - name: "MONGO"
-            value: "mongodb://mongo"
-          - name: PROTOPORT
-            value: "8080"
-          - name: PROTOHOST
-            value: "0.0.0.0"          
-          - name: "PROTOHOSTPUBLIC"
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP            
+        - name: kubdiag
+          image: rogeralsing/kubdiagg:v4
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          env:
+            - name: KUBERNETES_SERVICE_PORT_HTTPS
+              value: "443"
+            - name: KUBERNETES_SERVICE_HOST
+              value: "https://myaksclust-myresourcegroup-0dee3a-b7406f6e.hcp.westeurope.azmk8s.io"
+            - name: "MONGO"
+              value: "mongodb://mongo"
+            - name: PROTOPORT
+              value: "8080"
+            - name: PROTOHOST
+              value: "0.0.0.0"
+            - name: "PROTOHOSTPUBLIC"
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP

--- a/src/Proto.Cluster.Kubernetes/KubernetesClusterMonitor.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesClusterMonitor.cs
@@ -101,7 +101,7 @@ namespace Proto.Cluster.Kubernetes
                 if (_stopping) return;
 
                 // We log it and attempt to watch again, overcome transient issues
-                Logger.LogInformation("[Cluster] Unable to watch the cluster status: {Error}", ex.Message);
+                Logger.LogWarning("[Cluster] Unable to watch the cluster status: {Error}", ex.Message);
                 Restart();
             }
 

--- a/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
@@ -18,20 +18,6 @@ using static Proto.Cluster.Kubernetes.ProtoLabels;
 
 namespace Proto.Cluster.Kubernetes
 {
-    public record KubernetesProviderConfig
-    {
-        public int WatchTimeoutSeconds { get; }
-        private bool DeveloperLogging { get; }
-
-        public KubernetesProviderConfig(int watchTimeoutSeconds = 30, bool developerLogging = false)
-        {
-            WatchTimeoutSeconds = watchTimeoutSeconds;
-            DeveloperLogging = developerLogging;
-        }
-        
-        internal LogLevel DebugLogLevel => DeveloperLogging ? LogLevel.Information : LogLevel.Debug;
-    }
-
     [PublicAPI]
     public class KubernetesProvider : IClusterProvider
     {

--- a/src/Proto.Cluster.Kubernetes/KubernetesProviderConfig.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProviderConfig.cs
@@ -1,0 +1,23 @@
+// -----------------------------------------------------------------------
+// <copyright file="KubernetesProviderConfig.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using Microsoft.Extensions.Logging;
+
+namespace Proto.Cluster.Kubernetes
+{
+    public record KubernetesProviderConfig
+    {
+        public int WatchTimeoutSeconds { get; }
+        private bool DeveloperLogging { get; }
+
+        public KubernetesProviderConfig(int watchTimeoutSeconds = 30, bool developerLogging = false)
+        {
+            WatchTimeoutSeconds = watchTimeoutSeconds;
+            DeveloperLogging = developerLogging;
+        }
+        
+        internal LogLevel DebugLogLevel => DeveloperLogging ? LogLevel.Information : LogLevel.Debug;
+    }
+}

--- a/src/Proto.Cluster.Kubernetes/Messages.cs
+++ b/src/Proto.Cluster.Kubernetes/Messages.cs
@@ -28,10 +28,5 @@ namespace Proto.Cluster.Kubernetes
 
             public string ClusterName { get; }
         }
-
-        // public class EnsureWatcher
-        // {
-        //     public static EnsureWatcher Instance { get; } = new EnsureWatcher();
-        // }
     }
 }


### PR DESCRIPTION
This PR aims to resolve #1017

Reports are saying the Watch fails after 5 min. due to problems with keepalive connections.
This PR allows to set a hard timeout on the watch, with the intention to exit the watch well before any such keepalive connection fails.

We also provide the ability to set developer logging, turning all debug logs into information level for the KubernetesProvider