### PR TITLE
Bootstrap fixes for generated grains

### DIFF
--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -25,7 +25,7 @@ namespace {{CsNamespace}}
 
         {{#each Services}}
         public static ClusterKind Get{{Name}}(Func<IContext, ClusterIdentity, {{Name}}Base> innerFactory)
-            => new({{Name}}Kind, Props.FromProducer(() => new {{Name}}Actor(innerFactory)));
+            => new({{Name}}, Props.FromProducer(() => new {{Name}}Actor(innerFactory)));
         {{/each}}
     }
 

--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -24,8 +24,8 @@ namespace {{CsNamespace}}
         {{/each}}
 
         {{#each Services}}
-        public static ClusterKind Get{{Name}}(Func<IContext, string, string, {{Name}}Base> createGrain)
-            => new({{Name}}Kind, Props.FromProducer(() => new {{Name}}Actor(createGrain)));
+        public static ClusterKind Get{{Name}}(Func<IContext, ClusterIdentity, {{Name}}Base> innerFactory)
+            => new({{Name}}Kind, Props.FromProducer(() => new {{Name}}Actor(innerFactory)));
         {{/each}}
     }
 
@@ -136,9 +136,9 @@ namespace {{CsNamespace}}
     {
         private {{Name}}Base _inner;
         private IContext _context;
-        private Func<IContext, string, string, {{Name}}Base> _innerFactory;        
+        private Func<IContext, ClusterIdentity, {{Name}}Base> _innerFactory;        
     
-        public {{Name}}Actor(Func<IContext, string, string, {{Name}}Base> innerFactory)
+        public {{Name}}Actor(Func<IContext, ClusterIdentity, {{Name}}Base> innerFactory)
         {
             _innerFactory = innerFactory;
         }
@@ -151,7 +151,7 @@ namespace {{CsNamespace}}
                 {
                     _context = context;
                     var id = context.Get<ClusterIdentity>();
-                    _inner = _innerFactory(context, id.Identity, id.Kind);
+                    _inner = _innerFactory(context, id);
                     await _inner.OnStarted();
                     break;
                 }

--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -17,7 +17,19 @@ using Proto.Cluster;
 
 namespace {{CsNamespace}}
 {
-    public static class GrainExtensions
+    public static partial class GrainKindConfig
+    {
+        {{#each Services}}
+        public const string {{Name}} = ""{{Name}}"";
+        {{/each}}
+
+        {{#each Services}}
+        public static ClusterKind Get{{Name}}(Func<IContext, string, string, {{Name}}Base> createGrain)
+            => new({{Name}}Kind, Props.FromProducer(() => new {{Name}}Actor(createGrain)));
+        {{/each}}
+    }
+
+    public static partial class GrainExtensions
     {
         {{#each Services}}
         public static {{Name}}Client Get{{Name}}(this Cluster cluster, string identity) => new(cluster, identity);
@@ -84,7 +96,7 @@ namespace {{CsNamespace}}
         {
             var gr = new GrainRequestMessage({{Index}}, {{#if UseParameter}}{{Parameter}}{{else}}null{{/if}});
             //request the RPC method to be invoked
-            var res = await _cluster.RequestAsync<object>(_id, ""{{../Name}}"", gr, ct);
+            var res = await _cluster.RequestAsync<object>(_id, GrainKindConfig.{{../Name}}, gr, ct);
 
             return res switch
             {
@@ -103,7 +115,7 @@ namespace {{CsNamespace}}
         {
             var gr = new GrainRequestMessage({{Index}}, {{#if UseParameter}}{{Parameter}}{{else}}null{{/if}});
             //request the RPC method to be invoked
-            var res = await _cluster.RequestAsync<object>(_id, ""{{../Name}}"", gr,context, ct);
+            var res = await _cluster.RequestAsync<object>(_id, GrainKindConfig.{{../Name}}, gr,context, ct);
 
             return res switch
             {
@@ -120,7 +132,7 @@ namespace {{CsNamespace}}
 		{{/each}}
     }
 
-    class {{Name}}Actor : IActor
+    public class {{Name}}Actor : IActor
     {
         private {{Name}}Base _inner;
         private IContext _context;

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
@@ -12,7 +12,7 @@ namespace Acme.OtherSystem.Foo
         public const string TestGrain = "TestGrain";
 
         public static ClusterKind GetTestGrain(Func<IContext, ClusterIdentity, TestGrainBase> innerFactory)
-            => new(TestGrainKind, Props.FromProducer(() => new TestGrainActor(innerFactory)));
+            => new(TestGrain, Props.FromProducer(() => new TestGrainActor(innerFactory)));
     }
 
     public static partial class GrainExtensions

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
@@ -7,7 +7,15 @@ using Proto.Cluster;
 
 namespace Acme.OtherSystem.Foo
 {
-    public static class GrainExtensions
+    public static partial class GrainKindConfig
+    {
+        public const string TestGrain = "TestGrain";
+
+        public static ClusterKind GetTestGrain(Func<IContext, string, string, TestGrainBase> createGrain)
+            => new(TestGrainKind, Props.FromProducer(() => new TestGrainActor(createGrain)));
+    }
+
+    public static partial class GrainExtensions
     {
         public static TestGrainClient GetTestGrain(this Cluster cluster, string identity) => new(cluster, identity);
 
@@ -100,7 +108,7 @@ namespace Acme.OtherSystem.Foo
         {
             var gr = new GrainRequestMessage(0, null);
             //request the RPC method to be invoked
-            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr, ct);
+            var res = await _cluster.RequestAsync<object>(_id, GrainKindConfig.TestGrain, gr, ct);
 
             return res switch
             {
@@ -119,7 +127,7 @@ namespace Acme.OtherSystem.Foo
         {
             var gr = new GrainRequestMessage(0, null);
             //request the RPC method to be invoked
-            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr,context, ct);
+            var res = await _cluster.RequestAsync<object>(_id, GrainKindConfig.TestGrain, gr,context, ct);
 
             return res switch
             {
@@ -137,7 +145,7 @@ namespace Acme.OtherSystem.Foo
         {
             var gr = new GrainRequestMessage(1, request);
             //request the RPC method to be invoked
-            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr, ct);
+            var res = await _cluster.RequestAsync<object>(_id, GrainKindConfig.TestGrain, gr, ct);
 
             return res switch
             {
@@ -156,7 +164,7 @@ namespace Acme.OtherSystem.Foo
         {
             var gr = new GrainRequestMessage(1, request);
             //request the RPC method to be invoked
-            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr,context, ct);
+            var res = await _cluster.RequestAsync<object>(_id, GrainKindConfig.TestGrain, gr,context, ct);
 
             return res switch
             {
@@ -174,7 +182,7 @@ namespace Acme.OtherSystem.Foo
         {
             var gr = new GrainRequestMessage(2, request);
             //request the RPC method to be invoked
-            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr, ct);
+            var res = await _cluster.RequestAsync<object>(_id, GrainKindConfig.TestGrain, gr, ct);
 
             return res switch
             {
@@ -193,7 +201,7 @@ namespace Acme.OtherSystem.Foo
         {
             var gr = new GrainRequestMessage(2, request);
             //request the RPC method to be invoked
-            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr,context, ct);
+            var res = await _cluster.RequestAsync<object>(_id, GrainKindConfig.TestGrain, gr,context, ct);
 
             return res switch
             {
@@ -211,7 +219,7 @@ namespace Acme.OtherSystem.Foo
         {
             var gr = new GrainRequestMessage(3, null);
             //request the RPC method to be invoked
-            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr, ct);
+            var res = await _cluster.RequestAsync<object>(_id, GrainKindConfig.TestGrain, gr, ct);
 
             return res switch
             {
@@ -230,7 +238,7 @@ namespace Acme.OtherSystem.Foo
         {
             var gr = new GrainRequestMessage(3, null);
             //request the RPC method to be invoked
-            var res = await _cluster.RequestAsync<object>(_id, "TestGrain", gr,context, ct);
+            var res = await _cluster.RequestAsync<object>(_id, GrainKindConfig.TestGrain, gr,context, ct);
 
             return res switch
             {
@@ -246,7 +254,7 @@ namespace Acme.OtherSystem.Foo
         }
     }
 
-    class TestGrainActor : IActor
+    public class TestGrainActor : IActor
     {
         private TestGrainBase _inner;
         private IContext _context;

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
@@ -11,8 +11,8 @@ namespace Acme.OtherSystem.Foo
     {
         public const string TestGrain = "TestGrain";
 
-        public static ClusterKind GetTestGrain(Func<IContext, string, string, TestGrainBase> createGrain)
-            => new(TestGrainKind, Props.FromProducer(() => new TestGrainActor(createGrain)));
+        public static ClusterKind GetTestGrain(Func<IContext, ClusterIdentity, TestGrainBase> innerFactory)
+            => new(TestGrainKind, Props.FromProducer(() => new TestGrainActor(innerFactory)));
     }
 
     public static partial class GrainExtensions
@@ -258,9 +258,9 @@ namespace Acme.OtherSystem.Foo
     {
         private TestGrainBase _inner;
         private IContext _context;
-        private Func<IContext, string, string, TestGrainBase> _innerFactory;        
+        private Func<IContext, ClusterIdentity, TestGrainBase> _innerFactory;        
     
-        public TestGrainActor(Func<IContext, string, string, TestGrainBase> innerFactory)
+        public TestGrainActor(Func<IContext, ClusterIdentity, TestGrainBase> innerFactory)
         {
             _innerFactory = innerFactory;
         }
@@ -273,7 +273,7 @@ namespace Acme.OtherSystem.Foo
                 {
                     _context = context;
                     var id = context.Get<ClusterIdentity>();
-                    _inner = _innerFactory(context, id.Identity, id.Kind);
+                    _inner = _innerFactory(context, id);
                     await _inner.OnStarted();
                     break;
                 }


### PR DESCRIPTION
Fixes grain actor visibility, adds helpers to easily  create cluster kinds.
Changed from stringly typed identity / kind in grain-factory