### PR TITLE
Generate void / parameterless grain methods

### DIFF
--- a/ProtoActor.sln
+++ b/ProtoActor.sln
@@ -215,6 +215,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Proto.Cluster.AmazonECS", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EcsDiagnostics", "benchmarks\AmazonEcsDiagnostics\EcsDiagnostics.csproj", "{F787F9DE-0B2C-423B-B1EC-BA763C8C4296}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Proto.Cluster.CodeGen.Tests", "tests\Proto.Cluster.CodeGen.Tests\Proto.Cluster.CodeGen.Tests.csproj", "{04C4B2CB-2F97-43B4-BDAE-C6E82160642A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1017,6 +1019,18 @@ Global
 		{F787F9DE-0B2C-423B-B1EC-BA763C8C4296}.Release|x64.Build.0 = Release|Any CPU
 		{F787F9DE-0B2C-423B-B1EC-BA763C8C4296}.Release|x86.ActiveCfg = Release|Any CPU
 		{F787F9DE-0B2C-423B-B1EC-BA763C8C4296}.Release|x86.Build.0 = Release|Any CPU
+		{04C4B2CB-2F97-43B4-BDAE-C6E82160642A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{04C4B2CB-2F97-43B4-BDAE-C6E82160642A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{04C4B2CB-2F97-43B4-BDAE-C6E82160642A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{04C4B2CB-2F97-43B4-BDAE-C6E82160642A}.Debug|x64.Build.0 = Debug|Any CPU
+		{04C4B2CB-2F97-43B4-BDAE-C6E82160642A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{04C4B2CB-2F97-43B4-BDAE-C6E82160642A}.Debug|x86.Build.0 = Debug|Any CPU
+		{04C4B2CB-2F97-43B4-BDAE-C6E82160642A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{04C4B2CB-2F97-43B4-BDAE-C6E82160642A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{04C4B2CB-2F97-43B4-BDAE-C6E82160642A}.Release|x64.ActiveCfg = Release|Any CPU
+		{04C4B2CB-2F97-43B4-BDAE-C6E82160642A}.Release|x64.Build.0 = Release|Any CPU
+		{04C4B2CB-2F97-43B4-BDAE-C6E82160642A}.Release|x86.ActiveCfg = Release|Any CPU
+		{04C4B2CB-2F97-43B4-BDAE-C6E82160642A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1115,6 +1129,7 @@ Global
 		{B5C06C32-D9B9-4DD8-8974-11A8622C8736} = {771514F1-12AE-4A26-89CB-2646D3EF7034}
 		{F4BA6863-3D17-48A1-8076-DF48E9B7DF03} = {86C608E7-AD97-45C9-9EAC-F45466A59DF0}
 		{F787F9DE-0B2C-423B-B1EC-BA763C8C4296} = {0F3AB331-C042-4371-A2F0-0AFDFA13DC9F}
+		{04C4B2CB-2F97-43B4-BDAE-C6E82160642A} = {9AA2BCF0-19AB-4DD9-8D91-7D188E463806}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD0D1E44-8118-4682-8793-6B20ABFA824C}

--- a/src/Proto.Actor/Messages/Messages.cs
+++ b/src/Proto.Actor/Messages/Messages.cs
@@ -132,4 +132,9 @@ namespace Proto
     }
 
     public record ProcessDiagnosticsRequest(TaskCompletionSource<string> Result) : SystemMessage;
+    
+    public static class Nothing
+    {
+        public static readonly Google.Protobuf.WellKnownTypes.Empty Instance = new();
+    }
 }

--- a/src/Proto.Cluster.CodeGen/model/ProtoMethod.cs
+++ b/src/Proto.Cluster.CodeGen/model/ProtoMethod.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2015-2020 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
+using System;
 using Google.Protobuf.Reflection;
 
 namespace Proto.Cluster.CodeGen.model
@@ -17,9 +18,17 @@ namespace Proto.Cluster.CodeGen.model
         public DescriptorProto InputObject { get; set; } = null!;
 
         public string InputName => InputObject.File().Options.CsharpNamespace + "." + InputNameRaw;
-        
+
         public DescriptorProto OutputObject { get; set; } = null!;
-        
+
         public string OutputName => OutputObject.File().Options.CsharpNamespace + "." + OutputNameRaw;
+
+        public string Parameter => UseParameter ? "request" : string.Empty;
+        public string SingleParameterDefinition => UseParameter ? $"{InputName} {Parameter}" : string.Empty;
+        public string LeadingParameterDefinition => UseParameter ? $"{InputName} {Parameter}, " : string.Empty;
+        public bool EmptyReturn { get; set; }
+        public bool EmptyParameter { get; set; }
+        public bool UseParameter => !EmptyParameter;
+        public bool UseReturn => !EmptyReturn;
     }
 }

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
@@ -1,0 +1,348 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using Proto;
+using Proto.Cluster;
+
+namespace Acme.OtherSystem.Foo
+{
+    public static class GrainExtensions
+    {
+        public static TestGrainClient GetTestGrain(this Cluster cluster, string identity) => new(cluster, identity);
+
+        public static TestGrainClient GetTestGrain(this IContext context, string identity) => new(context.System.Cluster(), identity);
+    }
+
+    public abstract class TestGrainBase
+    {
+        protected IContext Context {get;}
+        protected ActorSystem System => Context.System;
+        protected Cluster Cluster => Context.System.Cluster();
+    
+        protected TestGrainBase(IContext context)
+        {
+            Context = context;
+        }
+        
+        public virtual Task OnStarted() => Task.CompletedTask;
+        public virtual Task OnStopping() => Task.CompletedTask;
+        public virtual Task OnStopped() => Task.CompletedTask;
+        public virtual Task OnReceive() => Task.CompletedTask;
+
+        public virtual async Task GetState(Action<Acme.Mysystem.Bar.GetCurrentStateResponse> respond, Action<string> onError)
+        {
+            try
+            {
+                var res = await GetState();
+                respond(res);
+            }
+            catch (Exception x)
+            {
+                onError(x.ToString());
+            }
+        }
+        public virtual async Task SendCommand(Acme.Mysystem.Bar.SomeCommand request, Action respond, Action<string> onError)
+        {
+            try
+            {
+                await SendCommand(request);
+                respond();
+            }
+            catch (Exception x)
+            {
+                onError(x.ToString());
+            }
+        }
+        public virtual async Task RequestResponse(Acme.Mysystem.Bar.Query request, Action<Acme.Mysystem.Bar.Response> respond, Action<string> onError)
+        {
+            try
+            {
+                var res = await RequestResponse(request);
+                respond(res);
+            }
+            catch (Exception x)
+            {
+                onError(x.ToString());
+            }
+        }
+        public virtual async Task NoParameterOrReturn(Action respond, Action<string> onError)
+        {
+            try
+            {
+                await NoParameterOrReturn();
+                respond();
+            }
+            catch (Exception x)
+            {
+                onError(x.ToString());
+            }
+        }
+    
+        public abstract Task<Acme.Mysystem.Bar.GetCurrentStateResponse> GetState();
+        public abstract Task SendCommand(Acme.Mysystem.Bar.SomeCommand request);
+        public abstract Task<Acme.Mysystem.Bar.Response> RequestResponse(Acme.Mysystem.Bar.Query request);
+        public abstract Task NoParameterOrReturn();
+    }
+
+    public class TestGrainClient
+    {
+        private readonly string _id;
+        private readonly Cluster _cluster;
+
+        public TestGrainClient(Cluster cluster, string id)
+        {
+            _id = id;
+            _cluster = cluster;
+        }
+
+        public async Task<Acme.Mysystem.Bar.GetCurrentStateResponse> GetState(CancellationToken ct)
+        {
+            var gr = new GrainRequestMessage(0, Nothing.Instance);
+            //request the RPC method to be invoked
+            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr, ct);
+
+            return res switch
+            {
+                // normal response
+                GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.GetCurrentStateResponse)grainResponse.ResponseMessage,
+                // error response
+                GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                //timeout
+                null => null,
+                // unsupported response
+                _ => throw new NotSupportedException()
+            };
+        }
+        
+        public async Task<Acme.Mysystem.Bar.GetCurrentStateResponse> GetState(ISenderContext context, CancellationToken ct)
+        {
+            var gr = new GrainRequestMessage(0, request);
+            //request the RPC method to be invoked
+            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr,context, ct);
+
+            return res switch
+            {
+                // normal response
+                GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.GetCurrentStateResponse)grainResponse.ResponseMessage,
+                // error response
+                GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                //timeout
+                null => null,
+                // unsupported response
+                _ => throw new NotSupportedException()
+            };
+        }
+        public async Task<Google.Protobuf.WellKnownTypes.Empty> SendCommand(Acme.Mysystem.Bar.SomeCommand request, CancellationToken ct)
+        {
+            var gr = new GrainRequestMessage(1, request);
+            //request the RPC method to be invoked
+            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr, ct);
+
+            return res switch
+            {
+                // normal response
+                GrainResponseMessage grainResponse => (Google.Protobuf.WellKnownTypes.Empty)grainResponse.ResponseMessage,
+                // error response
+                GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                //timeout
+                null => null,
+                // unsupported response
+                _ => throw new NotSupportedException()
+            };
+        }
+        
+        public async Task<Google.Protobuf.WellKnownTypes.Empty> SendCommand(Acme.Mysystem.Bar.SomeCommand request, ISenderContext context, CancellationToken ct)
+        {
+            var gr = new GrainRequestMessage(1, request);
+            //request the RPC method to be invoked
+            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr,context, ct);
+
+            return res switch
+            {
+                // normal response
+                GrainResponseMessage grainResponse => (Google.Protobuf.WellKnownTypes.Empty)grainResponse.ResponseMessage,
+                // error response
+                GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                //timeout
+                null => null,
+                // unsupported response
+                _ => throw new NotSupportedException()
+            };
+        }
+        public async Task<Acme.Mysystem.Bar.Response> RequestResponse(Acme.Mysystem.Bar.Query request, CancellationToken ct)
+        {
+            var gr = new GrainRequestMessage(2, request);
+            //request the RPC method to be invoked
+            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr, ct);
+
+            return res switch
+            {
+                // normal response
+                GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.Response)grainResponse.ResponseMessage,
+                // error response
+                GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                //timeout
+                null => null,
+                // unsupported response
+                _ => throw new NotSupportedException()
+            };
+        }
+        
+        public async Task<Acme.Mysystem.Bar.Response> RequestResponse(Acme.Mysystem.Bar.Query request, ISenderContext context, CancellationToken ct)
+        {
+            var gr = new GrainRequestMessage(2, request);
+            //request the RPC method to be invoked
+            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr,context, ct);
+
+            return res switch
+            {
+                // normal response
+                GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.Response)grainResponse.ResponseMessage,
+                // error response
+                GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                //timeout
+                null => null,
+                // unsupported response
+                _ => throw new NotSupportedException()
+            };
+        }
+        public async Task<Google.Protobuf.WellKnownTypes.Empty> NoParameterOrReturn(CancellationToken ct)
+        {
+            var gr = new GrainRequestMessage(3, Nothing.Instance);
+            //request the RPC method to be invoked
+            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr, ct);
+
+            return res switch
+            {
+                // normal response
+                GrainResponseMessage grainResponse => (Google.Protobuf.WellKnownTypes.Empty)grainResponse.ResponseMessage,
+                // error response
+                GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                //timeout
+                null => null,
+                // unsupported response
+                _ => throw new NotSupportedException()
+            };
+        }
+        
+        public async Task<Google.Protobuf.WellKnownTypes.Empty> NoParameterOrReturn(ISenderContext context, CancellationToken ct)
+        {
+            var gr = new GrainRequestMessage(3, request);
+            //request the RPC method to be invoked
+            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr,context, ct);
+
+            return res switch
+            {
+                // normal response
+                GrainResponseMessage grainResponse => (Google.Protobuf.WellKnownTypes.Empty)grainResponse.ResponseMessage,
+                // error response
+                GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                //timeout
+                null => null,
+                // unsupported response
+                _ => throw new NotSupportedException()
+            };
+        }
+    }
+
+    class TestGrainActor : IActor
+    {
+        private TestGrainBase _inner;
+        private IContext _context;
+        private Func<IContext, string, string, TestGrainBase> _innerFactory;        
+    
+        public TestGrainActor(Func<IContext, string, string, TestGrainBase> innerFactory)
+        {
+            _innerFactory = innerFactory;
+        }
+
+        public async Task ReceiveAsync(IContext context)
+        {
+            switch (context.Message)
+            {
+                case Started msg: 
+                {
+                    _context = context;
+                    var id = context.Get<ClusterIdentity>();
+                    _inner = _innerFactory(context, id.Identity, id.Kind);
+                    await _inner.OnStarted();
+                    break;
+                }
+                case ClusterInit:
+                    //Ignored
+                    break;
+                case Stopping:
+                {
+                    await _inner.OnStopping();
+                    break;
+                }
+                case Stopped:
+                {
+                    await _inner.OnStopped();
+                    break;
+                }    
+                case GrainRequestMessage(var methodIndex, var r):
+                {
+                    switch (methodIndex)
+                    {
+                        case 0:
+                        {   
+                            if(r is Google.Protobuf.WellKnownTypes.Empty input){
+                                await _inner.GetState(Nothing.Instance, Respond, OnError);
+                            } else {
+                                OnError("Invalid client contract");
+                            }
+
+                            break;
+                        }
+                        case 1:
+                        {   
+                            if(r is Acme.Mysystem.Bar.SomeCommand input){
+                                await _inner.SendCommand(input, Respond, OnError);
+                            } else {
+                                OnError("Invalid client contract");
+                            }
+
+                            break;
+                        }
+                        case 2:
+                        {   
+                            if(r is Acme.Mysystem.Bar.Query input){
+                                await _inner.RequestResponse(input, Respond, OnError);
+                            } else {
+                                OnError("Invalid client contract");
+                            }
+
+                            break;
+                        }
+                        case 3:
+                        {   
+                            if(r is Google.Protobuf.WellKnownTypes.Empty input){
+                                await _inner.NoParameterOrReturn(Nothing.Instance, Respond, OnError);
+                            } else {
+                                OnError("Invalid client contract");
+                            }
+
+                            break;
+                        }
+                        default:
+                            OnError("Invalid client contract");
+                            break;
+                    }
+
+                    break;
+                }
+                default:
+                {
+                    await _inner.OnReceive();
+                    break;
+                }
+            }
+        }
+
+        private void Respond<T>(T response) where T: IMessage => _context.Respond( new GrainResponseMessage(response));
+        private void Respond() => _context.Respond(Nothing.Instance);
+        private void OnError(string error) => _context.Respond( new GrainErrorResponse {Err = error } );
+    }
+}

