### PR TITLE
Fix endpoint activations

### DIFF
--- a/src/Proto.Actor/Props.cs
+++ b/src/Proto.Actor/Props.cs
@@ -45,18 +45,25 @@ namespace Proto
 
         public static PID DefaultSpawner(ActorSystem system, string name, Props props, PID? parent)
         {
+            //Ordering is important here
+            //first we create a mailbox and attach it to a process
             props = system.ConfigureProps(props);
             var mailbox = props.MailboxProducer();
             var dispatcher = props.Dispatcher;
             var process = new ActorProcess(system, mailbox);
+            
+            //then we register it to the process registry
             var (self, absent) = system.ProcessRegistry.TryAdd(name, process);
-
+            //if this fails we exit and the process and mailbox is Garbage Collected
             if (!absent) throw new ProcessNameExistException(name, self);
-
+            
+            //if successful, we create the actor and attach it to the mailbox
             var ctx = ActorContext.Setup(system, props, parent, self, mailbox);
             Initialize(props, ctx);
             mailbox.RegisterHandlers(ctx, dispatcher);
             mailbox.PostSystemMessage(Started.Instance);
+            
+            //finally, start the mailbox and make the actor consume messages
             mailbox.Start();
 
             return self;

--- a/src/Proto.Remote/Endpoints/EndpointManager.cs
+++ b/src/Proto.Remote/Endpoints/EndpointManager.cs
@@ -133,21 +133,44 @@ namespace Proto.Remote
 
         internal PID? GetEndpoint(string address)
         {
-            if (string.IsNullOrWhiteSpace(address)) throw new ArgumentNullException(nameof(address));
-            
-            if (_terminatedConnections.ContainsKey(address) || _cancellationTokenSource.IsCancellationRequested) return null;
 
-            return _connections.GetOrAdd(address, v => {
-                    Logger.LogDebug("[EndpointManager] Requesting new endpoint for {Address}", v);
-                    var props = Props
-                        .FromProducer(() => new EndpointActor(v, _remoteConfig, _channelProvider))
-                        .WithMailbox(() => new EndpointWriterMailbox(_system, _remoteConfig.EndpointWriterOptions.EndpointWriterBatchSize, v))
-                        .WithGuardianSupervisorStrategy(new EndpointSupervisorStrategy(v, _remoteConfig, _system));
-                    var endpointActorPid = _system.Root.SpawnNamed(props, $"endpoint-{v}");
-                    Logger.LogDebug("[EndpointManager] Created new endpoint for {Address}", v);
-                    return endpointActorPid;
+                if (string.IsNullOrWhiteSpace(address)) throw new ArgumentNullException(nameof(address));
+
+                if (_terminatedConnections.ContainsKey(address) || _cancellationTokenSource.IsCancellationRequested) return null;
+
+                //default to try to fetch from the concurrent dict
+                // ReSharper disable once InconsistentlySynchronizedField
+                if (_connections.TryGetValue(address, out var pid))
+                {
+                    return pid;
                 }
-            );
+
+                lock (_synLock)
+                {
+                    //this thread previously found no instance, check again, now within the lock
+                    // ReSharper disable once InconsistentlySynchronizedField
+                    if (_connections.TryGetValue(address, out pid))
+                    {
+                        return pid;
+                    }
+                    
+                    //still no instance, we can spawn and add it here.
+                    Logger.LogDebug("[EndpointManager] Requesting new endpoint for {Address}", address);
+                    var props = Props
+                        .FromProducer(() => new EndpointActor(address, _remoteConfig, _channelProvider))
+                        .WithMailbox(() => new EndpointWriterMailbox(_system, _remoteConfig.EndpointWriterOptions.EndpointWriterBatchSize, address))
+                        .WithGuardianSupervisorStrategy(new EndpointSupervisorStrategy(address, _remoteConfig, _system));
+                    pid = _system.Root.SpawnNamed(props, $"endpoint-{address}");
+                    Logger.LogDebug("[EndpointManager] Created new endpoint for {Address}", address);
+
+
+                    if (!_connections.TryAdd(address, pid))
+                    {
+                        //Famous last words, but this should never happen. if it does, someone added this entry outside of this lock
+                        Logger.LogWarning("[EndpointManager] Could not add the endpoint {Address}", address);
+                    }
+                    return pid;
+                }
         }
 
         private void SpawnActivator()


### PR DESCRIPTION
Fixing a non-issue really, previous code relied on GetOrAdd for endpoint lookup, where SpawnNamed was used within the GetOrAdd, making it impossible for multiple activations to be spawned.

But, Just to make this more clear and easier to track. here is a modified version of it