### PR TITLE
Removes the check and logging of k8s port matching

### DIFF
--- a/src/Proto.Cluster.Kubernetes/KubernetesExtensions.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesExtensions.cs
@@ -22,15 +22,6 @@ namespace Proto.Cluster.Kubernetes
         private static string cachedNamespace;
 
         /// <summary>
-        ///     Find the container port for a given pod than matches the given port.
-        /// </summary>
-        /// <param name="pod">Kubernetes Pod object</param>
-        /// <param name="port">Port to find in container ports</param>
-        /// <returns></returns>
-        internal static V1ContainerPort FindPort(this V1Pod pod, int port)
-            => pod.Spec.Containers[0].Ports.FirstOrDefault(x => x.ContainerPort == port);
-
-        /// <summary>
         ///     Replace pod labels
         /// </summary>
         /// <param name="kubernetes">Kubernetes client</param>

--- a/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
@@ -107,10 +107,6 @@ namespace Proto.Cluster.Kubernetes
 
             Logger.LogInformation("[Cluster][KubernetesProvider] Using Kubernetes namespace: " + pod.Namespace());
 
-            var matchingPort = pod.FindPort(_port);
-
-            if (matchingPort is null) Logger.LogWarning("[Cluster][KubernetesProvider] Registration port doesn't match any of the container ports");
-
             Logger.LogInformation("[Cluster][KubernetesProvider] Using Kubernetes port: " + _port);
 
             var existingLabels = pod.Metadata.Labels;


### PR DESCRIPTION
## Description

Closes #1107 

Removes the check and logging of k8s declared ports vs the port of the actor system

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