--- a/tests/Proto.Cluster.CodeGen.Tests/Proto.Cluster.CodeGen.Tests.csproj
+++ b/tests/Proto.Cluster.CodeGen.Tests/Proto.Cluster.CodeGen.Tests.csproj
@@ -4,7 +4,7 @@
 
         <IsPackable>false</IsPackable>
 
-        <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
+        <TargetFramework>net5.0</TargetFramework>
 
         <OutputType>Library</OutputType>
 
@@ -38,6 +38,15 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\Proto.Cluster.CodeGen\Proto.Cluster.CodeGen.csproj" />
+    </ItemGroup>
+
+
+
+    <ItemGroup>
+      <Compile Remove="ExpectedOutput.cs" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="ExpectedOutput.cs" CopyToOutputDirectory="PreserveNewest"/>
     </ItemGroup>
 
 </Project>

--- a/tests/Proto.Cluster.CodeGen.Tests/Proto.Cluster.CodeGen.Tests.csproj
+++ b/tests/Proto.Cluster.CodeGen.Tests/Proto.Cluster.CodeGen.Tests.csproj
@@ -4,9 +4,9 @@
 
         <IsPackable>false</IsPackable>
 
-        <TargetFramework>net5.0</TargetFramework>
-
         <OutputType>Library</OutputType>
