### PR TITLE
Remote blocklist 2

### DIFF
--- a/ProtoActor.sln.DotSettings
+++ b/ProtoActor.sln.DotSettings
@@ -1,4 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=eventstream/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pids/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Routee/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Routees/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Routees/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=watchee/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Proto.Cluster/Member/MemberList.cs
+++ b/src/Proto.Cluster/Member/MemberList.cs
@@ -262,7 +262,7 @@ namespace Proto.Cluster
 
         private void TerminateMember(Member memberThatLeft)
         {
-            var endpointTerminated = new EndpointTerminatedEvent {Address = memberThatLeft.Address};
+            var endpointTerminated = new EndpointTerminatedEvent(memberThatLeft.Address);
             Logger.LogDebug("[MemberList] Published event {@EndpointTerminated}", endpointTerminated);
             _cluster.System.EventStream.Publish(endpointTerminated);
         }

--- a/src/Proto.Remote.GrpcCore/GrpcCoreRemote.cs
+++ b/src/Proto.Remote.GrpcCore/GrpcCoreRemote.cs
@@ -37,6 +37,8 @@ namespace Proto.Remote.GrpcCore
         }
 
         public bool Started { get; private set; }
+
+        public BlockList BlockList { get; } = new();
         public ActorSystem System { get; }
         public RemoteConfigBase Config => _config;
 

--- a/src/Proto.Remote.GrpcNet/GrpcNetRemote.cs
+++ b/src/Proto.Remote.GrpcNet/GrpcNetRemote.cs
@@ -34,6 +34,9 @@ namespace Proto.Remote.GrpcNet
         }
 
         public bool Started { get; private set; }
+        
+        public BlockList BlockList { get; } = new();
+        
         public RemoteConfigBase Config => _config;
         public ActorSystem System { get; }
 

