### PR TITLE
Revert "Bump Handlebars.Net from 2.0.7 to 2.0.8"

### DIFF
--- a/src/Proto.Cluster.CodeGen/Proto.Cluster.CodeGen.csproj
+++ b/src/Proto.Cluster.CodeGen/Proto.Cluster.CodeGen.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Handlebars.Net" Version="2.0.8" />
+    <PackageReference Include="Handlebars.Net" Version="2.0.7" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-20204-02" PrivateAssets="All" />
     <PackageReference Include="protobuf-net" Version="3.0.101" />


### PR DESCRIPTION
Reverts AsynkronIT/protoactor-dotnet#1084