### PR TITLE
Serialization Cache

### DIFF
--- a/benchmarks/RemoteBenchmark/Messages/Messages.cs
+++ b/benchmarks/RemoteBenchmark/Messages/Messages.cs
@@ -1,0 +1,20 @@
+// -----------------------------------------------------------------------
+// <copyright file="Messages.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using Google.Protobuf;
+using Proto.Remote;
+
+namespace Messages
+{
+    public partial class Ping : ICachedSerialization
+    {
+        public (ByteString bytes, string typename, int serializerId, bool boolHasData) SerializerData { get; set; }
+    }
+    
+    public partial class Pong : ICachedSerialization
+    {
+        public (ByteString bytes, string typename, int serializerId, bool boolHasData) SerializerData { get; set; }
+    }
+}

--- a/benchmarks/RemoteBenchmark/Messages/Messages.csproj
+++ b/benchmarks/RemoteBenchmark/Messages/Messages.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />
+    <ProjectReference Include="..\..\..\src\Proto.Remote\Proto.Remote.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="Protos.proto" GrpcServices="Server" AdditionalImportDirs=".; ..\..\..\src" />

--- a/benchmarks/RemoteBenchmark/Node2/Program.cs
+++ b/benchmarks/RemoteBenchmark/Node2/Program.cs
@@ -21,6 +21,7 @@ namespace Node2
     public class EchoActor : IActor
     {
         private PID _sender;
+        private static readonly Pong Pong = new Pong();
 
         public Task ReceiveAsync(IContext context)
         {
@@ -32,7 +33,7 @@ namespace Node2
                     context.Respond(new Start());
                     return Task.CompletedTask;
                 case Ping _:
-                    context.Send(_sender, new Pong());
+                    context.Send(_sender, Pong);
                     return Task.CompletedTask;
                 default:
                     return Task.CompletedTask;

--- a/src/Proto.Remote/Endpoints/EndpointActor.cs
+++ b/src/Proto.Remote/Endpoints/EndpointActor.cs
@@ -257,7 +257,21 @@ namespace Proto.Remote
 
                 try
                 {
-                    (bytes, typeName, serializerId) = _remoteConfig.Serialization.Serialize(message);
+                    var cached = message as ICachedSerialization;
+                    if (cached is {SerializerData: {boolHasData: true}} )
+                    {
+                        (bytes, typeName, serializerId, _) = cached.SerializerData;
+                    }
+                    else
+                    {
+                        (bytes, typeName, serializerId) = _remoteConfig.Serialization.Serialize(message);
+
+                        if (cached is not null)
+                        {
+                            cached.SerializerData = (bytes, typeName, serializerId, true);
+                        }
+                    }
+
                 }
                 catch (CodedOutputStream.OutOfSpaceException oom)
                 {

--- a/src/Proto.Remote/Serialization/ICachedSerialization.cs
+++ b/src/Proto.Remote/Serialization/ICachedSerialization.cs
@@ -1,0 +1,14 @@
+// -----------------------------------------------------------------------
+// <copyright file="ICachedSerialization.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using Google.Protobuf;
+
+namespace Proto.Remote
+{
+    public interface ICachedSerialization
+    {
+        (ByteString bytes, string typename, int serializerId, bool boolHasData) SerializerData { get; set; }
+    }
+}


### PR DESCRIPTION
Edgecase optimization. messages implementing `ICachedSerialization` can store the serialization data. payload etc.
Allowing it to bypass repeated serialization.

This of course assumes the message is immutable

On my small laptop we now push 4.2 mil messages / second over remote
<img width="1440" alt="Skärmavbild 2021-09-05 kl  10 10 05" src="https://user-images.githubusercontent.com/647031/132120400-1edff800-95c4-4684-ae46-b41903193e7d.png">
