### PR TITLE
Added ability to access and send message headers in requests

### DIFF
--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -65,8 +65,6 @@ namespace Proto.Context
             if (_messageOrEnvelope is not null) EnsureExtras().Stash.Push(_messageOrEnvelope);
         }
 
-        public void Respond(object message, MessageHeader header) => Respond(new MessageEnvelope(message, null, header));
-        
         public void Respond(object message)
         {
             if (Sender is not null)

--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -65,6 +65,8 @@ namespace Proto.Context
             if (_messageOrEnvelope is not null) EnsureExtras().Stash.Push(_messageOrEnvelope);
         }
 
+        public void Respond(object message, MessageHeader header) => Respond(new MessageEnvelope(message, null, header));
+        
         public void Respond(object message)
         {
             if (Sender is not null)
@@ -115,7 +117,7 @@ namespace Proto.Context
             if (duration == ReceiveTimeout) return;
 
             ReceiveTimeout = duration;
-            
+
             EnsureExtras();
             _extras!.StopReceiveTimeoutTimer();
 
@@ -159,7 +161,7 @@ namespace Proto.Context
                     break;
             }
         }
-        
+
         public void Request(PID target, object message, PID? sender)
         {
             var messageEnvelope = new MessageEnvelope(message, sender);
@@ -284,7 +286,7 @@ namespace Proto.Context
                 var res = System.Config.DiagnosticsSerializer(Actor!);
                 diagnosticsString += res;
             }
-            
+
             processDiagnosticsRequest.Result.SetResult(diagnosticsString);
 
             return default;
