### PR TITLE
Fixed using "." path in AdditionalImportPaths in ClusterCodeGen

### DIFF
--- a/src/Proto.Cluster.CodeGen/PathPolyfill.cs
+++ b/src/Proto.Cluster.CodeGen/PathPolyfill.cs
@@ -17,12 +17,12 @@ namespace Proto.Cluster.CodeGen
         {
             if (string.IsNullOrEmpty(relativeTo))
             {
-                throw new ArgumentNullException(nameof(relativeTo));
+                throw new ArgumentException("value cannot be null or empty", nameof(relativeTo));
             }
 
             if (string.IsNullOrEmpty(path))
             {
-                throw new ArgumentNullException(nameof(path));
+                throw new ArgumentException("value cannot be null or empty", nameof(path));
             }
 
             var relativeToUri = GetUri(relativeTo);
@@ -43,6 +43,11 @@ namespace Proto.Cluster.CodeGen
             }
 
             relativePath = relativePath.TrimEnd(Path.DirectorySeparatorChar);
+
+            if (relativePath == string.Empty)
+            {
+                relativePath = ".";
+            }
 
             return relativePath;
         }

--- a/tests/Proto.Cluster.CodeGen.Tests/PathPolyfillTests.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/PathPolyfillTests.cs
@@ -14,8 +14,11 @@ namespace Proto.Cluster.CodeGen.Tests
     {
         [Theory]
         [InlineData(@"some\other\path")]
+        [InlineData(@"some\other\path\")]
         [InlineData(@".\some\other\path")]
+        [InlineData(@".\some\other\path\")]
         [InlineData(@".\foo\..\some\other\path")]
+        [InlineData(@".\foo\..\some\other\path\")]
         public void CanGetRelativePath(string unadjustedPath)
         {
             var relativeTo = AdjustToCurrentOs(@"root\dir");
@@ -30,6 +33,28 @@ namespace Proto.Cluster.CodeGen.Tests
             relativePath
                 .Should()
                 .Be(Path.GetRelativePath(relativeTo, path));
+        }
+
+        [Theory]
+        [InlineData(@"root\dir")]
+        [InlineData(@"root\dir\")]
+        [InlineData(".")]
+        [InlineData(@".\")]
+        [InlineData(@".\foo\..")]
+        [InlineData(@".\foo\..\")]
+        public void CanGetEmptyRelativePath(string unadjustedPath)
+        {
+            var path = AdjustToCurrentOs(unadjustedPath);
+
+            var relativePath = PathPolyfill.GetRelativePath(path, path);
+
+            relativePath
+                .Should()
+                .Be(".");
+
+            relativePath
+                .Should()
+                .Be(Path.GetRelativePath(path, path));
         }
 
         private static string AdjustToCurrentOs(string path) => path


### PR DESCRIPTION
This fixes #1211. I've tested it locally on Windows with Visual Studio, Rider, and `dotnet` command. It would be nice if someone tested it on Mac.