### PR TITLE
Debugging partition lookup issues

### DIFF
--- a/benchmarks/ClusterBenchmark/Configuration.cs
+++ b/benchmarks/ClusterBenchmark/Configuration.cs
@@ -71,7 +71,7 @@ namespace ClusterExperiment1
             }
         }
 
-        public static IIdentityLookup GetIdentityLookup() =>  new PartitionIdentityLookup(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(500));
+        public static IIdentityLookup GetIdentityLookup() => new PartitionIdentityLookup(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(500));
 
         private static IIdentityLookup GetRedisIdentityLookup()
         {
@@ -160,7 +160,7 @@ namespace ClusterExperiment1
         public static void SetupLogger()
         {
             Log.Logger = new LoggerConfiguration()
-                .WriteTo.Console(LogEventLevel.Information)
+                .WriteTo.Console(LogEventLevel.Error)
                 .CreateLogger();
             
             Proto.Log.SetLoggerFactory(LoggerFactory.Create(l =>

--- a/benchmarks/ClusterBenchmark/Program.cs
+++ b/benchmarks/ClusterBenchmark/Program.cs
@@ -32,6 +32,7 @@ namespace ClusterExperiment1
 
         public static async Task Main(string[] args)
         {
+            Configuration.SetupLogger();
             AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
             //    ThreadPool.SetMinThreads(500, 500);
             Request = new HelloRequest();
@@ -45,8 +46,6 @@ namespace ClusterExperiment1
                 Thread.Sleep(Timeout.Infinite);
                 return;
             }
-
-            Configuration.SetupLogger();
 
             ts = new TaskCompletionSource<bool>();
 

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -87,9 +87,9 @@ namespace Proto.Cluster
 
         public async Task StartMemberAsync()
         {
+            await BeginStartAsync(false);
             //gossiper must be started whenever any topology events starts flowing
             await Gossip.StartAsync();
-            await BeginStartAsync(false);
             await Provider.StartMemberAsync(this);
             Logger.LogInformation("Started as cluster member");
         }

--- a/src/Proto.Cluster/Gossip/GossipActor.cs
+++ b/src/Proto.Cluster/Gossip/GossipActor.cs
@@ -53,6 +53,7 @@ namespace Proto.Cluster.Gossip
         {
             var logger = context.Logger()?.BeginScope<GossipActor>();
             logger?.LogDebug("Gossip Request {Sender}", context.Sender!);
+            Logger.LogDebug("Gossip Request {Sender}", context.Sender!);
             var remoteState = gossipRequest.State;
             var updates = GossipStateManagement.MergeState(_state, remoteState, out var newState);
 
@@ -93,7 +94,7 @@ namespace Proto.Cluster.Gossip
 
             GossipStateManagement.SetKey(_state, setStateKey.Key, setStateKey.Value, context.System.Id, ref _localSequenceNo);
             logger?.LogDebug("Setting state key {Key} - {Value} - {State}", setStateKey.Key, setStateKey.Value, _state);
-
+            Logger.LogDebug("Setting state key {Key} - {Value} - {State}", setStateKey.Key, setStateKey.Value, _state);
             if (!_state.Members.ContainsKey(context.System.Id))
             {
                 logger?.LogCritical("State corrupt");
@@ -136,6 +137,7 @@ namespace Proto.Cluster.Gossip
             }
 
             logger?.LogInformation("Sending GossipRequest to {MemberId}", member.Id);
+            Logger.LogInformation("Sending GossipRequest to {MemberId}", member.Id);
 
             //a short timeout is massively important, we cannot afford hanging around waiting for timeout, blocking other gossips from getting through
             //TODO: This will deadlock....

--- a/src/Proto.Cluster/Gossip/GossipStateManagement.cs
+++ b/src/Proto.Cluster/Gossip/GossipStateManagement.cs
@@ -191,11 +191,13 @@ namespace Proto.Cluster.Gossip
                 
                 if (hashes.All(h => h.TopologyHash == first.TopologyHash) && first.TopologyHash != 0)
                 {
-                    ctx.Logger()?.LogDebug("Reached Consensus {TopologyHash} - {State}", first.TopologyHash, state);
+                    Logger.LogDebug("Reached Consensus {TopologyHash} - {State}", first.TopologyHash, state);
+                    logger?.LogDebug("Reached Consensus {TopologyHash} - {State}", first.TopologyHash, state);
                     //all members have the same hash
                     return (true, first.TopologyHash);
                 }
 
+                Logger.LogDebug("No Consensus {Hashes}, {State}", hashes.Select(h => h.TopologyHash),  state);
                 logger?.LogDebug("No Consensus {Hashes}, {State}", hashes.Select(h => h.TopologyHash),  state);
                 return (false, 0);
             }

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -57,6 +57,7 @@ namespace Proto.Cluster.Gossip
 
         public void SetState(string key, IMessage value)
         {
+            Logger.LogDebug("Gossiper setting state to {Pid}", _pid);
             _context.System.Logger()?.LogDebug("Gossiper setting state to {Pid}", _pid);
             if (_pid == null)
             {
@@ -83,7 +84,7 @@ namespace Proto.Cluster.Gossip
             {
                 try
                 {
-                    
+                    Logger.LogDebug("Gossip loop");
                     await Task.Delay((int)_cluster.Config.GossipInterval.TotalMilliseconds);
                     SetState("heartbeat", new MemberHeartbeat());
                     await SendStateAsync();

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -78,13 +78,13 @@ namespace Proto.Cluster.Gossip
 
         private async Task GossipLoop()
         {
+            Logger.LogInformation("Starting gossip loop");
             await Task.Yield();
         
             while (!_cluster.System.Shutdown.IsCancellationRequested)
             {
                 try
                 {
-                    Logger.LogDebug("Gossip loop");
                     await Task.Delay((int)_cluster.Config.GossipInterval.TotalMilliseconds);
                     SetState("heartbeat", new MemberHeartbeat());
                     await SendStateAsync();

--- a/src/Proto.Cluster/Member/MemberList.cs
+++ b/src/Proto.Cluster/Member/MemberList.cs
@@ -68,7 +68,17 @@ namespace Proto.Cluster
 
         public ImmutableHashSet<string> GetMembers() => _activeMembers.Members.Select(m=>m.Id).ToImmutableHashSet();
 
-        public Task TopologyConsensus() => _topologyConsensus.Task;
+        public async Task TopologyConsensus()
+        {
+            while (true)
+            {
+                var t = _topologyConsensus.Task;
+                await Task.WhenAny(t, Task.Delay(500));
+                if (t.IsCompleted)
+                    return;
+                
+            }
+        }
 
         public Member? GetActivator(string kind, string requestSourceAddress)
         {

--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -63,7 +63,7 @@ namespace Proto.Cluster.Partition
 
         private async Task OnClusterTopology(ClusterTopology msg, IContext context)
         {
-         //   await _cluster.MemberList.TopologyConsensus();
+            await _cluster.MemberList.TopologyConsensus();
             if (_topologyHash == msg.TopologyHash) return;
 
             _topologyHash = msg.TopologyHash;
@@ -153,7 +153,7 @@ namespace Proto.Cluster.Partition
             _partitionLookup[msg.ClusterIdentity] = msg.Pid;
         }
 
-        private Task OnActivationRequest(ActivationRequest msg, IContext context)
+        private async Task OnActivationRequest(ActivationRequest msg, IContext context)
         {
             var ownerAddress = _rdv.GetOwnerMemberByIdentity(msg.Identity);
 
@@ -163,7 +163,7 @@ namespace Proto.Cluster.Partition
                 Logger.LogWarning("Tried to spawn on wrong node, forwarding");
                 context.Forward(ownerPid);
 
-                return Task.CompletedTask;
+                return;
             }
 
             //Check if exist in current partition dictionary
@@ -174,11 +174,11 @@ namespace Proto.Cluster.Partition
                     Logger.LogError("Null PID for ClusterIdentity {ClusterIdentity}",msg.ClusterIdentity);
                 }
                 context.Respond(new ActivationResponse {Pid = pid});
-                return Task.CompletedTask;
+                return;
             }
             
             //only activate members when we are all in sync
-        //    await _cluster.MemberList.TopologyConsensus();
+            await _cluster.MemberList.TopologyConsensus();
 
             //Get activator
             var activatorAddress = _cluster.MemberList.GetActivator(msg.Kind, context.Sender!.Address)?.Address;
@@ -189,7 +189,7 @@ namespace Proto.Cluster.Partition
                 //No activator currently available, return unavailable
                 Logger.LogWarning("No members currently available for kind {Kind}", msg.Kind);
                 context.Respond(new ActivationResponse {Pid = null});
-                return Task.CompletedTask;
+                return;
             }
 
             //What is this?
@@ -260,8 +260,6 @@ namespace Proto.Cluster.Partition
                     return Task.CompletedTask;
                 }
             );
-            
-            return Task.CompletedTask;
         }
 
         private async Task<ActivationResponse> SpawnRemoteActor(ActivationRequest req, string activator)


### PR DESCRIPTION
Sometimes when booting the cluster benchmark with many nodes and using the partition identity lookup, the whole thing gets stuck. it is seeing all the nodes, gossip is flowing. 