+
+        <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
 
     </PropertyGroup>
 
@@ -46,7 +46,7 @@
       <Compile Remove="ExpectedOutput.cs" />
     </ItemGroup>
     <ItemGroup>
-        <None Include="ExpectedOutput.cs" CopyToOutputDirectory="PreserveNewest"/>
+        <None Include="ExpectedOutput.cs" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
 </Project>

--- a/tests/Proto.Cluster.CodeGen.Tests/Proto.Cluster.CodeGen.Tests.csproj
+++ b/tests/Proto.Cluster.CodeGen.Tests/Proto.Cluster.CodeGen.Tests.csproj
@@ -1,52 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-
         <IsPackable>false</IsPackable>
-
         <OutputType>Library</OutputType>
-
         <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
-
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Handlebars.Net" Version="2.0.7" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-        <PackageReference Include="protobuf-net.Reflection" Version="3.0.101" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="coverlet.collector" Version="3.0.3">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
+        <PackageReference Include="Handlebars.Net" Version="2.0.7"/>
+        <PackageReference Include="protobuf-net.Reflection" Version="3.0.101"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Remove="foo.proto"/>
+        <None Remove="bar.proto"/>
+        <Compile Remove="ExpectedOutput.cs"/>
+        <Content Include="foo.proto" CopyToOutputDirectory="Always"/>
+        <Content Include="bar.proto" CopyToOutputDirectory="Always"/>
+        <Content Include="ExpectedOutput.cs" CopyToOutputDirectory="PreserveNewest"/>
     </ItemGroup>
 
 