--- a/src/Proto.Remote.GrpcNet/HostedGrpcNetRemote.cs
+++ b/src/Proto.Remote.GrpcNet/HostedGrpcNetRemote.cs
@@ -9,7 +9,7 @@ namespace Proto.Remote.GrpcNet
 {
     public class HostedGrpcNetRemote : IRemote
     {
-        private readonly object _lock = new(); 
+        private readonly object _lock = new();
         private readonly GrpcNetRemoteConfig _config;
         private readonly EndpointManager _endpointManager;
         private readonly ILogger _logger;
@@ -34,6 +34,8 @@ namespace Proto.Remote.GrpcNet
         public RemoteConfigBase Config => _config;
         public ActorSystem System { get; }
         public bool Started { get; private set; }
+        
+        public BlockList BlockList { get; } = new();
 
         public Task StartAsync()
         {

--- a/src/Proto.Remote/BlockList.cs
+++ b/src/Proto.Remote/BlockList.cs
@@ -1,0 +1,18 @@
+// -----------------------------------------------------------------------
+// <copyright file="BlockList.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using Proto.Utils;
+
+namespace Proto.Remote
+{
+    public class BlockList
+    {
+        private readonly ConcurrentSet<string> _blockedMembers = new();
+
+        public void Block(string memberId) => _blockedMembers.Add(memberId);
+
+        public bool IsBlocked(string memberId) => _blockedMembers.Contains(memberId);
+    }
+}

--- a/src/Proto.Remote/Endpoints/EndpointActor.cs
+++ b/src/Proto.Remote/Endpoints/EndpointActor.cs
@@ -89,10 +89,7 @@ namespace Proto.Remote
             if (res.Blocked)
             {
                 Logger.LogError("Connection Refused to remote member {MemberId} address {Address}, we are blocked", res.MemberId, _address);
-                var terminated = new EndpointTerminatedEvent
-                {
-                    Address = _address
-                };
+                var terminated = new EndpointTerminatedEvent(_address);
                 context.System.EventStream.Publish(terminated);
                 // ReSharper disable once MethodHasAsyncOverload
                 context.Stop(context.Self);
@@ -110,10 +107,7 @@ namespace Proto.Remote
                     {
                         await _stream.ResponseStream.MoveNext();
                         Logger.LogDebug("[EndpointActor] {Address} Disconnected", _address);
-                        var terminated = new EndpointTerminatedEvent
-                        {
-                            Address = _address
-                        };
+                        var terminated = new EndpointTerminatedEvent(_address);
                         context.System.EventStream.Publish(terminated);
                     }
                     catch (RpcException x) when (x.StatusCode == StatusCode.Unavailable)
@@ -141,10 +135,7 @@ namespace Proto.Remote
 
             Logger.LogDebug("[EndpointActor] Created reader for address {Address}", _address);
 
-            var connected = new EndpointConnectedEvent
-            {
-                Address = _address
-            };
+            var connected = new EndpointConnectedEvent(_address);
             context.System.EventStream.Publish(connected);
 
             Logger.LogDebug("[EndpointActor] Connected to address {Address}", _address);

--- a/src/Proto.Remote/Endpoints/EndpointSupervisorStrategy.cs
+++ b/src/Proto.Remote/Endpoints/EndpointSupervisorStrategy.cs
@@ -48,7 +48,7 @@ namespace Proto.Remote
                     _address, reason.GetType().Name
                 );
                 _cancelFutureRetries.Cancel();
-                var terminated = new EndpointTerminatedEvent {Address = _address!};
+                var terminated = new EndpointTerminatedEvent(_address);
                 _system.EventStream.Publish(terminated);
             }
             else

--- a/src/Proto.Remote/IRemote.cs
+++ b/src/Proto.Remote/IRemote.cs
@@ -8,6 +8,8 @@ namespace Proto.Remote
         RemoteConfigBase Config { get; }
         ActorSystem System { get; }
         bool Started { get; }
+        
+        BlockList BlockList { get; }
 
         Task ShutdownAsync(bool graceful = true);
 

--- a/src/Proto.Remote/Messages.cs
+++ b/src/Proto.Remote/Messages.cs
@@ -8,22 +8,17 @@ using System;
 
 namespace Proto.Remote
 {
-    public sealed record EndpointTerminatedEvent
+    public sealed record EndpointTerminatedEvent(string Address)
     {
-        public string Address { get; set; } = null!;
-
         public override string ToString() => $"EndpointTerminatedEvent: {Address}";
     }
 
-    public sealed record EndpointConnectedEvent
-    {
-        public string Address { get; set; } = null!;
-    }
+    public sealed record EndpointConnectedEvent(string Address);
 
     public sealed record EndpointErrorEvent
     {
-        public string Address { get; set; } = null!;
-        public Exception Exception { get; set; } = null!;
+        public string Address { get; init; } = null!;
+        public Exception Exception { get; init; } = null!;
     }
 
     public sealed record RemoteTerminate(PID Watcher, PID Watchee);
@@ -32,6 +27,5 @@ namespace Proto.Remote
 
     public sealed record RemoteUnwatch(PID Watcher, PID Watchee);
 
-    public sealed record RemoteDeliver (Proto.MessageHeader Header, object Message, PID Target, PID Sender);
-
+    public sealed record RemoteDeliver(Proto.MessageHeader Header, object Message, PID Target, PID? Sender);
 }

--- a/src/Proto.Remote/Protos.proto
+++ b/src/Proto.Remote/Protos.proto
@@ -42,8 +42,9 @@ message ConnectRequest {
 }
 
 message ConnectResponse {
-  int32 default_serializer_id = 1;
+  //int32 default_serializer_id = 1; Obsoleted
   string member_id = 2;
+  bool blocked = 3;
 }
 
 service Remoting {


### PR DESCRIPTION
Initial code to handle blocked response from remote nodes.
Initial code to allow endpoint readers to keep track of blocked nodes