### PR TITLE
Disable deprecation warnings for generated code.

### DIFF
--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -145,7 +145,9 @@ namespace {{CsNamespace}}
                     await _inner.OnStarted();
                     break;
                 }
+#pragma warning disable 618
                 case ClusterInit _:
+#pragma warning restore 618
                     //Ignored
                     break;
                 case Stopping _:

--- a/tests/Proto.Actor.Tests/PoisonTests.cs
+++ b/tests/Proto.Actor.Tests/PoisonTests.cs
@@ -25,7 +25,7 @@ namespace Proto.Tests
         public async Task PoisonReturnsIfPidDoesNotExist()
         {
             var deadPid = PID.FromAddress(System.Address, "nowhere");
-            var timeout = Task.Delay(1000);
+            var timeout = Task.Delay(2000);
 
             var poisonTask = Context.PoisonAsync(deadPid);
 
@@ -42,7 +42,7 @@ namespace Proto.Tests
             const string message = "hello";
             (await Context.RequestAsync<string>(pid, message)).Should().Be(message);
 
-            var timeout = Task.Delay(1000);
+            var timeout = Task.Delay(2000);
             var poisonTask = Context.PoisonAsync(pid);
             await Task.WhenAny(timeout, poisonTask);
 

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
@@ -271,7 +271,9 @@ namespace Acme.OtherSystem.Foo
                     await _inner.OnStarted();
                     break;
                 }
+#pragma warning disable 618
                 case ClusterInit _:
+#pragma warning restore 618
                     //Ignored
                     break;
                 case Stopping _:


### PR DESCRIPTION
Grains explicitly skip the deprecated ClusterInit message. This removes the warnings from the generated code