@@ -422,7 +424,7 @@ namespace Proto.Context
         private Task HandleAutoRespond(IAutoRespond autoRespond)
         {
             // receive normally
-            var res =  Actor!.ReceiveAsync(_props.ContextDecoratorChain is not null ? EnsureExtras().Context : this);
+            var res = Actor!.ReceiveAsync(_props.ContextDecoratorChain is not null ? EnsureExtras().Context : this);
             //then respond automatically
             var response = autoRespond.GetAutoResponse();
             Respond(response);

--- a/src/Proto.Actor/Context/IContext.cs
+++ b/src/Proto.Actor/Context/IContext.cs
@@ -33,6 +33,13 @@ namespace Proto
         /// </summary>
         /// <param name="message">The message to send</param>
         void Respond(object message);
+        
+        /// <summary>
+        ///     Sends a response to the current Sender, including message header
+        /// </summary>
+        /// <param name="message">The message to send</param>
+        /// <param name="header"></param>
+        void Respond(object message, MessageHeader header) => Respond(new MessageEnvelope(message, null, header));
 
         /// <summary>
         ///     Stashes the current message on a stack for re-processing when the actor restarts.

--- a/src/Proto.Actor/Future/FutureBatch.cs
+++ b/src/Proto.Actor/Future/FutureBatch.cs
@@ -85,7 +85,7 @@ namespace Proto.Future
 
             try
             {
-                tcs.TrySetResult(MessageEnvelope.UnwrapMessage(message)!);
+                tcs.TrySetResult(message);
                 _completionSources[index] = default;
             }
             finally

--- a/src/Proto.Actor/Future/Futures.cs
+++ b/src/Proto.Actor/Future/Futures.cs
@@ -92,7 +92,7 @@ namespace Proto.Future
         {
             try
             {
-                _tcs.TrySetResult(MessageEnvelope.UnwrapMessage(message)!);
+                _tcs.TrySetResult(message!);
             }
             finally
             {

--- a/src/Proto.Actor/Future/SharedFuture.cs
+++ b/src/Proto.Actor/Future/SharedFuture.cs
@@ -89,7 +89,7 @@ namespace Proto.Future
 
             try
             {
-                slot.CompletionSource!.TrySetResult(MessageEnvelope.UnwrapMessage(message)!);
+                slot.CompletionSource!.TrySetResult(message);
             }
             finally
             {

--- a/src/Proto.Actor/Messages/MessageEnvelope.cs
+++ b/src/Proto.Actor/Messages/MessageEnvelope.cs
@@ -26,6 +26,9 @@ namespace Proto
         public static MessageEnvelope Wrap(object message) =>
             message is MessageEnvelope env ? env : new MessageEnvelope(message, null);
 
+        public static MessageEnvelope Wrap(object message, MessageHeader header) =>
+            message is MessageEnvelope env ? env.MergeHeader(header) : new MessageEnvelope(message, null, header);
+
         public MessageEnvelope WithSender(PID sender) =>
             this with {Sender = sender};
 
@@ -34,6 +37,16 @@ namespace Proto
 
         public MessageEnvelope WithHeader(MessageHeader header) =>
             this with {Header = header};
+
+        public MessageEnvelope MergeHeader(MessageHeader header)
+        {
+            if (header.Count == 0)
+            {
+                return this;
+            }
+
+            return this with {Header = Header.With(header)};
+        }
 
         public MessageEnvelope WithHeader(string key, string value)
         {

--- a/src/Proto.Actor/Messages/MessageHeader.cs
+++ b/src/Proto.Actor/Messages/MessageHeader.cs
@@ -48,5 +48,17 @@ namespace Proto
 
         public MessageHeader With(IEnumerable<KeyValuePair<string, string>> items) =>
             this with {Inner = Inner.SetItems(items)};
+
+        public MessageHeader With(MessageHeader header)
+        {
+            if (header.Count == 0)
+            {
+                return this;
+            }
+
+            if (Count == 0) return header;
+
+            return this with {Inner = Inner.SetItems(header.Inner)};
+        }
     }
 }

--- a/src/Proto.Cluster/DefaultClusterContext.cs
+++ b/src/Proto.Cluster/DefaultClusterContext.cs
@@ -235,7 +235,8 @@ namespace Proto.Cluster
         
         private static (ResponseStatus Ok, T?) ToResult<T>(PidSource source, ISenderContext context, object result)
         {
-            switch (result)
+            var message = MessageEnvelope.UnwrapMessage(result);
+            switch (message)
             {
                 case DeadLetterResponse:
                     if (!context.System.Shutdown.IsCancellationRequested)
@@ -245,7 +246,7 @@ namespace Proto.Cluster
                 case null: return (ResponseStatus.Ok, default);
                 case T t:  return (ResponseStatus.Ok, t);
                 default:
-                    Logger.LogWarning("Unexpected message. Was type {Type} but expected {ExpectedType}", result.GetType(), typeof(T));
+                    Logger.LogWarning("Unexpected message. Was type {Type} but expected {ExpectedType}", message.GetType(), typeof(T));
                     return (ResponseStatus.Exception, default);
             }
         }

--- a/src/Proto.Cluster/ExperimentalClusterContext.cs
+++ b/src/Proto.Cluster/ExperimentalClusterContext.cs
@@ -220,7 +220,8 @@ namespace Proto.Cluster
 
         private static (ResponseStatus Ok, T?) ToResult<T>(PidSource source, ISenderContext context, object result)
         {
-            switch (result)
+            var message = MessageEnvelope.UnwrapMessage(result);
+            switch (message)
             {
                 case DeadLetterResponse:
                     if (!context.System.Shutdown.IsCancellationRequested)
@@ -230,7 +231,7 @@ namespace Proto.Cluster
                 case null: return (ResponseStatus.Ok, default);
                 case T t:  return (ResponseStatus.Ok, t);
                 default:
-                    Logger.LogError("Unexpected message. Was type {Type} but expected {ExpectedType}", result.GetType(), typeof(T));
+                    Logger.LogError("Unexpected message. Was type {Type} but expected {ExpectedType}", message.GetType(), typeof(T));
                     return (ResponseStatus.InvalidResponse, default);
             }
         }

--- a/tests/Proto.Cluster.Tests/PidCacheInvalidationTests.cs
+++ b/tests/Proto.Cluster.Tests/PidCacheInvalidationTests.cs
@@ -58,7 +58,7 @@ namespace Proto.Cluster.Tests
                 var response = await member.RequestAsync<HereIAm>(id, EchoActor.Kind, new WhereAreYou(), CancellationToken.None);
 
                 // Get the first member which does not have the activation local to it.
-                if (!response.Address.Equals(member.System.Address)) return member;
+                if (!response.Address.Equals(member.System.Address, StringComparison.OrdinalIgnoreCase)) return member;
             }
 
             throw new Exception("Something wrong here..");


### PR DESCRIPTION
Alternative to solve #1024, and support richer use cases for headers. Breaking change for future-tasks, as they no longer unpack message envelopes.