### PR TITLE
Updated spawn benchmarks

### DIFF
--- a/benchmarks/ProtoActorBenchmarks/SkyNetBenchmark.cs
+++ b/benchmarks/ProtoActorBenchmarks/SkyNetBenchmark.cs
@@ -3,10 +3,12 @@
 //      Copyright (C) 2015-2021 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
+
 using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Proto;
+// ReSharper disable MethodHasAsyncOverload
 
 namespace ProtoActorBenchmarks
 {
@@ -16,7 +18,7 @@ namespace ProtoActorBenchmarks
         private RootContext _context;
         private ActorSystem _actorSystem;
 
-        [Params(0, 5000)]
+        [Params(0)]
         public int SharedFutures { get; set; }
 
         [GlobalSetup]
@@ -37,34 +39,57 @@ namespace ProtoActorBenchmarks
         public void Cleanup() => _actorSystem.ShutdownAsync();
 
         [Benchmark]
-        public Task SkyNetTest()
+        public Task SkyNetRequestAsync()
         {
-            var pid = _context.Spawn(SkyNetActor.Props);
-            return _context.RequestAsync<long>(pid, new Calculate(1_000_000, 0), CancellationToken.None);
+            var pid = _context.Spawn(SkyNetRequestResponseActor.Props(_actorSystem));
+            return _context.RequestAsync<long>(pid, new Request
+                {
+                    Num = 0,
+                    Size = 1000000,
+                }, CancellationToken.None
+            );
         }
 
-        private class SkyNetActor : IActor
+        [Benchmark]
+        public Task SkyNetMessaging()
         {
-            public static readonly Props Props = Props.FromProducer(() => new SkyNetActor());
+            var pid = _context.Spawn(SkynetActor.Props(_actorSystem));
+            return _context.RequestAsync<long>(pid, new Request
+                {
+                    Num = 0,
+                    Size = 1000000,
+                }, CancellationToken.None
+            );
+        }
+
+        private class SkyNetRequestResponseActor : IActor
+        {
+            private readonly ActorSystem _system;
+
+            private SkyNetRequestResponseActor(ActorSystem system) => _system = system;
 
             public async Task ReceiveAsync(IContext context)
             {
-                if (context.Message is Calculate calc)
+                if (context.Message is Request calc)
                 {
-                    if (calc.Count <= 1)
+                    if (calc.Size == 1)
                     {
-                        context.Respond((long) calc.From);
+                        context.Respond(calc.Num);
+                        context.Stop(context.Self);
                         return;
                     }
 
                     var tasks = new Task<long>[10];
-                    var each = calc.Count / 10;
-                    var to = calc.From + calc.Count;
+                    var each = calc.Size / 10;
 
                     for (var i = 0; i < 10; i++)
                     {
-                        var pid = context.Spawn(Props);
-                        tasks[i] = context.RequestAsync<long>(pid, new Calculate(each, calc.From + i * each)
+                        var pid = _system.Root.Spawn(Props(_system));
+                        tasks[i] = context.RequestAsync<long>(pid, new Request
+                            {
+                                Size = each,
+                                Num = calc.Num + i * each
+                            }
                         );
                     }
 
@@ -80,18 +105,74 @@ namespace ProtoActorBenchmarks
                     context.Stop(context.Self);
                 }
             }
+
+            private static SkyNetRequestResponseActor ProduceActor(ActorSystem system) => new(system);
+
+            public static Props Props(ActorSystem system) => Proto.Props.FromProducer(() => ProduceActor(system));
         }
 
-        readonly struct Calculate
+        class SkynetActor : IActor
         {
-            public Calculate(int count, int from)
+            private readonly ActorSystem _system;
+            private long _replies;
+            private PID _replyTo;
+            private long _sum;
+
+            private SkynetActor(ActorSystem system) => _system = system;
+
+            public Task ReceiveAsync(IContext context)
             {
-                Count = count;
-                From = from;
+                var msg = context.Message;
+
+                switch (msg)
+                {
+                    case Request {Size: 1} r:
+                        context.Respond(r.Num);
+                        context.Stop(context.Self);
+                        return Task.CompletedTask;
+                    case Request r: {
+                        _replies = 10;
+                        _replyTo = context.Sender;
+
+                        for (var i = 0; i < 10; i++)
+                        {
+                            var child = _system.Root.Spawn(Props(_system));
+                            context.Request(child, new Request
+                                {
+                                    Num = r.Num + i * (r.Size / 10),
+                                    Size = r.Size / 10,
+                                }
+                            );
+                        }
+
+                        return Task.CompletedTask;
+                    }
+                    case long res: {
+                        _sum += res;
+                        _replies--;
+
+                        if (_replies == 0)
+                        {
+                            context.Send(_replyTo, _sum);
+                            context.Stop(context.Self);
+                        }
+
+                        return Task.CompletedTask;
+                    }
+                    default:
+                        return Task.CompletedTask;
+                }
             }
 
-            public int Count { get; }
-            public int From { get; }
+            private static SkynetActor ProduceActor(ActorSystem system) => new(system);
+
+            public static Props Props(ActorSystem system) => Proto.Props.FromProducer(() => ProduceActor(system));
+        }
+
+        class Request
+        {
+            public long Num;
+            public long Size;
         }
     }
 }

--- a/benchmarks/SpawnBenchmark/Program.cs
+++ b/benchmarks/SpawnBenchmark/Program.cs
@@ -58,7 +58,12 @@ namespace SpawnBenchmark
                 case long res: {
                     _sum += res;
                     _replies--;
-                    if (_replies == 0) context.Send(_replyTo, _sum);
+
+                    if (_replies == 0)
+                    {
+                        context.Send(_replyTo, _sum);
+                        context.Stop(context.Self);
+                    }
                     return Task.CompletedTask;
                 }
                 default:
@@ -95,7 +100,6 @@ namespace SpawnBenchmark
                 var res = t.Result;
                 Console.WriteLine(sw.Elapsed);
                 Console.WriteLine(res);
-                context.StopAsync(pid).Wait();
                 Task.Delay(500).Wait();
             }
 


### PR DESCRIPTION
Now includes both RequesAsync / Request based spawns in Skynet-Benchmark.

Local testing on a Ryzen 9 3900X yielded:

|             Method |      Mean |   Error |  StdDev |
|------------------- |---------:|--------:|--------:|
| SkyNetRequestAsync |              534.3 ms | 4.34 ms | 3.84 ms |
|    SkyNetMessaging |              336.1 ms | 5.37 ms | 5.02 ms |