-
     <ItemGroup>
-      <None Remove="foo.proto" />
-      <Content Include="foo.proto">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </Content>
-      <None Remove="bar.proto" />
-      <Content Include="bar.proto">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </Content>
-    </ItemGroup>
-
-
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Proto.Cluster.CodeGen\Proto.Cluster.CodeGen.csproj" />
-    </ItemGroup>
-
-
-
-    <ItemGroup>
-      <Compile Remove="ExpectedOutput.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="ExpectedOutput.cs" CopyToOutputDirectory="PreserveNewest" />
+        <ProjectReference Include="..\..\src\Proto.Cluster.CodeGen\Proto.Cluster.CodeGen.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/tests/Proto.Cluster.CodeGen.Tests/Proto.Cluster.CodeGen.Tests.csproj
+++ b/tests/Proto.Cluster.CodeGen.Tests/Proto.Cluster.CodeGen.Tests.csproj
@@ -7,22 +7,23 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Handlebars.Net" Version="2.0.7"/>
-        <PackageReference Include="protobuf-net.Reflection" Version="3.0.101"/>
+        <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
+        <PackageReference Include="Handlebars.Net" Version="2.0.7" />
+        <PackageReference Include="protobuf-net.Reflection" Version="3.0.101" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="foo.proto"/>
-        <None Remove="bar.proto"/>
-        <Compile Remove="ExpectedOutput.cs"/>
-        <Content Include="foo.proto" CopyToOutputDirectory="Always"/>
-        <Content Include="bar.proto" CopyToOutputDirectory="Always"/>
-        <Content Include="ExpectedOutput.cs" CopyToOutputDirectory="PreserveNewest"/>
+        <None Remove="foo.proto" />
+        <None Remove="bar.proto" />
+        <Compile Remove="ExpectedOutput.cs" />
+        <Content Include="foo.proto" CopyToOutputDirectory="Always" />
+        <Content Include="bar.proto" CopyToOutputDirectory="Always" />
+        <Content Include="ExpectedOutput.cs" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Proto.Cluster.CodeGen\Proto.Cluster.CodeGen.csproj"/>
+        <ProjectReference Include="..\..\src\Proto.Cluster.CodeGen\Proto.Cluster.CodeGen.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/Proto.Cluster.CodeGen.Tests/ProtoGrainGenerationTests.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ProtoGrainGenerationTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using FluentAssertions;
 using Google.Protobuf.Reflection;
 using ProtoBuf.Reflection;
 using Xunit;
@@ -33,7 +32,7 @@ namespace Proto.Cluster.CodeGen.Tests
             }
 
             var expectedOutput = File.ReadAllText(expectedOutputFile).Trim();
-            res.Single().Text.Trim().Should().Be(expectedOutput);
+            Assert.Equal(expectedOutput, res.Single().Text.Trim());
         }
     }
 }

--- a/tests/Proto.Cluster.CodeGen.Tests/ProtoGrainGenerationTests.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ProtoGrainGenerationTests.cs
@@ -1,14 +1,11 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using FluentAssertions;
 using Google.Protobuf.Reflection;
-using Proto.Cluster.CodeGen;
-using ProtoBuf;
 using ProtoBuf.Reflection;
 using Xunit;
 using Xunit.Abstractions;
-using CodeGenerator = Proto.Cluster.CodeGen.CodeGenerator;
 
 namespace Proto.Cluster.CodeGen.Tests
 {
@@ -18,14 +15,14 @@ namespace Proto.Cluster.CodeGen.Tests
 
         public ProtoGrainGenerationTests(ITestOutputHelper testOutputHelper) => _testOutputHelper = testOutputHelper;
 
-        
-        [Fact]
-        public void CanFindImportedNamespaces()
+        [Theory]
+        [InlineData("foo.proto", "ExpectedOutput.cs")]
+        public void CanGenerateGrains(string protoDefinitionFile, string expectedOutputFile)
         {
-            var r = new FileInfo("foo.proto").OpenText();
+            var r = new FileInfo(protoDefinitionFile).OpenText();
             var set = new FileDescriptorSet();
             set.AddImportPath(".");
-            set.Add("foo.proto", true, r);
+            set.Add(protoDefinitionFile, true, r);
             set.Process();
             var c = new CodeGenerator(Template.DefaultTemplate);
             var res = c.Generate(set, NameNormalizer.Default, new Dictionary<string, string>()).ToArray();
@@ -35,6 +32,8 @@ namespace Proto.Cluster.CodeGen.Tests
                 _testOutputHelper.WriteLine(codeFile.Text);
             }
 
+            var expectedOutput = File.ReadAllText(expectedOutputFile).Trim();
+            res.Single().Text.Trim().Should().Be(expectedOutput);
         }
     }
 }

--- a/tests/Proto.Cluster.CodeGen.Tests/bar.proto
+++ b/tests/Proto.Cluster.CodeGen.Tests/bar.proto
@@ -2,10 +2,18 @@ syntax = "proto3";
 package Bar;
 option csharp_namespace = "Acme.Mysystem.Bar";
 
-message GetCurrentStateRequest{
+message SomeCommand{
   
 }
 
 message GetCurrentStateResponse {
   
+}
+ 
+message Query {
+
+}
+
+message Response {
+
 }

--- a/tests/Proto.Cluster.CodeGen.Tests/foo.proto
+++ b/tests/Proto.Cluster.CodeGen.Tests/foo.proto
@@ -3,6 +3,11 @@ package Foo;
 option csharp_namespace = "Acme.OtherSystem.Foo";
 import "bar.proto";
 
-service AssetActor {
-  rpc GetCurrentState (Bar.GetCurrentStateRequest) returns(Bar.GetCurrentStateResponse) {}
+import "google/protobuf/empty.proto";
+
+service TestGrain {
+  rpc GetState (google.protobuf.Empty) returns(Bar.GetCurrentStateResponse) {}
+  rpc SendCommand (Bar.SomeCommand) returns(google.protobuf.Empty) {}
+  rpc RequestResponse (Bar.Query) returns(Bar.Response) {}
+  rpc NoParameterOrReturn (google.protobuf.Empty) returns(google.protobuf.Empty) {}
 }


### PR DESCRIPTION
Closes #1092 
Generate void / parameterless grain methods when return value or parameter is Google.Protobuf.WellKnownTypes.Empty.

Enabled regression tests for codegen.