### PR TITLE
Improve Partition Identity performance

### DIFF
--- a/ProtoActor.sln
+++ b/ProtoActor.sln
@@ -231,6 +231,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Proto.OpenTelemetry", "src\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Proto.OpenTelemetry.Tests", "tests\Proto.OpenTelemetry.Tests\Proto.OpenTelemetry.Tests.csproj", "{C8710CE8-E84F-430C-A20A-F439CB6FA6C5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Proto.Cluster.PartitionIdentity.Tests", "tests\Proto.Cluster.PartitionIdentity.Tests\Proto.Cluster.PartitionIdentity.Tests.csproj", "{2F76D090-2907-4A2C-BAE1-51D818C63CF1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1117,6 +1119,18 @@ Global
 		{C8710CE8-E84F-430C-A20A-F439CB6FA6C5}.Release|x64.Build.0 = Release|Any CPU
 		{C8710CE8-E84F-430C-A20A-F439CB6FA6C5}.Release|x86.ActiveCfg = Release|Any CPU
 		{C8710CE8-E84F-430C-A20A-F439CB6FA6C5}.Release|x86.Build.0 = Release|Any CPU
+		{2F76D090-2907-4A2C-BAE1-51D818C63CF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F76D090-2907-4A2C-BAE1-51D818C63CF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F76D090-2907-4A2C-BAE1-51D818C63CF1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2F76D090-2907-4A2C-BAE1-51D818C63CF1}.Debug|x64.Build.0 = Debug|Any CPU
+		{2F76D090-2907-4A2C-BAE1-51D818C63CF1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2F76D090-2907-4A2C-BAE1-51D818C63CF1}.Debug|x86.Build.0 = Debug|Any CPU
+		{2F76D090-2907-4A2C-BAE1-51D818C63CF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F76D090-2907-4A2C-BAE1-51D818C63CF1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F76D090-2907-4A2C-BAE1-51D818C63CF1}.Release|x64.ActiveCfg = Release|Any CPU
+		{2F76D090-2907-4A2C-BAE1-51D818C63CF1}.Release|x64.Build.0 = Release|Any CPU
+		{2F76D090-2907-4A2C-BAE1-51D818C63CF1}.Release|x86.ActiveCfg = Release|Any CPU
+		{2F76D090-2907-4A2C-BAE1-51D818C63CF1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1223,6 +1237,7 @@ Global
 		{13576D71-626E-43AE-9334-80C40F16CAFF} = {9AA2BCF0-19AB-4DD9-8D91-7D188E463806}
 		{6FAC658B-914B-4CA4-9DA6-1C9B5BE40787} = {771514F1-12AE-4A26-89CB-2646D3EF7034}
 		{C8710CE8-E84F-430C-A20A-F439CB6FA6C5} = {9AA2BCF0-19AB-4DD9-8D91-7D188E463806}
+		{2F76D090-2907-4A2C-BAE1-51D818C63CF1} = {9AA2BCF0-19AB-4DD9-8D91-7D188E463806}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD0D1E44-8118-4682-8793-6B20ABFA824C}

--- a/ProtoActor.sln.DotSettings
+++ b/ProtoActor.sln.DotSettings
@@ -1,11 +1,13 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=deadletter/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Asynkron/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=eventstream/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pids/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=protoactor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=protocluster/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=protoremote/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=requestasync/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Rebalance/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Routee/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Routees/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=threadpool/@EntryIndexedValue">True</s:Boolean>

--- a/benchmarks/ClusterBenchmark/ClusterBenchmark.csproj
+++ b/benchmarks/ClusterBenchmark/ClusterBenchmark.csproj
@@ -14,6 +14,7 @@
         <ProjectReference Include="..\..\src\Proto.OpenTelemetry\Proto.OpenTelemetry.csproj" />
         <ProjectReference Include="..\..\src\Proto.Cluster.Identity.MongoDb\Proto.Cluster.Identity.MongoDb.csproj" />
         <ProjectReference Include="..\..\src\Proto.Cluster.Kubernetes\Proto.Cluster.Kubernetes.csproj" />
+        <ProjectReference Include="..\..\src\Proto.Remote.GrpcCore\Proto.Remote.GrpcCore.csproj" />
         <ProjectReference Include="..\..\src\Proto.Remote.GrpcNet\Proto.Remote.GrpcNet.csproj" />
     </ItemGroup>
 

--- a/benchmarks/ClusterBenchmark/ClusterBenchmark.csproj
+++ b/benchmarks/ClusterBenchmark/ClusterBenchmark.csproj
@@ -11,6 +11,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\Proto.Cluster.Consul\Proto.Cluster.Consul.csproj" />
         <ProjectReference Include="..\..\src\Proto.Cluster.Identity.Redis\Proto.Cluster.Identity.Redis.csproj" />
+        <ProjectReference Include="..\..\src\Proto.OpenTelemetry\Proto.OpenTelemetry.csproj" />
         <ProjectReference Include="..\..\src\Proto.Cluster.Identity.MongoDb\Proto.Cluster.Identity.MongoDb.csproj" />
         <ProjectReference Include="..\..\src\Proto.Cluster.Kubernetes\Proto.Cluster.Kubernetes.csproj" />
         <ProjectReference Include="..\..\src\Proto.Remote.GrpcNet\Proto.Remote.GrpcNet.csproj" />
@@ -18,12 +19,13 @@
 
     <ItemGroup>
         <PackageReference Include="DotNet.Testcontainers" Version="1.5.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.40.0" PrivateAssets="All" />
+        <PackageReference Include="Grpc.Tools" Version="2.42.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
         <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-        <PackageReference Include="Serilog" Version="2.10.1-dev-01366" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.2-dev-10289" />
+        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.1.0" />
+        <PackageReference Include="Serilog" Version="2.10.0" />
+        <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
     </ItemGroup>
 

--- a/benchmarks/ClusterBenchmark/Configuration.cs
+++ b/benchmarks/ClusterBenchmark/Configuration.cs
@@ -12,6 +12,8 @@ using Grpc.Net.Compression;
 using k8s;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Proto;
 using Proto.Cluster;
 using Proto.Cluster.Consul;
@@ -20,6 +22,7 @@ using Proto.Cluster.Identity.MongoDb;
 using Proto.Cluster.Identity.Redis;
 using Proto.Cluster.Kubernetes;
 using Proto.Cluster.Partition;
+using Proto.OpenTelemetry;
 using Proto.Remote;
 using Proto.Remote.GrpcNet;
 using Serilog;
@@ -31,6 +34,31 @@ namespace ClusterExperiment1
 {
     public static class Configuration
     {
+        private const bool EnableTracing = true;
+
+        private static readonly object InitLock = new();
+        private static TracerProvider? tracerProvider;
+
+#pragma warning disable CS0162
+        private static void InitTracing()
+        {
+            if (!EnableTracing) return;
+
+            lock (InitLock)
+            {
+                if (tracerProvider is not null) return;
+
+                tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+                    .SetResourceBuilder(ResourceBuilder.CreateDefault()
+                        .AddService("ClusterBenchmark")
+                    )
+                    .AddProtoActorInstrumentation()
+                    .AddJaegerExporter(options => options.AgentHost = "localhost")
+                    .Build();
+            }
+        }
+#pragma warning restore CS0162
+
         private static ClusterConfig GetClusterConfig(
             IClusterProvider clusterProvider,
             IIdentityLookup identityLookup
@@ -64,7 +92,7 @@ namespace ClusterExperiment1
                 )
                 .WithProtoMessages(MessagesReflection.Descriptor)
                 .WithEndpointWriterMaxRetries(2);
-            
+
             return remoteConfig;
         }
 
@@ -83,16 +111,14 @@ namespace ClusterExperiment1
             }
         }
 
-        public static IIdentityLookup GetIdentityLookup()
-        {
-            return GetRedisIdentityLookup();
-            //return new PartitionIdentityLookup(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
-        }
+        public static IIdentityLookup GetIdentityLookup() => new PartitionIdentityLookup(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5),
+            new PartitionConfig(false, 5000, TimeSpan.FromSeconds(1))
+        );
 
         private static IIdentityLookup GetRedisIdentityLookup()
         {
             var multiplexer = ConnectionMultiplexer.Connect("localhost:6379");
-            var redisIdentityStorage = new RedisIdentityStorage("mycluster", multiplexer,maxConcurrency:50);
+            var redisIdentityStorage = new RedisIdentityStorage("mycluster", multiplexer, maxConcurrency: 50);
 
             return new IdentityStorageLookup(redisIdentityStorage);
         }
@@ -124,52 +150,65 @@ namespace ClusterExperiment1
 
         public static async Task<Cluster> SpawnMember()
         {
-            var system = new ActorSystem(new ActorSystemConfig()
-                .WithSharedFutures()
-                .WithDeadLetterThrottleCount(3)
-                .WithDeadLetterThrottleInterval(TimeSpan.FromSeconds(1))
-                .WithDeadLetterRequestLogging(false)
-                .WithDeveloperSupervisionLogging(false)
-                .WithDeveloperReceiveLogging(TimeSpan.FromSeconds(1))
+            InitTracing();
+            var system = new ActorSystem(GetMemberActorSystemConfig()
             );
             system.EventStream.Subscribe<ClusterTopology>(e => {
-                Console.ForegroundColor = ConsoleColor.Yellow;
-                Console.WriteLine($"{system.Id}-ClusterTopology:{e.GetMembershipHashCode()}");
-                Console.ResetColor();
-            });
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    Console.WriteLine($"M:{system.Id}-{system.Address}-ClusterTopology:{e.GetMembershipHashCode()}");
+                    Console.ResetColor();
+                }
+            );
             system.EventStream.Subscribe<LeaderElected>(e => {
-                Console.ForegroundColor = ConsoleColor.Cyan;
-                Console.WriteLine($"{system.Id}-Leader:{e.Leader.Id}");
-                Console.ResetColor();
-            });
+                    Console.ForegroundColor = ConsoleColor.Cyan;
+                    Console.WriteLine($"M:{system.Id}-{system.Address}-Leader:{e.Leader.Id}");
+                    Console.ResetColor();
+                }
+            );
             var clusterProvider = ClusterProvider();
             var identity = GetIdentityLookup();
-            
-            system.WithRemote(GetRemoteConfig()).WithCluster(GetClusterConfig(clusterProvider,identity));
+
+            system.WithRemote(GetRemoteConfig()).WithCluster(GetClusterConfig(clusterProvider, identity));
             await system.Cluster().StartMemberAsync();
             return system.Cluster();
         }
 
-        public static async Task<Cluster> SpawnClient()
+        private static ActorSystemConfig GetMemberActorSystemConfig()
         {
-            var system = new ActorSystem(new ActorSystemConfig().WithDeadLetterThrottleCount(3)
-                .WithSharedFutures()
+            var config = new ActorSystemConfig()
+                // .WithSharedFutures()
+                .WithDeadLetterThrottleCount(3)
                 .WithDeadLetterThrottleInterval(TimeSpan.FromSeconds(1))
                 .WithDeadLetterRequestLogging(false)
-            );
+                .WithDeveloperSupervisionLogging(true)
+                .WithDeveloperReceiveLogging(TimeSpan.FromSeconds(1));
+
+            return EnableTracing ? config.WithConfigureProps(props => props.WithTracing()) : config;
+        }
+
+        public static async Task<Cluster> SpawnClient()
+        {
+            InitTracing();
+            var config = new ActorSystemConfig().WithDeadLetterThrottleCount(3)
+                .WithSharedFutures()
+                .WithDeadLetterThrottleInterval(TimeSpan.FromSeconds(1))
+                .WithDeadLetterRequestLogging(false);
+            var system = new ActorSystem(EnableTracing ? config.WithConfigureProps(props => props.WithTracing()) : config);
             system.EventStream.Subscribe<ClusterTopology>(e => {
-                Console.ForegroundColor = ConsoleColor.Yellow;
-                Console.WriteLine($"{system.Id}-ClusterTopology:{e.GetMembershipHashCode()}");
-                Console.ResetColor();
-            });
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    Console.WriteLine($"C:{system.Id}-{system.Address}-ClusterTopology:{e.GetMembershipHashCode()}");
+                    Console.ResetColor();
+                }
+            );
             system.EventStream.Subscribe<LeaderElected>(e => {
-                Console.ForegroundColor = ConsoleColor.Cyan;
-                Console.WriteLine($"{system.Id}-Leader:{e.Leader.Id}");
-                Console.ResetColor();
-            });
+                    Console.ForegroundColor = ConsoleColor.Cyan;
+                    Console.WriteLine($"C:{system.Id}-{system.Address}-Leader:{e.Leader.Id}");
+                    Console.ResetColor();
+                }
+            );
             var clusterProvider = ClusterProvider();
             var identity = GetIdentityLookup();
-            system.WithRemote(GetRemoteConfig()).WithCluster(GetClusterConfig(clusterProvider,identity));
+            system.WithRemote(GetRemoteConfig()).WithCluster(GetClusterConfig(clusterProvider, identity));
 
             await system.Cluster().StartClientAsync();
             return system.Cluster();
@@ -180,7 +219,7 @@ namespace ClusterExperiment1
             Log.Logger = new LoggerConfiguration()
                 .WriteTo.Console(LogEventLevel.Error)
                 .CreateLogger();
-            
+
             Proto.Log.SetLoggerFactory(LoggerFactory.Create(l =>
                     l.AddSerilog().SetMinimumLevel(loglevel)
                 )

--- a/benchmarks/ClusterBenchmark/Program.cs
+++ b/benchmarks/ClusterBenchmark/Program.cs
@@ -377,7 +377,7 @@ namespace ClusterExperiment1
                 followers.Add(p);
             }
 
-            await Task.Delay(15000);
+            await Task.Delay(4000);
 
             startClient();
             Console.WriteLine("Client started...");

--- a/benchmarks/ClusterMicroBenchmarks/ConcurrentSpawnBenchmark.cs
+++ b/benchmarks/ClusterMicroBenchmarks/ConcurrentSpawnBenchmark.cs
@@ -1,0 +1,109 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="PidCacheBenchmark.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Proto;
+using Proto.Cluster;
+using Proto.Cluster.Partition;
+using Proto.Cluster.Testing;
+using Proto.Remote.GrpcNet;
+
+namespace ClusterMicroBenchmarks
+{
+    [MemoryDiagnoser, InProcess]
+    public class ConcurrentSpawnBenchmark
+    {
+        private Cluster _cluster;
+        private const string Kind = "echo";
+
+        [Params(IdentityLookup.Partition)]
+        public IdentityLookup IdentityProvider { get; set; }
+
+        [Params(10_000, 20_000)]
+        public int ConcurrentSpawns { get; set; }
+
+        [GlobalSetup]
+        public async Task Setup()
+        {
+            var echoProps = Props.FromFunc(ctx => {
+                    if (ctx.Sender is not null) ctx.Respond(ctx.Message!);
+                    return Task.CompletedTask;
+                }
+            );
+
+            var echoKind = new ClusterKind(Kind, echoProps);
+
+            var sys = new ActorSystem(new ActorSystemConfig())
+                .WithRemote(GrpcNetRemoteConfig.BindToLocalhost(9090))
+                .WithCluster(ClusterConfig().WithClusterKind(echoKind));
+
+            _cluster = sys.Cluster();
+            await _cluster.StartMemberAsync();
+        }
+
+        private ClusterConfig ClusterConfig() => Proto.Cluster.ClusterConfig.Setup("test-cluster",
+            new TestProvider(new TestProviderOptions(), new InMemAgent()),
+            GetIdentityLookup()
+        );
+
+        private PartitionIdentityLookup GetIdentityLookup()
+        {
+            switch (IdentityProvider)
+            {
+                case IdentityLookup.Partition:
+                    return new PartitionIdentityLookup();
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        [GlobalCleanup]
+        public Task Cleanup() => _cluster.ShutdownAsync();
+
+        [Benchmark]
+        public async Task SpawnIdentities()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var tasks = new Task<PID>[ConcurrentSpawns];
+
+            for (var i = 0; i < ConcurrentSpawns; i++)
+            {
+                tasks[i] = _cluster.GetAsync(i.ToString(), Kind, cts.Token);
+            }
+
+            var pids = await Task.WhenAll(tasks);
+
+            for (var i = 0; i < ConcurrentSpawns; i++)
+            {
+                if (pids[i] is null) throw new Exception("Failed to return id " + i);
+            }
+        }
+
+        [IterationCleanup]
+        public void RemoveActivations()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var tasks = new Task[ConcurrentSpawns];
+
+            for (var i = 0; i < ConcurrentSpawns; i++)
+            {
+                var id = ClusterIdentity.Create(i.ToString(), Kind);
+                tasks[i] = _cluster.RequestAsync<Terminated>(id, PoisonPill.Instance, cts.Token);
+            }
+
+            Task.WhenAll(tasks).GetAwaiter().GetResult();
+        }
+
+        public enum IdentityLookup
+        {
+            Partition,
+            Redis,
+            MongoDb
+        }
+    }
+}

--- a/benchmarks/ClusterMicroBenchmarks/Program.cs
+++ b/benchmarks/ClusterMicroBenchmarks/Program.cs
@@ -4,6 +4,6 @@ namespace ClusterMicroBenchmarks
 {
     class Program
     {
-        static void Main() => BenchmarkRunner.Run<InProcessClusterRequestBenchmark>();
+        static void Main() => BenchmarkRunner.Run<ConcurrentSpawnBenchmark>();
     }
 }

--- a/benchmarks/ClusterMicroBenchmarks/RendezvousBenchmark.cs
+++ b/benchmarks/ClusterMicroBenchmarks/RendezvousBenchmark.cs
@@ -1,0 +1,65 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="RendezvousBenchmark.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Proto;
+using Proto.Cluster;
+using Proto.Cluster.Partition;
+using Proto.Router;
+
+namespace ClusterMicroBenchmarks
+{
+    [MemoryDiagnoser, InProcess]
+    public class RendezvousBenchmark
+    {
+        [Params(1, 10, 100)]
+        public int NodeCount { get; set; }
+
+        private int _i = 0;
+        private static readonly string[] Ids = Enumerable.Range(0, 100).Select(_ => Guid.NewGuid().ToString()).ToArray();
+
+        private Rendezvous _rendezvous;
+        private MemberHashRing _memberHashRing;
+        private HashRing<Member> _hashRing;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var members = Enumerable.Range(0, NodeCount).Select(i => new Member
+                {
+                    Host = "localhost",
+                    Id = Guid.NewGuid().ToString("N"),
+                    Port = i + 1000
+                }
+            ).ToArray();
+            _rendezvous = new Rendezvous();
+            _rendezvous.UpdateMembers(members);
+            _memberHashRing = new MemberHashRing(members);
+            _hashRing = new HashRing<Member>(members, member => member.Address, MurmurHash2.Hash, 50);
+        }
+
+        [Benchmark]
+        public void Rendezvous()
+        {
+            var owner = _rendezvous.GetOwnerMemberByIdentity(TestId());
+        }
+
+        [Benchmark]
+        public void MemberRing()
+        {
+            var owner = _memberHashRing.GetOwnerMemberByIdentity(TestId());
+        }
+
+        [Benchmark]
+        public void HashRing()
+        {
+            var owner = _hashRing.GetNode(TestId());
+        }
+
+        private string TestId() => Ids[_i++ % Ids.Length];
+    }
+}

--- a/benchmarks/RemoteBenchmark/Messages/Messages.csproj
+++ b/benchmarks/RemoteBenchmark/Messages/Messages.csproj
@@ -3,9 +3,9 @@
     <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.18.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.19.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.40.0" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.42.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/benchmarks/RemoteBenchmark/Node2/Program.cs
+++ b/benchmarks/RemoteBenchmark/Node2/Program.cs
@@ -22,7 +22,7 @@ namespace Node2
     {
         private PID _sender;
         private static readonly Pong Pong = new Pong();
-        private int _count = 0;
+        // private int _count = 0;
 
         public Task ReceiveAsync(IContext context)
         {

--- a/examples/ActorMetrics/ActorMetrics.csproj
+++ b/examples/ActorMetrics/ActorMetrics.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Grpc.Tools" Version="2.40.0">
+        <PackageReference Include="Grpc.Tools" Version="2.42.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/examples/Chat/Messages/Chat.Messages.csproj
+++ b/examples/Chat/Messages/Chat.Messages.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Grpc.Tools" Version="2.40.0" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.42.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/ClusterPubSub/ClusterPubSub.csproj
+++ b/examples/ClusterPubSub/ClusterPubSub.csproj
@@ -12,8 +12,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Google.Protobuf" Version="3.18.0" />
-      <PackageReference Include="Grpc.Tools" Version="2.40.0">
+      <PackageReference Include="Google.Protobuf" Version="3.19.1" />
+      <PackageReference Include="Grpc.Tools" Version="2.42.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/examples/EventStreamTopicsCluster/EventStreamTopicsCluster.csproj
+++ b/examples/EventStreamTopicsCluster/EventStreamTopicsCluster.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Grpc.Tools" Version="2.40.0">
+      <PackageReference Include="Grpc.Tools" Version="2.42.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/examples/KafkaVirtualActorIngress/KafkaVirtualActorIngress.csproj
+++ b/examples/KafkaVirtualActorIngress/KafkaVirtualActorIngress.csproj
@@ -16,8 +16,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Google.Protobuf" Version="3.18.0" />
-      <PackageReference Include="Grpc.Tools" Version="2.40.0" />
+      <PackageReference Include="Google.Protobuf" Version="3.19.1" />
+      <PackageReference Include="Grpc.Tools" Version="2.42.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
       <PackageReference Include="StackExchange.Redis" Version="2.2.50" />
     </ItemGroup>
 

--- a/examples/Persistence/Messages/Messages.csproj
+++ b/examples/Persistence/Messages/Messages.csproj
@@ -3,9 +3,9 @@
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.18.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.19.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.40.0" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.42.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="Protos.proto" GrpcServices="Server,Client" />

--- a/src/Proto.Actor/EventStream/DeadLetter.cs
+++ b/src/Proto.Actor/EventStream/DeadLetter.cs
@@ -4,14 +4,11 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-// ReSharper disable once CheckNamespace
-
-// ReSharper disable once CheckNamespace
-
 using System;
 using JetBrains.Annotations;
 using Proto.Metrics;
 
+// ReSharper disable once CheckNamespace
 namespace Proto
 {
     [PublicAPI]

--- a/src/Proto.Actor/Proto.Actor.csproj
+++ b/src/Proto.Actor/Proto.Actor.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.18.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.40.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.19.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.42.0" PrivateAssets="All" />
     <PackageReference Include="IsExternalInit.System.Runtime.CompilerServices" Version="1.0.0" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Roslynator.Analyzers" Version="3.2.2">

--- a/src/Proto.Actor/Router/HashRing.cs
+++ b/src/Proto.Actor/Router/HashRing.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // <copyright file="HashRing.cs" company="Asynkron AB">
 //      Copyright (C) 2015-2020 Asynkron AB All rights reserved
 // </copyright>
@@ -9,33 +9,109 @@ using System.Linq;
 
 namespace Proto.Router
 {
-    public class HashRing
+    public class HashRing<T>
     {
+        private readonly Func<T, string> _getKey;
         private readonly Func<string, uint> _hash;
-        private readonly List<Tuple<uint, string>> _ring;
+        private readonly int _replicaCount;
+        
+        // Does not update these, replaced on mutation. Would otherwise break clone.
+        private uint[] _hashes;
+        private (uint hash, T value)[] _ring;
 
-        public HashRing(IEnumerable<string> nodes, Func<string, uint> hash, int replicaCount)
+        public HashRing(IEnumerable<T> nodes, Func<T, string> getKey, Func<string, uint> hash, int replicaCount)
         {
+            _getKey = getKey;
             _hash = hash;
+            _replicaCount = replicaCount;
 
-            _ring = nodes
-                .SelectMany(
-                    n =>
-                        Enumerable
-                            .Range(0, replicaCount)
-                            .Select(
-                                i => new
-                                {
-                                    hashKey = i + n,
-                                    node = n
-                                }
-                            )
-                )
-                .Select(a => Tuple.Create(_hash(a.hashKey), a.node))
-                .OrderBy(t => t.Item1)
-                .ToList();
+            _ring = ToHashTuples(nodes);
+            _hashes = _ring.Select(it => it.hash).ToArray();
         }
 
-        public string GetNode(string key) => (_ring.FirstOrDefault(t => t.Item1 > _hash(key)) ?? _ring.First()).Item2;
+        private HashRing(Func<T, string> getKey, Func<string, uint> hash, int replicaCount, (uint hash, T value)[] ring, uint[] hashes)
+        {
+            _getKey = getKey;
+            _hash = hash;
+            _replicaCount = replicaCount;
+            _ring = ring;
+            _hashes = hashes;
+        }
+
+        public T GetNode(string key)
+        {
+            if (_ring.Length == 0) return default!;
+            if (_replicaCount == _ring.Length) return _ring[0].value;
+
+            var hash = _hash(key);
+
+            var result = Array.BinarySearch(_hashes, hash);
+
+            if (result >= 0) return _ring[result].value;
+
+            // Get the next higher value by taking the complement of the result
+            var nextIndex = ~result;
+
+            // Return the next higher value if it exists, or the first one
+            return _ring[nextIndex % _ring.Length].value;
+        }
+
+        public void Add(params T[] added) => SetRing(Merge(ToHashTuples(added), _ring));
+
+        public void Remove(ISet<T> nodes) => SetRing(_ring.Where(it => !nodes.Contains(it.value)).ToArray());
+
+        public void Remove(T node) => SetRing(_ring.Where(it => !node!.Equals(it.value)).ToArray());
+
+        private void SetRing((uint hash, T value)[] ring)
+        {
+            _ring = ring;
+            _hashes = _ring.Select(it => it.hash).ToArray();
+        }
+
+        private static (uint hash, T value)[] Merge((uint hash, T value)[] left, (uint hash, T value)[] right)
+        {
+            var result = new (uint hash, T value)[left.Length + right.Length];
+            var i = 0;
+            var j = 0;
+            var k = 0;
+
+            while (i < result.Length && j < left.Length && k < right.Length)
+            {
+                result[i++] = left[j].hash < right[k].hash ? left[j++] : right[k++];
+            }
+
+            while (i < result.Length && k < right.Length)
+            {
+                result[i++] = right[k++];
+            }
+
+            while (i < result.Length && j < left.Length)
+            {
+                result[i++] = left[j++];
+            }
+
+            return result;
+        }
+
+        private (uint hash, T value)[] ToHashTuples(IEnumerable<T> nodes) => nodes
+            .SelectMany(
+                n =>
+                    Enumerable
+                        .Range(0, _replicaCount)
+                        .Select(
+                            i => new
+                            {
+                                hashKey = i + _getKey(n),
+                                node = n
+                            }
+                        )
+            )
+            .Select(a => (_hash(a.hashKey), a.node))
+            .OrderBy(t => t.Item1)
+            .ToArray();
+
+        public int Count => _ring.Length / _replicaCount;
+
+        public HashRing<T> Clone() => new(_getKey, _hash, _replicaCount, _ring, _hashes);
     }
 }

--- a/src/Proto.Actor/Router/Routers/ConsistentHashRouterState.cs
+++ b/src/Proto.Actor/Router/Routers/ConsistentHashRouterState.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Proto.Router.Routers
@@ -14,9 +15,8 @@ namespace Proto.Router.Routers
         private readonly Func<string, uint> _hash;
         private readonly Func<object, string>? _messageHasher;
         private readonly int _replicaCount;
-        private readonly Dictionary<string, PID> _routeeMap = new();
         private readonly ISenderContext _senderContext;
-        private HashRing? _hashRing;
+        private HashRing<PID>? _hashRing;
 
         public ConsistentHashRouterState(
             ISenderContext senderContext,
@@ -31,21 +31,10 @@ namespace Proto.Router.Routers
             _messageHasher = messageHasher;
         }
 
-        public override HashSet<PID> GetRoutees() => _routeeMap.Values.ToHashSet();
-
         public override void SetRoutees(PID[] routees)
         {
-            _routeeMap.Clear();
-            var nodes = new List<string>();
-
-            foreach (var pid in routees)
-            {
-                var nodeName = pid.ToString();
-                nodes.Add(nodeName);
-                _routeeMap[nodeName] = pid;
-            }
-
-            _hashRing = new HashRing(nodes, _hash, _replicaCount);
+            base.SetRoutees(routees);
+            _hashRing = new HashRing<PID>(routees, pid => pid.ToString(), _hash, _replicaCount);
         }
 
         public override void RouteMessage(object message)
@@ -57,8 +46,7 @@ namespace Proto.Router.Routers
             if (env.message is IHashable hashable)
             {
                 var key = hashable.HashBy();
-                var node = _hashRing.GetNode(key);
-                var routee = _routeeMap[node];
+                var routee = _hashRing.GetNode(key);
 
                 //by design, just forward message
                 _senderContext.Send(routee, message);
@@ -66,8 +54,7 @@ namespace Proto.Router.Routers
             else if (_messageHasher is not null)
             {
                 var key = _messageHasher(message);
-                var node = _hashRing.GetNode(key);
-                var routee = _routeeMap[node];
+                var routee = _hashRing.GetNode(key);
 
                 //by design, just forward message
                 _senderContext.Send(routee, message);

--- a/src/Proto.Cluster/ClusterContracts.proto
+++ b/src/Proto.Cluster/ClusterContracts.proto
@@ -19,6 +19,19 @@ message IdentityHandoverResponse {
   uint64 topology_hash = 4;
 }
 
+message IdentityHandover {
+  repeated Activation actors = 1;
+  uint32 chunk_id = 2;
+  bool final = 3;
+  uint64 topology_hash = 4;
+  uint32 skipped = 5;
+}
+
+message IdentityHandoverAck {
+  uint32 chunk_id = 1;
+  uint64 topology_hash = 2;
+}
+
 message ClusterIdentity{
   string identity = 1;
   string kind = 2;

--- a/src/Proto.Cluster/ClusterContracts.proto
+++ b/src/Proto.Cluster/ClusterContracts.proto
@@ -6,34 +6,45 @@ import "Proto.Actor/Protos.proto";
 //request response call from Identity actor sent to each member
 //asking what activations they hold that belong to the requester
 message IdentityHandoverRequest {
-    uint64 topology_hash = 1;
-    string address = 2;
-    repeated Member members = 3;
+  uint64 topology_hash = 1;
+  string address = 2;
+  repeated Member members = 3;
 }
 
 //response message to the above
 message IdentityHandoverResponse {
-    repeated Activation actors = 1;
+  repeated Activation actors = 1;
+  int32 chunk_id = 2;
+  bool final = 3;
+  uint64 topology_hash = 4;
 }
 
 message ClusterIdentity{
-    string identity = 1;
-    string kind = 2;
+  string identity = 1;
+  string kind = 2;
 }
 
 message Activation {
-    actor.PID pid = 1;
-    ClusterIdentity cluster_identity = 2;
+  actor.PID pid = 1;
+  ClusterIdentity cluster_identity = 2;
 }
 
+// Started terminating, not yet removed from IIdentityLookup
+message ActivationTerminating {
+  actor.PID pid = 1;
+  ClusterIdentity cluster_identity = 2;
+}
+
+// Terminated, removed from lookup
 message ActivationTerminated {
-    actor.PID pid = 1;
-    ClusterIdentity cluster_identity = 2;
+  actor.PID pid = 1;
+  ClusterIdentity cluster_identity = 2;
 }
 
 message ActivationRequest {
-    ClusterIdentity cluster_identity = 1;
-    string request_id = 2;
+  ClusterIdentity cluster_identity = 1;
+  string request_id = 2;
+  uint64 topology_hash = 3;
 }
 
 message ProxyActivationRequest {
@@ -42,23 +53,31 @@ message ProxyActivationRequest {
 }
 
 message ActivationResponse {
-    actor.PID pid = 1;
-    bool failed = 2;
+  actor.PID pid = 1;
+  bool failed = 2;
+  uint64 topology_hash = 3;
+}
+
+message ReadyForRebalance {
+  uint64 topology_hash = 1;
+}
+message RebalanceCompleted {
+  uint64 topology_hash = 1;
 }
 
 message Member {
-    string host = 1;
-    int32 port = 2;
-    string id = 3;
-    repeated string kinds = 4;
+  string host = 1;
+  int32 port = 2;
+  string id = 3;
+  repeated string kinds = 4;
 }
 
 message ClusterTopology {
-    uint64 topology_hash = 1;
-    repeated Member members = 2;
-    repeated Member joined = 3;
-    repeated Member left = 4;
-    repeated string blocked = 5;
+  uint64 topology_hash = 1;
+  repeated Member members = 2;
+  repeated Member joined = 3;
+  repeated Member left = 4;
+  repeated string blocked = 5;
 }
 
 message HeartbeatRequest {

--- a/src/Proto.Cluster/ClusterExtension.cs
+++ b/src/Proto.Cluster/ClusterExtension.cs
@@ -108,6 +108,11 @@ namespace Proto.Cluster
 
                 if (identity is not null)
                 {
+                    ctx.System.EventStream.Publish(new ActivationTerminating
+                    {
+                        Pid = ctx.Self,
+                        ClusterIdentity = identity,
+                    });
                     cluster.PidCache.RemoveByVal(identity, ctx.Self);
                 }
 

--- a/src/Proto.Cluster/ExperimentalClusterContext.cs
+++ b/src/Proto.Cluster/ExperimentalClusterContext.cs
@@ -177,17 +177,7 @@ namespace Proto.Cluster
         }
 
 
-        private PID? GetCachedPid(ClusterIdentity clusterIdentity)
-        {
-            var pid = clusterIdentity.CachedPid;
-
-            if (pid is null && _pidCache.TryGet(clusterIdentity, out pid))
-            {
-                clusterIdentity.CachedPid = pid;
-            }
-
-            return pid;
-        }
+        private PID? GetCachedPid(ClusterIdentity clusterIdentity) => _pidCache.TryGet(clusterIdentity, out var pid) ? pid : null;
 
         private async Task<PID?> GetPidFromLookup(ClusterIdentity clusterIdentity, ISenderContext context, CancellationToken ct)
         {

--- a/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
+++ b/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -27,6 +26,7 @@ namespace Proto.Cluster.Identity
         //kind -> the actor kind
         //eventId -> the cluster wide eventId when this actor was created
         private readonly Dictionary<ClusterIdentity, PID> _myActors = new();
+        private EventStreamSubscription<object>? _subscription;
 
         public IdentityStoragePlacementActor(Cluster cluster, IdentityStorageLookup identityLookup)
         {
@@ -36,44 +36,60 @@ namespace Proto.Cluster.Identity
 
         public Task ReceiveAsync(IContext context) => context.Message switch
         {
-            Stopping _            => Stopping(context),
-            Stopped _             => Stopped(context),
-            Terminated msg        => Terminated(context, msg),
-            ActivationRequest msg => ActivationRequest(context, msg),
-            _                     => Task.CompletedTask
+            Started                   => OnStarted(context),
+            Stopping _                => Stopping(),
+            Stopped _                 => Stopped(),
+            ActivationTerminating msg => Terminated(context, msg),
+            ActivationRequest msg     => ActivationRequest(context, msg),
+            _                         => Task.CompletedTask
         };
 
-        private Task Stopping(IContext context)
+        private Task OnStarted(IContext context)
         {
-            Logger.LogInformation("Stopping placement actor");
+            _subscription = context.System.EventStream.Subscribe<ActivationTerminating>(e => context.Send(context.Self, e));
             return Task.CompletedTask;
         }
 
-        private Task Stopped(IContext context)
+        private Task Stopping()
+        {
+            Logger.LogInformation("Stopping placement actor");
+            _subscription?.Unsubscribe();
+            return Task.CompletedTask;
+        }
+
+        private Task Stopped()
         {
             Logger.LogInformation("Stopped placement actor");
             return Task.CompletedTask;
         }
 
-        private async Task Terminated(IContext context, Terminated msg)
+        private async Task Terminated(IContext context, ActivationTerminating msg)
         {
             if (context.System.Shutdown.IsCancellationRequested) return;
-
-            var (identity, pid) = _myActors.FirstOrDefault(kvp => kvp.Value.Equals(msg.Who));
-
-            if (identity != null && pid != null)
+            
+            if (!_myActors.TryGetValue(msg.ClusterIdentity, out var pid))
             {
-                _myActors.Remove(identity);
-                _cluster.PidCache.RemoveByVal(identity, pid);
+                Logger.LogWarning("Activation not found: {ActivationTerminating}", msg);
+                return;
+            }
 
-                try
-                {
-                    await _identityLookup.RemovePidAsync(identity, msg.Who, CancellationToken.None);
-                }
-                catch (Exception e)
-                {
-                    Logger.LogError(e, "Failed to remove {Activation} from storage", pid);
-                }
+            if (!pid.Equals(msg.Pid))
+            {
+                Logger.LogWarning("Activation did not match pid: {ActivationTerminating}, {Pid}", msg, pid);
+                return;
+            }
+
+
+            _myActors.Remove(msg.ClusterIdentity);
+            _cluster.PidCache.RemoveByVal(msg.ClusterIdentity, pid);
+
+            try
+            {
+                await _identityLookup.RemovePidAsync(msg.ClusterIdentity, pid, CancellationToken.None);
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, "Failed to remove {Activation} from storage", pid);
             }
         }
 

--- a/src/Proto.Cluster/Member/LocalAffinityStrategy.cs
+++ b/src/Proto.Cluster/Member/LocalAffinityStrategy.cs
@@ -16,7 +16,6 @@ namespace Proto.Cluster
     class LocalAffinityStrategy : IMemberStrategy
     {
         private readonly Cluster _cluster;
-        private readonly Rendezvous _rdv;
         private readonly RoundRobinMemberSelector _rr;
         private Member? _me;
         private ImmutableList<Member> _members = ImmutableList<Member>.Empty;
@@ -24,7 +23,6 @@ namespace Proto.Cluster
         public LocalAffinityStrategy(Cluster cluster)
         {
             _cluster = cluster;
-            _rdv = new Rendezvous();
             _rr = new RoundRobinMemberSelector(this);
         }
 
@@ -37,13 +35,11 @@ namespace Proto.Cluster
 
             if (member.Address.Equals(_cluster.System.Address, StringComparison.InvariantCulture)) _me = member;
             _members = _members.Add(member);
-            _rdv.UpdateMembers(_members);
         }
 
         public void RemoveMember(Member member)
         {
             _members = _members.RemoveAll(x => x.Address == member.Address);
-            _rdv.UpdateMembers(_members);
         }
 
         public Member? GetActivator(string senderAddress)

--- a/src/Proto.Cluster/Member/MemberStrategy.cs
+++ b/src/Proto.Cluster/Member/MemberStrategy.cs
@@ -22,15 +22,10 @@ namespace Proto.Cluster
 
     class SimpleMemberStrategy : IMemberStrategy
     {
-        private readonly Rendezvous _rdv;
-        private readonly RoundRobinMemberSelector _rr;
+        private readonly RoundRobinMemberSelector _selector;
         private ImmutableList<Member> _members = ImmutableList<Member>.Empty;
 
-        public SimpleMemberStrategy()
-        {
-            _rdv = new Rendezvous();
-            _rr = new RoundRobinMemberSelector(this);
-        }
+        public SimpleMemberStrategy() => _selector = new RoundRobinMemberSelector(this);
 
         public ImmutableList<Member> GetAllMembers() => _members;
 
@@ -41,16 +36,11 @@ namespace Proto.Cluster
             if (_members.Any(x => x.Address == member.Address)) return;
 
             _members = _members.Add(member);
-            _rdv.UpdateMembers(_members);
         }
 
         //TODO: account for Member.MemberId
-        public void RemoveMember(Member member)
-        {
-            _members = _members.RemoveAll(x => x.Address == member.Address);
-            _rdv.UpdateMembers(_members);
-        }
+        public void RemoveMember(Member member) => _members = _members.RemoveAll(x => x.Address == member.Address);
 
-        public Member? GetActivator(string senderAddress) => _rr.GetMember();
+        public Member? GetActivator(string senderAddress) => _selector.GetMember();
     }
 }

--- a/src/Proto.Cluster/Messages/Messages.cs
+++ b/src/Proto.Cluster/Messages/Messages.cs
@@ -4,11 +4,12 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-// ReSharper disable once CheckNamespace
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Google.Protobuf;
 
+// ReSharper disable once CheckNamespace
 namespace Proto.Cluster
 {
     public sealed partial class ClusterIdentity : ICustomDiagnosticMessage
@@ -48,6 +49,11 @@ namespace Proto.Cluster
     {
         //this ignores joined and left members, only the actual members are relevant
         public uint GetMembershipHashCode() => Member.TopologyHash(Members);
+        
+        /// <summary>
+        /// Topology based logic (IE partition based) can use this token to cancel any work when this topology is no longer valid
+        /// </summary>
+        public CancellationToken? TopologyValidityToken { get; init; }
     }
 
     public partial class Member
@@ -55,7 +61,7 @@ namespace Proto.Cluster
         public static uint TopologyHash(IEnumerable<Member> members)
         {
             var x = members.Select(m => m.Id).OrderBy(i => i).ToArray();
-            var key = string.Join("", x);
+            var key = string.Concat(x);
             var hash = MurmurHash2.Hash(key);
             return hash;
         }

--- a/src/Proto.Cluster/Partition/Extensions.cs
+++ b/src/Proto.Cluster/Partition/Extensions.cs
@@ -1,0 +1,57 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Extensions.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Proto.Cluster.Gossip;
+
+namespace Proto.Cluster.Partition
+{
+    internal static class Extensions
+    {
+        private const string ReadyForRebalanceKey = "reb:ready";
+        private const string RebalanceCompletedKey = "reb:done";
+
+        private static readonly Gossiper.ConsensusCheckBuilder<ulong> TopologyConsensus = Gossiper.ConsensusCheckBuilder<ulong>
+            .Create<ClusterTopology>("topology", topology => topology.TopologyHash);
+
+        private static readonly Gossiper.ConsensusCheckBuilder<ulong> ReadyForRebalance = TopologyConsensus
+            .InConsensusWith<ReadyForRebalance>(ReadyForRebalanceKey, rebalance => rebalance.TopologyHash);
+
+        private static readonly Gossiper.ConsensusCheckBuilder<ulong> RebalanceCompleted = TopologyConsensus
+            .InConsensusWith<RebalanceCompleted>(RebalanceCompletedKey, rebalance => rebalance.TopologyHash);
+
+        public static async Task<(bool consensus, T value)> WaitFor<T>(
+            this Gossiper gossip,
+            Gossiper.ConsensusCheckBuilder<T> check,
+            TimeSpan maxWait,
+            CancellationToken cancellationToken
+        )
+        {
+            using var consensusCheck = gossip.RegisterConsensusCheck(check);
+
+            return await consensusCheck.TryGetConsensus(maxWait, cancellationToken).ConfigureAwait(false);
+        }
+
+        public static Task<(bool consensus, ulong topologyHash)> WaitUntilInFlightActivationsAreCompleted(
+            this Gossiper gossip,
+            TimeSpan maxWait,
+            CancellationToken cancellationToken
+        ) => WaitFor(gossip, ReadyForRebalance, maxWait, cancellationToken);
+
+        public static Task<(bool consensus, ulong topologyHash)> WaitUntilAllMembersCompletedRebalance(
+            this Gossiper gossip,
+            TimeSpan maxWait,
+            CancellationToken cancellationToken
+        ) => WaitFor(gossip, RebalanceCompleted, maxWait, cancellationToken);
+
+        public static void SetInFlightActivationsCompleted(this Gossiper gossip, ulong topologyHash)
+            => gossip.SetState(ReadyForRebalanceKey, new ReadyForRebalance {TopologyHash = topologyHash});
+
+        public static void SetRebalanceCompleted(this Gossiper gossip, ulong topologyHash)
+            => gossip.SetState(RebalanceCompletedKey, new RebalanceCompleted {TopologyHash = topologyHash});
+    }
+}

--- a/src/Proto.Cluster/Partition/HandoverState.cs
+++ b/src/Proto.Cluster/Partition/HandoverState.cs
@@ -1,0 +1,71 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="PartitionIdentityHandover.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2022 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Collections.Generic;
+
+namespace Proto.Cluster.Partition
+{
+    internal class HandoverState
+    {
+        public ulong TopologyHash { get; }
+        private readonly Dictionary<string, MemberState> _incompleteHandovers = new();
+
+        public HandoverState(ClusterTopology topology)
+        {
+            TopologyHash = topology.TopologyHash;
+
+            foreach (var member in topology.Members)
+            {
+                _incompleteHandovers.Add(member.Address, new MemberState());
+            }
+        }
+
+        public bool IsFinalHandoverMessage(PID sender, IdentityHandover message)
+        {
+            if (message.TopologyHash != TopologyHash)
+            {
+                // This does not belong to the current topology
+                return false;
+            }
+
+            if (_incompleteHandovers.TryGetValue(sender.Address, out var incompleteMember))
+            {
+                if (incompleteMember.HasAllChunks(message.ChunkId, message.Final))
+                {
+                    _incompleteHandovers.Remove(sender.Address);
+                }
+            }
+
+            return _incompleteHandovers.Count == 0;
+        }
+
+        private class MemberState
+        {
+            private uint? _finalChunk;
+            private HashSet<uint>? _receivedChunks;
+
+            public bool HasAllChunks(uint chunkId, bool isFinalChunk)
+            {
+                if (isFinalChunk)
+                {
+                    if (chunkId == 1) return true;
+
+                    _finalChunk = chunkId;
+                }
+
+                if (_receivedChunks is null)
+                {
+                    _receivedChunks = new HashSet<uint> {chunkId};
+                }
+                else
+                {
+                    _receivedChunks.Add(chunkId);
+                }
+
+                return _finalChunk?.Equals((uint) _receivedChunks.Count) == true;
+            }
+        }
+    }
+}

--- a/src/Proto.Cluster/Partition/MemberHashRing.cs
+++ b/src/Proto.Cluster/Partition/MemberHashRing.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="MemberRing.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Collections.Generic;
+using Proto.Router;
+
+namespace Proto.Cluster.Partition
+{
+    public class MemberHashRing : HashRing<Member>
+
+    {
+        public MemberHashRing(IReadOnlyCollection<Member> nodes) : base(nodes, member => member.Address, MurmurHash2.Hash, 50)
+        {
+        }
+
+        public string GetOwnerMemberByIdentity(ClusterIdentity clusterIdentity) => GetNode(clusterIdentity.Identity)?.Address ?? "";
+
+        public string GetOwnerMemberByIdentity(string identity) => GetNode(identity)?.Address ?? "";
+    }
+}

--- a/src/Proto.Cluster/Partition/PartitionConfig.cs
+++ b/src/Proto.Cluster/Partition/PartitionConfig.cs
@@ -3,7 +3,9 @@
 //      Copyright (C) 2015-2021 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
+using System;
+
 namespace Proto.Cluster.Partition
 {
-    public record PartitionConfig(bool DeveloperLogging);
+    public record PartitionConfig(bool DeveloperLogging, int HandoverChunkSize, TimeSpan RebalanceRequestTimeout);
 }

--- a/src/Proto.Cluster/Partition/PartitionConfig.cs
+++ b/src/Proto.Cluster/Partition/PartitionConfig.cs
@@ -1,11 +1,17 @@
 // -----------------------------------------------------------------------
 // <copyright file="PartitionConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2022 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 using System;
 
 namespace Proto.Cluster.Partition
 {
-    public record PartitionConfig(bool DeveloperLogging, int HandoverChunkSize, TimeSpan RebalanceRequestTimeout);
+    public record PartitionConfig(
+        bool DeveloperLogging,
+        int HandoverChunkSize,
+        TimeSpan RebalanceRequestTimeout,
+        PartitionIdentityLookup.Mode Mode = PartitionIdentityLookup.Mode.Pull,
+        PartitionIdentityLookup.Send Send = PartitionIdentityLookup.Send.Delta
+    );
 }

--- a/src/Proto.Cluster/Partition/PartitionIdentityLookup.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityLookup.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="PartitionIdentityLookup.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2020 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2022 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 using System;
@@ -35,7 +35,7 @@ namespace Proto.Cluster.Partition
         {
             using var cts = new CancellationTokenSource(_getPidTimeout);
             //Get address to node owning this ID
-            var (identityOwner,topologyHash) = _partitionManager.Selector.GetIdentityOwner(clusterIdentity.Identity);
+            var (identityOwner, topologyHash) = _partitionManager.Selector.GetIdentityOwner(clusterIdentity.Identity);
             Logger.LogDebug("Identity belongs to {Address}", identityOwner);
             if (string.IsNullOrEmpty(identityOwner)) return null;
 
@@ -74,7 +74,7 @@ namespace Proto.Cluster.Partition
             {
                 try
                 {
-                    var resp = await _cluster.System.Root.RequestAsync<Touched>(remotePid, new Touch(), CancellationTokens.FromSeconds(2));
+                    var resp = await _cluster.System.Root.RequestAsync<Touched?>(remotePid, new Touch(), CancellationTokens.FromSeconds(2));
 
                     if (resp == null)
                     {
@@ -123,6 +123,32 @@ namespace Proto.Cluster.Partition
         {
             _partitionManager.Shutdown();
             return Task.CompletedTask;
+        }
+
+        public enum Mode
+        {
+            /// <summary>
+            /// Each member queries every member to get the currently owned identities
+            /// </summary>
+            Pull,
+
+            /// <summary>
+            /// Each activation owner publishes activations to the current identity owner
+            /// </summary>
+            Push
+        }
+
+        public enum Send
+        {
+            /// <summary>
+            /// Only identities which have changed owner since the last completed topology rebalance are sent
+            /// </summary>
+            Delta,
+
+            /// <summary>
+            /// All activations are sent on every topology rebalance
+            /// </summary>
+            Everything
         }
     }
 }

--- a/src/Proto.Cluster/Partition/PartitionIdentityRebalanceWorker.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityRebalanceWorker.cs
@@ -1,0 +1,223 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="TopologyRelocationActor.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Proto.Cluster.Partition
+{
+    /// <summary>
+    /// Used by partitionIdentityActor to update partition lookup on topology changes.
+    /// Delegates each member to a separate worker actor which handles chunked transfers and can be retried on a member basis.
+    /// </summary>
+    class PartitionIdentityRebalanceWorker : IActor, IDisposable
+    {
+        private readonly TimeSpan _handoverTimeout;
+        private readonly CancellationToken _cancellationToken;
+        private static readonly ILogger Logger = Log.CreateLogger<PartitionIdentityActor>();
+
+        private readonly Dictionary<ClusterIdentity, PID> _partitionLookup;
+        private readonly TaskCompletionSource<bool> _onRelocationComplete;
+        private readonly Dictionary<string, PID> _waitingRequests = new();
+        private readonly Stopwatch _timer = new();
+        private IdentityHandoverRequest? _request;
+        private CancellationTokenRegistration? _tokenRegistration;
+
+        public PartitionIdentityRebalanceWorker(TimeSpan handoverTimeout, CancellationToken cancellationToken)
+        {
+            _handoverTimeout = handoverTimeout;
+            _cancellationToken = cancellationToken;
+            _partitionLookup = new Dictionary<ClusterIdentity, PID>();
+            _onRelocationComplete = new TaskCompletionSource<bool>();
+        }
+
+        public Task ReceiveAsync(IContext context) => context.Message switch
+        {
+            IdentityHandoverRequest request             => OnIdentityHandoverRequest(request, context),
+            PartitionWorker.PartitionCompleted response => OnPartitionCompleted(response, context),
+            PartitionWorker.PartitionFailed response    => OnPartitionFailed(response, context),
+            _                                           => Task.CompletedTask
+        };
+
+        private Task OnIdentityHandoverRequest(IdentityHandoverRequest request, IContext context)
+        {
+            _tokenRegistration = _cancellationToken.Register(() => context.Self.Stop(context.System)
+            );
+            _timer.Start();
+            _request = request;
+
+            foreach (var member in request.Members)
+            {
+                var memberAddress = member.Address;
+                StartRebalanceFromMember(request, context, memberAddress);
+            }
+
+            context.ReenterAfter(_onRelocationComplete.Task, () => {
+                    context.Respond(new PartitionsRebalanced(_partitionLookup, _request.TopologyHash));
+                    context.Self.Stop(context.System);
+                }
+            );
+            return Task.CompletedTask;
+        }
+
+        private Task OnPartitionCompleted(PartitionWorker.PartitionCompleted response, IContext context)
+        {
+            foreach (var activation in response.Activations)
+            {
+                TakeOwnership(activation, context);
+            }
+
+            _waitingRequests.Remove(response.MemberAddress);
+
+            if (_waitingRequests.Count == 0)
+            {
+                _timer.Stop();
+                Logger.LogDebug("IdentityRelocation completed, received {Count} actors in {Elapsed}", _partitionLookup.Count, _timer.Elapsed);
+                _onRelocationComplete.TrySetResult(true);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private Task OnPartitionFailed(PartitionWorker.PartitionFailed response, IContext context)
+        {
+            Logger.LogWarning("Retrying member {Member}, failed with {Reason}", response.MemberAddress, response.Reason);
+            StartRebalanceFromMember(_request!, context, response.MemberAddress);
+            return Task.CompletedTask;
+        }
+
+        private void TakeOwnership(Activation msg, IContext context)
+        {
+            if (_partitionLookup.TryGetValue(msg.ClusterIdentity, out var existing))
+            {
+                if (existing.Address == msg.Pid.Address && existing.Id == msg.Pid.Id) return; // Identical activation, no-op
+
+                // If they are not equal, we might have multiple activations, ie invalid state
+                Logger.LogWarning("Duplicate activation: {ClusterIdentity}, {Pid1}, {Pid2}", msg.ClusterIdentity, existing, msg.Pid);
+                context.Poison(existing);
+            }
+
+            // Logger.LogDebug("Taking Ownership of: {Identity}, pid: {Pid}", msg.Identity, msg.Pid);
+            _partitionLookup[msg.ClusterIdentity] = msg.Pid;
+        }
+
+        private void StartRebalanceFromMember(IdentityHandoverRequest request, IContext context, string memberAddress)
+        {
+            var childPid = context.Spawn(Props.FromProducer(() => new PartitionWorker(memberAddress, _handoverTimeout)));
+            context.Request(childPid, request);
+            _waitingRequests[memberAddress] = childPid;
+        }
+
+        /// <summary>
+        /// Handles a single member rebalance.
+        /// Split out to make sure a failure against a single member can be retried without affecting the rest.
+        /// </summary>
+        private class PartitionWorker : IActor
+        {
+            private readonly PID _targetMember;
+            private readonly BitArray _receivedChunks = new(64);
+            private readonly List<Activation> _receivedActivations = new();
+            private readonly string _memberAddress;
+            private readonly TimeSpan _timeout;
+            private readonly TaskCompletionSource<object> _completionSource = new();
+            private int _receivedCount;
+            private int? _finalChunk;
+
+            public PartitionWorker(string memberAddress, TimeSpan timeout)
+            {
+                _memberAddress = memberAddress;
+                _timeout = timeout;
+                _targetMember = PartitionManager.RemotePartitionPlacementActor(_memberAddress);
+            }
+
+            public Task ReceiveAsync(IContext context)
+            {
+                switch (context.Message)
+                {
+                    case IdentityHandoverRequest msg:
+                        OnIdentityHandoverRequest(msg, context);
+                        break;
+                    case IdentityHandoverResponse msg:
+                        OnIdentityHandoverResponse(msg, context);
+                        break;
+                    case ReceiveTimeout:
+                        FailPartition("Timeout");
+                        break;
+                    case DeadLetterResponse:
+                        FailPartition("DeadLetter");
+                        break;
+                }
+
+                return Task.CompletedTask;
+            }
+
+            private void OnIdentityHandoverRequest(IdentityHandoverRequest msg, IContext context)
+            {
+                context.Request(_targetMember, msg);
+                context.SetReceiveTimeout(_timeout);
+                context.ReenterAfter(_completionSource.Task, () => {
+                        context.Send(context.Parent!, _completionSource.Task.Result);
+                        context.Stop(context.Self);
+                    }
+                );
+            }
+
+            private void OnIdentityHandoverResponse(IdentityHandoverResponse response, IContext context)
+            {
+                var sender = context.Sender;
+
+                if (sender is null)
+                {
+                    // Invalid response, requires sender to be populated
+                    Logger.LogError("Invalid IdentityHandoverResponse chunk {ChunkId} count {Count}, final {Final}, topology {TopologyHash} received, missing sender", response.ChunkId, response.Actors.Count, response.Final, response.TopologyHash);
+                    // FailPartition("MissingSender");
+                }
+
+                _receivedActivations.AddRange(response.Actors);
+
+                if (HasReceivedAllChunks(response))
+                {
+                    _completionSource.SetResult(new PartitionCompleted(_memberAddress, _receivedActivations));
+                }
+            }
+
+            private void FailPartition(string reason) => _completionSource.TrySetResult(new PartitionFailed(_memberAddress, reason));
+
+            private bool HasReceivedAllChunks(IdentityHandoverResponse response)
+            {
+                while (_receivedChunks.Length <= response.ChunkId)
+                {
+                    _receivedChunks.Length *= 2;
+                }
+                if (_receivedChunks.Get(response.ChunkId))
+                {
+                    Logger.LogWarning("Chunk {ChunkId} already received", response.ChunkId);
+                    return false;
+                }
+
+                _receivedChunks.Set(response.ChunkId, true);
+                _receivedCount++;
+
+                if (response.Final)
+                {
+                    _finalChunk = response.ChunkId;
+                }
+
+                return _finalChunk.HasValue && _receivedCount == _finalChunk;
+            }
+
+            public record PartitionCompleted(string MemberAddress, List<Activation> Activations);
+
+            public record PartitionFailed(string MemberAddress, string Reason);
+        }
+
+        public void Dispose() => _tokenRegistration?.Dispose();
+    }
+}

--- a/src/Proto.Cluster/Partition/PartitionMemberSelector.cs
+++ b/src/Proto.Cluster/Partition/PartitionMemberSelector.cs
@@ -3,6 +3,9 @@
 //      Copyright (C) 2015-2020 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
+using System;
+using System.Collections.Immutable;
+
 namespace Proto.Cluster.Partition
 {
     //this class is responsible for translating between Identity->member
@@ -10,21 +13,21 @@ namespace Proto.Cluster.Partition
     class PartitionMemberSelector
     {
         private readonly object _lock = new();
-        private readonly Rendezvous _rdv = new();
+        private MemberHashRing _rdv = new(ImmutableList<Member>.Empty);
+        private ulong _topologyHash;
 
-        public void Update(Member[] members)
+        public void Update(Member[] members, ulong topologyHash)
         {
-            lock (_lock) _rdv.UpdateMembers(members);
+            lock (_lock)
+            {
+                _rdv = new MemberHashRing(members);
+                _topologyHash = topologyHash;
+            }
         }
 
-        public string GetIdentityOwner(string key)
+        public (string owner, ulong topologyHash) GetIdentityOwner(string key)
         {
-            lock (_lock) return _rdv.GetOwnerMemberByIdentity(key);
-        }
-
-        public void DumpState()
-        {
-            lock (_lock) _rdv.Debug();
+            lock (_lock) return (_rdv.GetOwnerMemberByIdentity(key), _topologyHash);
         }
     }
 }

--- a/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
@@ -5,13 +5,13 @@
 // -----------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace Proto.Cluster.Partition
 {
-    class PartitionPlacementActor : IActor
+    class PartitionPlacementActor : IActor, IDisposable
     {
         private readonly Cluster _cluster;
         private static readonly ILogger Logger = Log.CreateLogger<PartitionPlacementActor>();
@@ -20,6 +20,7 @@ namespace Proto.Cluster.Partition
         //kind -> the actor kind
         private readonly Dictionary<ClusterIdentity, PID> _myActors = new();
         private readonly PartitionConfig _config;
+        private EventStreamSubscription<object>? _subscription;
 
         public PartitionPlacementActor(Cluster cluster, PartitionConfig config)
         {
@@ -30,21 +31,39 @@ namespace Proto.Cluster.Partition
         public Task ReceiveAsync(IContext context) =>
             context.Message switch
             {
-                Terminated msg              => Terminated(context, msg),
+                Started                     => OnStarted(context),
+                ActivationTerminating msg   => ActivationTerminating(msg),
                 IdentityHandoverRequest msg => IdentityHandoverRequest(context, msg),
                 ActivationRequest msg       => ActivationRequest(context, msg),
                 _                           => Task.CompletedTask
             };
 
-        private Task Terminated(IContext context, Terminated msg)
+        private Task OnStarted(IContext context)
         {
-            //TODO: if this turns out to be perf intensive, lets look at optimizations for reverse lookups
-            var (clusterIdentity, pid) = _myActors.FirstOrDefault(kvp => kvp.Value.Equals(msg.Who));
+            _subscription = context.System.EventStream.Subscribe<ActivationTerminating>(e => context.Send(context.Self, e));
+            return Task.CompletedTask;
+        }
+
+        private Task ActivationTerminating(ActivationTerminating msg)
+        {
+            if (!_myActors.TryGetValue(msg.ClusterIdentity, out var pid))
+            {
+                Logger.LogWarning("Activation not found: {ActivationTerminating}", msg);
+                return Task.CompletedTask;
+            }
+
+            if (!pid.Equals(msg.Pid))
+            {
+                Logger.LogWarning("Activation did not match pid: {ActivationTerminating}, {Pid}", msg, pid);
+                return Task.CompletedTask;
+            }
+
+            _myActors.Remove(msg.ClusterIdentity);
 
             var activationTerminated = new ActivationTerminated
             {
                 Pid = pid,
-                ClusterIdentity = clusterIdentity,
+                ClusterIdentity = msg.ClusterIdentity,
             };
 
             _cluster.MemberList.BroadcastEvent(activationTerminated);
@@ -53,7 +72,6 @@ namespace Proto.Cluster.Partition
             // var ownerPid = PartitionManager.RemotePartitionIdentityActor(ownerAddress);
             //
             // context.Send(ownerPid, activationTerminated);
-            _myActors.Remove(clusterIdentity);
             return Task.CompletedTask;
         }
 
@@ -63,36 +81,97 @@ namespace Proto.Cluster.Partition
         private Task IdentityHandoverRequest(IContext context, IdentityHandoverRequest msg)
         {
             var count = 0;
-            var response = new IdentityHandoverResponse();
             var requestAddress = context.Sender!.Address;
 
             //use a local selector, which is based on the requesters view of the world
-            var rdv = new Rendezvous();
-            rdv.UpdateMembers(msg.Members);
+            var memberHashRing = new MemberHashRing(msg.Members);
 
-            foreach (var (clusterIdentity, pid) in _myActors)
+            var chunk = 0;
+            var response = new IdentityHandoverResponse
             {
-                //who owns this identity according to the requesters memberlist?
-                var ownerAddress = rdv.GetOwnerMemberByIdentity(clusterIdentity.Identity);
+                ChunkId = ++chunk,
+                TopologyHash = msg.TopologyHash
+            };
+            var chunkSize = _config.HandoverChunkSize;
+            using var cancelRebalance = new CancellationTokenSource();
+            var outOfBandResponseHandler = context.System.Root.Spawn(AbortOnDeadLetter(cancelRebalance));
 
-                //this identity is not owned by the requester
-                if (ownerAddress != requestAddress) continue;
+            try
+            {
+                foreach (var (clusterIdentity, pid) in _myActors)
+                {
+                    //who owns this identity according to the requesters memberlist?
+                    var ownerAddress = memberHashRing.GetOwnerMemberByIdentity(clusterIdentity);
 
-                Logger.LogDebug("Transfer {Identity} to {newOwnerAddress} -- {TopologyHash}", clusterIdentity, ownerAddress,
-                    msg.TopologyHash
+                    //this identity is not owned by the requester
+                    if (ownerAddress != requestAddress) continue;
+
+                    Logger.LogDebug("Transfer {Identity} to {NewOwnerAddress} -- {TopologyHash}", clusterIdentity, ownerAddress,
+                        msg.TopologyHash
+                    );
+
+                    var actor = new Activation {ClusterIdentity = clusterIdentity, Pid = pid};
+                    response.Actors.Add(actor);
+                    count++;
+
+                    if (count % chunkSize == 0)
+                    {
+                        if (cancelRebalance.IsCancellationRequested)
+                        {
+                            return Task.CompletedTask;
+                        }
+
+                        context.Request(context.Sender, response, outOfBandResponseHandler);
+                        response = new IdentityHandoverResponse
+                        {
+                            ChunkId = ++chunk,
+                            TopologyHash = msg.TopologyHash
+                        };
+                    }
+                }
+
+                if (cancelRebalance.IsCancellationRequested)
+                {
+                    return Task.CompletedTask;
+                }
+
+                response.Final = true;
+                Logger.LogDebug("{Id}, Sending final response with {Count} activations, total {Total}, chunk {ChunkId}, {Pid}, Topology {TopologyHash}", context.System.Id, response.Actors.Count, count, chunk,
+                    outOfBandResponseHandler, msg.TopologyHash
                 );
 
-                var actor = new Activation {ClusterIdentity = clusterIdentity, Pid = pid};
-                response.Actors.Add(actor);
-                count++;
+                context.Request(context.Sender, response);
+
+                Logger.LogDebug("Transferred {Count} actor ownership to other members", count);
+            }
+            finally
+            {
+                if (cancelRebalance.IsCancellationRequested)
+                {
+                    if (_config.DeveloperLogging)
+                    {
+                        Console.WriteLine($"Cancelled rebalance handover for topology: {msg.TopologyHash}");
+                    }
+
+                    Logger.LogInformation("Cancelled rebalance: {@IdentityHandoverRequest}", msg);
+                }
+
+                context.Stop(outOfBandResponseHandler);
             }
 
-            //always respond, this is request response msg
-            context.Respond(response);
-
-            Logger.LogDebug("Transferred {Count} actor ownership to other members", count);
             return Task.CompletedTask;
         }
+
+        private Props AbortOnDeadLetter(CancellationTokenSource cts) => Props.FromFunc(responseContext => {
+                // Node lost or rebalance cancelled because of topology changes
+                if (responseContext.Message is DeadLetterResponse)
+                {
+                    cts.Cancel();
+                }
+
+                return Task.CompletedTask;
+            }
+        );
 
         private Task ActivationRequest(IContext context, ActivationRequest msg)
         {
@@ -105,7 +184,8 @@ namespace Proto.Cluster.Partition
                     //this identity already exists
                     var response = new ActivationResponse
                     {
-                        Pid = existing
+                        Pid = existing,
+                        TopologyHash = msg.TopologyHash
                     };
                     context.Respond(response);
                 }
@@ -128,14 +208,15 @@ namespace Proto.Cluster.Partition
 
                     var response = new ActivationResponse
                     {
-                        Pid = pid
+                        Pid = pid,
+                        TopologyHash = msg.TopologyHash
                     };
                     context.Respond(response);
                     if (_config.DeveloperLogging)
                         Console.WriteLine($"Activated {msg.RequestId}");
                 }
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 Logger.LogError(e, "Failed to spawn {Kind}/{Identity}", msg.Kind, msg.Identity);
                 var response = new ActivationResponse
@@ -147,5 +228,7 @@ namespace Proto.Cluster.Partition
 
             return Task.CompletedTask;
         }
+
+        public void Dispose() => _subscription?.Unsubscribe();
     }
 }

--- a/src/Proto.Cluster/Proto.Cluster.csproj
+++ b/src/Proto.Cluster/Proto.Cluster.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>net5.0;net6.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Grpc.Tools" Version="2.40.0" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.42.0" PrivateAssets="All" />
     <PackageReference Include="Roslynator.Analyzers" Version="3.2.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Proto.OpenTelemetry/OpenTelemetryDecorators.cs
+++ b/src/Proto.OpenTelemetry/OpenTelemetryDecorators.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenTelemetry.Trace;
+using Proto.Mailbox;
 
 namespace Proto.OpenTelemetry
 {
@@ -67,6 +68,9 @@ namespace Proto.OpenTelemetry
             => OpenTelemetryMethodsDecorators.RequestAsync(target, message, _sendActivitySetup,
                 () => base.RequestAsync<T>(target, message, cancellationToken)
             );
+
+        public override void Request(PID target, object message, PID? sender)
+            => OpenTelemetryMethodsDecorators.Request(target, message, sender, _sendActivitySetup, () => base.Request(target, message, sender));
 
         public override void Forward(PID target)
             => OpenTelemetryMethodsDecorators.Forward(target, base.Message!, _sendActivitySetup, () => base.Forward(target));
@@ -182,6 +186,12 @@ namespace Proto.OpenTelemetry
         internal static async Task Receive(MessageEnvelope envelope, ActivitySetup receiveActivitySetup, Func<Task> receive)
         {
             var message = envelope.Message;
+            
+            if (message is SystemMessage)
+            {
+                await receive().ConfigureAwait(false);
+                return;
+            }
 
             var propagationContext = envelope.Header.ExtractPropagationContext();
 

--- a/src/Proto.Persistence.Marten/MartenProvider.cs
+++ b/src/Proto.Persistence.Marten/MartenProvider.cs
@@ -13,7 +13,7 @@ namespace Proto.Persistence.Marten
 
         public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
         {
-            using var session = _store.OpenSession();
+            await using var session = _store.OpenSession();
 
             var events = await session.Query<Event>()
                 .Where(x => x.ActorName == actorName)
@@ -31,7 +31,7 @@ namespace Proto.Persistence.Marten
 
         public async Task<(object Snapshot, long Index)> GetSnapshotAsync(string actorName)
         {
-            using var session = _store.OpenSession();
+            await using var session = _store.OpenSession();
 
             var snapshot = await session.Query<Snapshot>()
                 .Where(x => x.ActorName == actorName)

--- a/src/Proto.Remote.GrpcNet/Proto.Remote.GrpcNet.csproj
+++ b/src/Proto.Remote.GrpcNet/Proto.Remote.GrpcNet.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.39.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.40.0" />
     <PackageReference Include="Roslynator.Analyzers" Version="3.2.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Proto.Remote/Endpoints/ServerConnector.cs
+++ b/src/Proto.Remote/Endpoints/ServerConnector.cs
@@ -29,7 +29,7 @@ namespace Proto.Remote
         private readonly RemoteConfigBase _remoteConfig;
         private readonly RemoteMessageHandler _remoteMessageHandler;
         private readonly string _address;
-        private readonly Type _connectortype;
+        private readonly Type _connectorType;
         private readonly IEndpoint _endpoint;
         private readonly TimeSpan _backoff;
         private readonly int _maxNrOfRetries;
@@ -44,14 +44,14 @@ namespace Proto.Remote
             _cts.Cancel();
             await _runner.ConfigureAwait(false);
         }
-        public ServerConnector(string address, Type connectortype, IEndpoint endpoint, IChannelProvider channelProvider, ActorSystem system, RemoteConfigBase remoteConfig, RemoteMessageHandler remoteMessageHandler)
+        public ServerConnector(string address, Type connectorType, IEndpoint endpoint, IChannelProvider channelProvider, ActorSystem system, RemoteConfigBase remoteConfig, RemoteMessageHandler remoteMessageHandler)
         {
             _channelProvider = channelProvider;
             _system = system;
             _remoteConfig = remoteConfig;
             _remoteMessageHandler = remoteMessageHandler;
             _address = address;
-            _connectortype = connectortype;
+            _connectorType = connectorType;
             _endpoint = endpoint;
             _maxNrOfRetries = remoteConfig.EndpointWriterOptions.MaxRetries;
             _withinTimeSpan = remoteConfig.EndpointWriterOptions.RetryTimeSpan;
@@ -73,7 +73,7 @@ namespace Proto.Remote
                     var client = new Remoting.RemotingClient(channel);
                     using var call = client.Receive(_remoteConfig.CallOptions);
 
-                    switch (_connectortype)
+                    switch (_connectorType)
                     {
                         case Type.ServerSide:
                             await call.RequestStream.WriteAsync(new RemoteMessage
@@ -178,7 +178,7 @@ namespace Proto.Remote
                                             break;
                                         }
                                     default:
-                                        if (_connectortype == Type.ServerSide)
+                                        if (_connectorType == Type.ServerSide)
                                             _logger.LogWarning("[{systemAddress}] Received {message} from {_address}", _system.Address, currentMessage, _address);
                                         else
                                             _remoteMessageHandler.HandleRemoteMessage(currentMessage);

--- a/tests/Proto.Actor.Tests/Router/HashRingTests.cs
+++ b/tests/Proto.Actor.Tests/Router/HashRingTests.cs
@@ -1,0 +1,127 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="HashRingTests.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Proto.Router.Tests
+{
+    public class HashRingTests
+    {
+        [Theory]
+        [InlineData(2, 1)]
+        [InlineData(10, 5)]
+        [InlineData(100, 10)]
+        public void Can_provide_consistent_results_when_removing_values(int nodeCount, int removeCount)
+        {
+            var values = Enumerable.Range(0, nodeCount).Select(_ => Guid.NewGuid().ToString("N")).ToArray();
+            var hashRing = new HashRing<string>(values, value => value, MurmurHash2.Hash, 20);
+
+            var results = new Dictionary<string, string>();
+
+            for (var i = 0; i < 10; i++)
+            {
+                var key = Guid.NewGuid().ToString("N");
+                var result = hashRing.GetNode(key);
+                results.Add(key, result);
+            }
+
+            var removed = results.Values.Take(removeCount).ToHashSet();
+
+            hashRing.Remove(removed);
+
+            foreach (var (key, prevResult) in results)
+            {
+                var currentResult = hashRing.GetNode(key);
+
+                if (removed.Contains(prevResult))
+                {
+                    currentResult.Should().NotBe(prevResult);
+                }
+                else
+                {
+                    currentResult.Should().Be(prevResult);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(10, 1, .8)]
+        [InlineData(100, 5, .9)]
+        public void Can_provide_relatively_consistent_results_when_adding_values(int nodeCount, int addedCount, double expectedRetainedRatio)
+        {
+            var values = Enumerable.Range(0, nodeCount).Select(_ => Guid.NewGuid().ToString("N")).ToArray();
+            var hashRing = new HashRing<string>(values, value => value, MurmurHash2.Hash, 20);
+
+            var results = new Dictionary<string, string>();
+
+            for (var i = 0; i < 1000; i++)
+            {
+                var key = Guid.NewGuid().ToString("N");
+                results.Add(key, hashRing.GetNode(key));
+            }
+
+            hashRing.Add(Enumerable.Range(0, addedCount).Select(_ => Guid.NewGuid().ToString("N")).ToArray());
+
+            double retained = results.Count(tuple => {
+                    var (key, previousResult) = tuple;
+                    var currentResult = hashRing.GetNode(key);
+                    return previousResult.Equals(currentResult, StringComparison.Ordinal);
+                }
+            );
+
+            var retainedRatio = retained / results.Count;
+            retainedRatio.Should().BeLessThan(1d, "New nodes should affect the result");
+            retainedRatio.Should().BeGreaterOrEqualTo(expectedRetainedRatio);
+        }
+
+        [Theory]
+        [InlineData(2, 1)]
+        [InlineData(10, 10)]
+        [InlineData(100, 10)]
+        public void Adding_values_is_equivalent_to_ctor_values(int nodeCount, int addedCount)
+        {
+            var values = Enumerable.Range(0, nodeCount).Select(_ => Guid.NewGuid().ToString("N")).ToArray();
+            var added = Enumerable.Range(0, addedCount).Select(_ => Guid.NewGuid().ToString("N")).ToArray();
+
+            var hashRing = new HashRing<string>(values.Concat(added), value => value, MurmurHash2.Hash, 20);
+            var mutatedHashSet = new HashRing<string>(values, value => value, MurmurHash2.Hash, 20);
+            mutatedHashSet.Add(added);
+
+            for (var i = 0; i < 100; i++)
+            {
+                var key = Guid.NewGuid().ToString("N");
+                var result = mutatedHashSet.GetNode(key);
+                var result2 = hashRing.GetNode(key);
+                result.Should().Be(result2);
+            }
+        }
+
+        [Theory]
+        [InlineData(2, 1)]
+        [InlineData(10, 10)]
+        [InlineData(100, 10)]
+        public void Removing_values_is_equivalent_to_ctor_values(int nodeCount, int removedCount)
+        {
+            var values = Enumerable.Range(0, nodeCount).Select(_ => Guid.NewGuid().ToString("N")).ToArray();
+            var removed = values.Take(removedCount).ToList();
+
+            var hashRing = new HashRing<string>(values.Except(removed), value => value, MurmurHash2.Hash, 20);
+            var mutatedHashSet = new HashRing<string>(values, value => value, MurmurHash2.Hash, 20);
+            mutatedHashSet.Remove(removed.ToHashSet());
+
+            for (var i = 0; i < 100; i++)
+            {
+                var key = Guid.NewGuid().ToString("N");
+                var result = mutatedHashSet.GetNode(key);
+                var result2 = hashRing.GetNode(key);
+                result.Should().Be(result2);
+            }
+        }
+    }
+}

--- a/tests/Proto.Cluster.MongoIdentity.Tests/MongoIdentityTests.cs
+++ b/tests/Proto.Cluster.MongoIdentity.Tests/MongoIdentityTests.cs
@@ -1,4 +1,5 @@
 ﻿// ReSharper disable UnusedType.Global
+using System;
 using Microsoft.Extensions.Configuration;
 using MongoDB.Driver;
 using Proto.Cluster.Identity;
@@ -13,7 +14,7 @@ namespace Proto.Cluster.MongoIdentity.Tests
 {
     public class MongoIdentityClusterFixture : BaseInMemoryClusterFixture
     {
-        public MongoIdentityClusterFixture() : base(3)
+        public MongoIdentityClusterFixture() : base(3, config => config with {ActorActivationTimeout = TimeSpan.FromSeconds(10)})
         {
         }
 
@@ -36,7 +37,7 @@ namespace Proto.Cluster.MongoIdentity.Tests
 
     public class ChaosMongoIdentityClusterFixture : BaseInMemoryClusterFixture
     {
-        public ChaosMongoIdentityClusterFixture() : base(3)
+        public ChaosMongoIdentityClusterFixture() : base(3, config => config with {ActorActivationTimeout = TimeSpan.FromSeconds(10)})
         {
         }
 

--- a/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
@@ -1,0 +1,265 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="PartitionIdentityTests.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClusterTest.Messages;
+using FluentAssertions;
+using Proto.Cluster.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Proto.Cluster.PartitionIdentity.Tests
+{
+    public class PartitionIdentityTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public PartitionIdentityTests(ITestOutputHelper output) => _output = output;
+
+        private int _requests = 0;
+
+        [Theory]
+        [InlineData(3, 100000, 1, 24, 30)]
+        public async Task ClusterMaintainsSingleConcurrentVirtualActorPerIdentity(
+            int memberCount,
+            int identityCount,
+            int batchSize,
+            int threads,
+            int runtimeSeconds
+        )
+        {
+            _requests = 0;
+            await using var fixture = await InitClusterFixture(memberCount);
+
+            var identities = Enumerable.Range(0, identityCount).Select(_ => Guid.NewGuid().ToString("N")).ToList();
+
+            var stop = new CancellationTokenSource(runtimeSeconds * 1000);
+            // ReSharper disable once AccessToDisposedClosure
+
+            foreach (var _ in Enumerable.Range(0, threads))
+            {
+                StartBackgroundRequests(fixture, identities, batchSize, stop.Token);
+            }
+
+            StartKillingRandomVirtualActors(fixture, identities, stop.Token);
+            StartSpawningAndStoppingMembers(fixture, stop.Token);
+
+            var timer = Stopwatch.StartNew();
+            var prev = _requests;
+
+            while (!stop.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                var now = _requests;
+
+                _output.WriteLine($"Consistent responses: {now - prev}/{timer.Elapsed}");
+                timer.Restart();
+                prev = now;
+            }
+
+            _output.WriteLine($"Stopping cluster of {fixture.Members.Count} members");
+            timer.Restart();
+            await fixture.DisposeAsync();
+            _output.WriteLine($"Stopped cluster in {timer.Elapsed}");
+
+            var actorStates = fixture.Repository.Contents.ToList();
+
+            var totalCalls = actorStates.Select(it => it.TotalCount).Sum();
+            var restarts = actorStates.Select(it => it.Events.Count(it => it is ActorStopped) - 1).Sum();
+
+            _output.WriteLine($"{totalCalls} requests, {restarts} restarts against " + actorStates.Count + " identities");
+
+            foreach (var actorState in actorStates)
+            {
+                if (actorState.Inconsistent)
+                {
+                    Assert.False(actorState.Inconsistent, actorState.ToString());
+                }
+            }
+        }
+
+        private void StartBackgroundRequests(
+            IClusterFixture clusterFixture,
+            List<string> identities,
+            int batchSize,
+            CancellationToken cancellationToken
+        ) => _ = Task.Run(async () => {
+                var rnd = new Random();
+                var identityIndex = rnd.Next(identities.Count);
+                var tasks = new List<Task>();
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    for (int i = 0; i < batchSize; i++)
+                    {
+                        var id = identities[identityIndex++ % identities.Count];
+
+                        tasks.Add(Inc(clusterFixture.Members[0], id, cancellationToken));
+
+                        if (rnd.Next() % 2 == 0)
+                        {
+                            // Try to provoke race condition, call simultaneously to another member
+                            tasks.Add(Inc(clusterFixture.Members[1], id, cancellationToken));
+                        }
+                    }
+
+                    await Task.WhenAll(tasks);
+                    tasks.Clear();
+                }
+            }
+        );
+
+        private static Cluster RandomMember(IClusterFixture fixture, Random rnd) => RandomMember(fixture.Members, rnd);
+
+        private static Cluster RandomMember(IList<Cluster> members, Random rnd)
+            => members[rnd.Next(members.Count)];
+
+        private async Task Inc(Cluster member, string id, CancellationToken cancellationToken)
+        {
+            var response = await member.RequestAsync<IncResponse>(new ClusterIdentity
+                {
+                    Identity = id,
+                    Kind = ConcurrencyVerificationActor.Kind
+                }, new IncCount(), cancellationToken
+            );
+
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                response.Should().NotBeNull();
+                Interlocked.Increment(ref _requests);
+
+                if (response.Count != response.ExpectedCount)
+                {
+                    _output.WriteLine($"Inconsistent state {id}/{response.SessionId} {response.Count} instead of {response.ExpectedCount}");
+                    // response.Count.Should().Be(response.ExpectedCount, $"Inconsistent state {id}/{response.SessionId} {response.Count} instead of {response.ExpectedCount}")
+                }
+            }
+        }
+
+        private void StartKillingRandomVirtualActors(
+            IClusterFixture clusterFixture,
+            List<string> identities,
+            CancellationToken cancellationToken
+        ) => _ = Task.Run(async () => {
+                var rnd = new Random();
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    await Task.Delay(rnd.Next(50), cancellationToken);
+                    var id = RandomIdentity(identities, rnd);
+                    var member = clusterFixture.Members[rnd.Next(clusterFixture.Members.Count)];
+                    await member.RequestAsync<Ack>(new ClusterIdentity
+                        {
+                            Identity = id,
+                            Kind = ConcurrencyVerificationActor.Kind
+                        }, new Die(), cancellationToken
+                    );
+                    Interlocked.Increment(ref _requests);
+                }
+            }
+        );
+
+        private static string RandomIdentity(List<string> identities, Random rnd) => identities[rnd.Next(identities.Count)];
+
+        private void StartSpawningAndStoppingMembers(
+            IClusterFixture clusterFixture,
+            CancellationToken cancellationToken
+        ) => _ = Task.Run(async () => {
+                const int maxMembers = 10;
+                const int minMembers = 2;
+                var rnd = new Random();
+
+                try
+                {
+                    while (!cancellationToken.IsCancellationRequested)
+                    {
+                        await Task.Delay(rnd.Next(10000), cancellationToken).ConfigureAwait(false);
+                        var spawn = rnd.Next() % 2 == 0;
+
+                        if (spawn)
+                        {
+                            if (clusterFixture.Members.Count < maxMembers)
+                            {
+                                _output.WriteLine("Spawning member");
+                                _ = clusterFixture.SpawnNode();
+                            }
+                        }
+                        else
+                        {
+                            // var graceful = rnd.Next() % 4 != 0;
+                            const bool graceful = true;
+
+                            if (clusterFixture.Members.Count > minMembers)
+                            {
+                                _output.WriteLine("Stopping member " + (graceful ? "gracefully" : "with wanton disregard"));
+                                _ = StopRandomMember(clusterFixture, clusterFixture.Members.Skip(2).ToList(), rnd, graceful);
+                            }
+                        }
+
+                        if (rnd.Next() % 2 == 0)
+                        {
+                            await Task.Delay(rnd.Next(100), cancellationToken).ConfigureAwait(false);
+
+                            if (spawn)
+                            {
+                                if (clusterFixture.Members.Count < maxMembers)
+                                {
+                                    _output.WriteLine("Spawning another member");
+
+                                    _ = clusterFixture.SpawnNode();
+                                }
+                            }
+                            else
+                            {
+                                // var graceful = rnd.Next() % 4 != 0;
+                                const bool graceful = true;
+
+                                if (clusterFixture.Members.Count > minMembers)
+                                {
+                                    _output.WriteLine("Stopping another member " + (graceful ? "gracefully" : "badly"));
+                                    _ = StopRandomMember(clusterFixture, clusterFixture.Members.Skip(2).ToList(), rnd, graceful);
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (Exception e)
+                {
+                    _output.WriteLine(e.ToString());
+                }
+            }, cancellationToken
+        );
+
+        private static Task StopRandomMember(IClusterFixture fixture, IList<Cluster> candidates, Random rnd, bool graceful)
+            => _ = fixture.RemoveNode(RandomMember(candidates, rnd), graceful);
+
+        private static async Task<PartitionIdentityClusterFixture> InitClusterFixture(int memberCount)
+        {
+            var fixture = new PartitionIdentityClusterFixture(memberCount);
+            await fixture.InitializeAsync();
+            return fixture;
+        }
+    }
+
+    public class PartitionIdentityClusterFixture : BaseInMemoryClusterFixture
+    {
+        public readonly ActorStateRepo Repository = new();
+
+        public PartitionIdentityClusterFixture(int memberCount) : base(memberCount)
+        {
+        }
+
+        protected override ClusterKind[] ClusterKinds
+            => new[] {new ClusterKind(ConcurrencyVerificationActor.Kind, Props.FromProducer(() => new ConcurrencyVerificationActor(Repository)))};
+    }
+}

--- a/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
@@ -26,7 +26,7 @@ namespace Proto.Cluster.PartitionIdentity.Tests
         private int _requests = 0;
 
         [Theory]
-        [InlineData(3, 100000, 1, 24, 30)]
+        [InlineData(3, 100000, 1, 24, 20)]
         public async Task ClusterMaintainsSingleConcurrentVirtualActorPerIdentity(
             int memberCount,
             int identityCount,

--- a/tests/Proto.Cluster.PartitionIdentity.Tests/Proto.Cluster.PartitionIdentity.Tests.csproj
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/Proto.Cluster.PartitionIdentity.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <LangVersion>9</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Proto.Cluster.Tests\Proto.Cluster.Tests.csproj" />
+        <ProjectReference Include="..\Proto.TestFixtures\Proto.TestFixtures.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Proto.Cluster.Tests/ClusterFixture.cs
+++ b/tests/Proto.Cluster.Tests/ClusterFixture.cs
@@ -1,17 +1,22 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using ClusterTest.Messages;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Proto.Cluster.Cache;
 using Proto.Cluster.Identity;
 using Proto.Cluster.Partition;
 using Proto.Cluster.Testing;
 using Proto.Logging;
+using Proto.OpenTelemetry;
 using Proto.Remote;
 using Proto.Remote.GrpcCore;
 using Xunit;
+// ReSharper disable ClassNeverInstantiated.Global
 
 namespace Proto.Cluster.Tests
 {
@@ -20,34 +25,58 @@ namespace Proto.Cluster.Tests
         IList<Cluster> Members { get; }
 
         public Task<Cluster> SpawnNode();
-        
+
         LogStore LogStore { get; }
 
         Task RemoveNode(Cluster member, bool graceful = true);
     }
 
-    public abstract class ClusterFixture : IAsyncLifetime, IClusterFixture
+    public abstract class ClusterFixture : IAsyncLifetime, IClusterFixture, IAsyncDisposable
     {
-        protected readonly string _clusterName;
-        private readonly int _clusterSize;
-        private readonly Func<ClusterConfig, ClusterConfig> _configure;
-        private readonly ILogger _logger = Log.CreateLogger(nameof(GetType));
+        private const bool EnableTracing = false;
 
-        protected ClusterFixture(int clusterSize, Func<ClusterConfig, ClusterConfig> configure = null)
+        protected readonly string ClusterName;
+        private readonly int _clusterSize;
+        private readonly Func<ClusterConfig, ClusterConfig>? _configure;
+        private readonly ILogger _logger = Log.CreateLogger(nameof(GetType));
+        private readonly TracerProvider? _tracerProvider;
+        private readonly List<Cluster> _members = new();
+
+        protected ClusterFixture(int clusterSize, Func<ClusterConfig, ClusterConfig>? configure = null)
         {
             _clusterSize = clusterSize;
             _configure = configure;
-            _clusterName = $"test-cluster-{Guid.NewGuid().ToString().Substring(0, 6)}";
+            ClusterName = $"test-cluster-{Guid.NewGuid().ToString().Substring(0, 6)}";
+
+#pragma warning disable CS0162
+            // ReSharper disable once HeuristicUnreachableCode
+            if (EnableTracing)
+            {
+                _tracerProvider = InitOpenTelemetryTracing();
+            }
+#pragma warning restore CS0162
         }
+
+        private static TracerProvider InitOpenTelemetryTracing() => global::OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+            .SetResourceBuilder(ResourceBuilder.CreateDefault()
+                .AddService("Proto.Cluster.Tests")
+            )
+            .AddProtoActorInstrumentation()
+            .AddJaegerExporter(options => options.AgentHost = "localhost")
+            .Build();
 
         protected virtual ClusterKind[] ClusterKinds => new[]
         {
             new ClusterKind(EchoActor.Kind, EchoActor.Props.WithClusterRequestDeduplication()),
             new ClusterKind(EchoActor.Kind2, EchoActor.Props),
-            new ClusterKind(EchoActor.LocalAffinityKind, EchoActor.Props).WithLocalAffinityRelocationStrategy()
+            new ClusterKind(EchoActor.LocalAffinityKind, EchoActor.Props).WithLocalAffinityRelocationStrategy(),
         };
 
-        public async Task InitializeAsync() => Members = await SpawnClusterNodes(_clusterSize, _configure).ConfigureAwait(false);
+        public async Task InitializeAsync()
+        {
+            var nodes = await SpawnClusterNodes(_clusterSize, _configure).ConfigureAwait(false);
+            _members.AddRange(nodes);
+        }
 
         public LogStore LogStore { get; } = new();
 
@@ -55,7 +84,8 @@ namespace Proto.Cluster.Tests
         {
             try
             {
-                await Task.WhenAll(Members?.Select(cluster => cluster.ShutdownAsync()) ?? new[] {Task.CompletedTask}).ConfigureAwait(false);
+                _tracerProvider?.Dispose();
+                await Task.WhenAll(Members.ToList().Select(cluster => cluster.ShutdownAsync())).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -86,29 +116,29 @@ namespace Proto.Cluster.Tests
             return newMember;
         }
 
-        public IList<Cluster> Members { get; private set; }
+        public IList<Cluster> Members => _members;
 
         private async Task<IList<Cluster>> SpawnClusterNodes(
             int count,
-            Func<ClusterConfig, ClusterConfig> configure = null
+            Func<ClusterConfig, ClusterConfig>? configure = null
         ) => (await Task.WhenAll(
             Enumerable.Range(0, count)
                 .Select(_ => SpawnClusterMember(configure))
         )).ToList();
 
-        protected virtual async Task<Cluster> SpawnClusterMember(Func<ClusterConfig, ClusterConfig> configure)
+        protected virtual async Task<Cluster> SpawnClusterMember(Func<ClusterConfig, ClusterConfig>? configure)
         {
             var config = ClusterConfig.Setup(
-                    _clusterName,
+                    ClusterName,
                     GetClusterProvider(),
-                    GetIdentityLookup(_clusterName)
+                    GetIdentityLookup(ClusterName)
                 )
                 .WithClusterKinds(ClusterKinds);
 
             config = configure?.Invoke(config) ?? config;
 
             var system = new ActorSystem(GetActorSystemConfig());
-            system.Extensions.Register(new InstanceLogger(LogLevel.Debug,LogStore,category:system.Id));
+            system.Extensions.Register(new InstanceLogger(LogLevel.Debug, LogStore, category: system.Id));
 
             var logger = system.Logger()?.BeginScope<EventStream>();
             system.EventStream.Subscribe<object>(e => { logger?.LogDebug("EventStream {MessageType}:{Message}", e.GetType().Name, e); }
@@ -123,18 +153,28 @@ namespace Proto.Cluster.Tests
             return cluster;
         }
 
-        protected virtual ActorSystemConfig GetActorSystemConfig() => ActorSystemConfig.Setup();
+        protected virtual ActorSystemConfig GetActorSystemConfig()
+        {
+            var actorSystemConfig = ActorSystemConfig.Setup();
+
+            // ReSharper disable once HeuristicUnreachableCode
+            return EnableTracing ? actorSystemConfig.WithConfigureProps(props => props.WithTracing()) : actorSystemConfig;
+        }
 
         protected abstract IClusterProvider GetClusterProvider();
 
-        protected virtual IIdentityLookup GetIdentityLookup(string clusterName) => new PartitionIdentityLookup();
+        protected virtual IIdentityLookup GetIdentityLookup(string clusterName) => new PartitionIdentityLookup(TimeSpan.FromSeconds(3),
+            TimeSpan.FromSeconds(2), new PartitionConfig(true, 1000, TimeSpan.FromSeconds(1))
+        );
+
+        async ValueTask IAsyncDisposable.DisposeAsync() => await DisposeAsync();
     }
 
     public abstract class BaseInMemoryClusterFixture : ClusterFixture
     {
         private readonly Lazy<InMemAgent> _inMemAgent = new(() => new InMemAgent());
 
-        protected BaseInMemoryClusterFixture(int clusterSize, Func<ClusterConfig, ClusterConfig> configure = null) :
+        protected BaseInMemoryClusterFixture(int clusterSize, Func<ClusterConfig, ClusterConfig>? configure = null) :
             base(
                 clusterSize,
                 configure
@@ -144,8 +184,7 @@ namespace Proto.Cluster.Tests
 
         private InMemAgent InMemAgent => _inMemAgent.Value;
 
-        protected override IClusterProvider GetClusterProvider() =>
-            new TestProvider(new TestProviderOptions(), InMemAgent);
+        protected override IClusterProvider GetClusterProvider() => new TestProvider(new TestProviderOptions(), InMemAgent);
     }
 
     // ReSharper disable once ClassNeverInstantiated.Global
@@ -175,7 +214,7 @@ namespace Proto.Cluster.Tests
         {
         }
 
-        protected override ActorSystemConfig GetActorSystemConfig() => ActorSystemConfig.Setup().WithSharedFutures();
+        protected override ActorSystemConfig GetActorSystemConfig() => base.GetActorSystemConfig().WithSharedFutures();
     }
 
     public class InMemoryPidCacheInvalidationClusterFixture : BaseInMemoryClusterFixture
@@ -188,7 +227,7 @@ namespace Proto.Cluster.Tests
 
         protected override ClusterKind[] ClusterKinds => base.ClusterKinds.Select(ck => ck.WithPidCacheInvalidation()).ToArray();
 
-        protected override async Task<Cluster> SpawnClusterMember(Func<ClusterConfig, ClusterConfig> configure)
+        protected override async Task<Cluster> SpawnClusterMember(Func<ClusterConfig, ClusterConfig>? configure)
         {
             var cluster = await base.SpawnClusterMember(configure);
             return cluster.WithPidCacheInvalidation();

--- a/tests/Proto.Cluster.Tests/ClusterFixture.cs
+++ b/tests/Proto.Cluster.Tests/ClusterFixture.cs
@@ -164,7 +164,7 @@ namespace Proto.Cluster.Tests
         protected abstract IClusterProvider GetClusterProvider();
 
         protected virtual IIdentityLookup GetIdentityLookup(string clusterName) => new PartitionIdentityLookup(TimeSpan.FromSeconds(3),
-            TimeSpan.FromSeconds(2), new PartitionConfig(true, 1000, TimeSpan.FromSeconds(1))
+            TimeSpan.FromSeconds(2), new PartitionConfig(true, 1000, TimeSpan.FromSeconds(1), PartitionIdentityLookup.Mode.Push)
         );
 
         async ValueTask IAsyncDisposable.DisposeAsync() => await DisposeAsync();

--- a/tests/Proto.Cluster.Tests/ConcurrencyVerificationActor.cs
+++ b/tests/Proto.Cluster.Tests/ConcurrencyVerificationActor.cs
@@ -1,0 +1,161 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="StatefulActor.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClusterTest.Messages;
+// ReSharper disable NotAccessedPositionalProperty.Global
+
+namespace Proto.Cluster.Tests
+{
+    public class ConcurrencyVerificationActor : IActor
+    {
+        public const string Kind = "concurrency-verification";
+
+        private readonly ActorStateRepo _repo;
+        private ActorState? _state;
+        private int _count;
+
+        public ConcurrencyVerificationActor(ActorStateRepo repo) => _repo = repo;
+
+        private Guid SessionId { get; set; }
+
+        public Task ReceiveAsync(IContext context) => context.Message switch
+        {
+            Started msg  => OnStarted(context),
+            Stopping msg => OnStopping(context),
+            Die          => StopNow(context),
+            IncCount     => OnInc(context),
+            _            => Task.CompletedTask
+        };
+
+        private Task OnInc(IContext context)
+        {
+            var (count, totalCount) = _state!.Inc(_count);
+            context.Respond(new IncResponse
+                {
+                    Count = count,
+                    ExpectedCount = totalCount,
+                    SessionId = SessionId.ToString("N"),
+                }
+            );
+
+            if (totalCount == count) // Expected == actual
+            {
+                _count = count;
+            }
+            else
+            {
+                _count = totalCount; // Reset to the global total count.
+                _state.RecordInconsistency(count, totalCount, context.Self);
+            }
+
+            _state.StoredCount = _count;
+
+            return Task.CompletedTask;
+        }
+
+        private Task StopNow(IContext context)
+        {
+            context.Respond(new Ack());
+            context.Stop(context.Self);
+            return Task.CompletedTask;
+        }
+
+        private async Task OnStopping(IContext context)
+        {
+            _state!.RecordStopping(context.Self);
+            await Task.Delay(new Random().Next(50));
+        }
+
+        private async Task OnStarted(IContext context)
+        {
+            SessionId = Guid.NewGuid();
+            _state = _repo.Get(context.ClusterIdentity()!.Identity);
+            _state!.RecordStarted(context.Self);
+            _count = _state.StoredCount;
+
+            // Simulate network hop
+            await Task.Delay(new Random().Next(50));
+        }
+    }
+
+    public record VerificationEvent(PID Activation, DateTimeOffset When);
+
+    public record ActorStarted(PID Activation, DateTimeOffset When, int StoredCount, int GlobalCount) : VerificationEvent(Activation, When);
+
+    public record ActorStopped(PID Activation, DateTimeOffset When, int StoredCount, int GlobalCount) : VerificationEvent(Activation, When);
+
+    public record ConsistencyError(
+            PID Activation,
+            DateTimeOffset When,
+            int StoredCount,
+            int GlobalCount,
+            int ExpectedCount,
+            int ActualCount
+        )
+        : VerificationEvent(Activation, When);
+
+    public class ActorState
+    {
+        private int _totalCount;
+        public int StoredCount { get; set; }
+        public bool Inconsistent { get; private set; }
+        public int TotalCount => _totalCount;
+        private readonly string _id;
+
+        public ActorState(string id) => _id = id;
+
+        public ConcurrentBag<VerificationEvent> Events { get; } = new();
+
+        public void RecordStarted(PID activation) => Events.Add(new ActorStarted(activation, DateTimeOffset.Now, StoredCount, TotalCount));
+
+        public void RecordStopping(PID activation)
+            => Events.Add(new ActorStopped(activation, DateTimeOffset.Now, StoredCount, TotalCount));
+
+        public void RecordInconsistency(int expected, int actual, PID activation)
+        {
+            Events.Add(new ConsistencyError(activation, DateTimeOffset.Now, StoredCount, TotalCount, expected, actual));
+            Inconsistent = true;
+        }
+
+        public (int local, int total) Inc(int actorLocalCount) => (actorLocalCount + 1, Interlocked.Increment(ref _totalCount));
+
+        // public void VerifyStateIsConsistent()
+        // {
+        //     Events.Should().NotBeEmpty();
+        //     using var events = Events.OrderBy(it => it.When).GetEnumerator();
+        //
+        //     // Check ordering of starts / stops for identity
+        //     while (events.MoveNext())
+        //     {
+        //         var sessionId = events.Current!.SessionId;
+        //         events.Current.Should().BeOfType<ActorStarted>();
+        //         events.MoveNext().Should().BeTrue("We should get the stopping event");
+        //         events.Current!.Should().BeOfType<ActorStopped>();
+        //         events.Current.SessionId.Should().Be(sessionId, "Start and stop should be from the same session");
+        //     }
+        // }
+
+        public override string ToString()
+            => $"Id: {_id}, {nameof(StoredCount)}: {StoredCount}, {nameof(TotalCount)}: {TotalCount}, {nameof(Events)}:\n {string.Join(",\n", Events.OrderBy(it => it.When))}";
+    }
+
+    public class ActorStateRepo
+    {
+        private readonly ConcurrentDictionary<string, ActorState> _db = new();
+
+        public ActorState Get(string id) => _db.GetOrAdd(id, identity => new ActorState(identity));
+
+        public ICollection<ActorState> Contents => _db.Values;
+
+        public void Reset() => _db.Clear();
+    }
+}

--- a/tests/Proto.Cluster.Tests/ConcurrencyVerificationActor.cs
+++ b/tests/Proto.Cluster.Tests/ConcurrencyVerificationActor.cs
@@ -29,11 +29,11 @@ namespace Proto.Cluster.Tests
 
         public Task ReceiveAsync(IContext context) => context.Message switch
         {
-            Started msg  => OnStarted(context),
-            Stopping msg => OnStopping(context),
-            Die          => StopNow(context),
-            IncCount     => OnInc(context),
-            _            => Task.CompletedTask
+            Started  => OnStarted(context),
+            Stopping => OnStopping(context),
+            Die      => StopNow(context),
+            IncCount => OnInc(context),
+            _        => Task.CompletedTask
         };
 
         private Task OnInc(IContext context)

--- a/tests/Proto.Cluster.Tests/ConcurrencyVerificationActor.cs
+++ b/tests/Proto.Cluster.Tests/ConcurrencyVerificationActor.cs
@@ -79,7 +79,7 @@ namespace Proto.Cluster.Tests
         {
             SessionId = Guid.NewGuid();
             _state = _repo.Get(context.ClusterIdentity()!.Identity);
-            _state!.RecordStarted(context.Self);
+            _state.RecordStarted(context.Self);
             _count = _state.StoredCount;
 
             // Simulate network hop

--- a/tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj
+++ b/tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj
@@ -8,13 +8,15 @@
     <ProjectReference Include="..\..\src\Proto.Cluster.Identity.MongoDb\Proto.Cluster.Identity.MongoDb.csproj" />
     <ProjectReference Include="..\..\src\Proto.Cluster.TestProvider\Proto.Cluster.TestProvider.csproj" />
     <ProjectReference Include="..\..\src\Proto.Cluster\Proto.Cluster.csproj" />
+    <ProjectReference Include="..\..\src\Proto.OpenTelemetry\Proto.OpenTelemetry.csproj" />
     <ProjectReference Include="..\..\src\Proto.Remote.GrpcCore\Proto.Remote.GrpcCore.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Divergic.Logging.Xunit" Version="3.6.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.40.0" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.42.0" PrivateAssets="All" />
     <PackageReference Include="IsExternalInit.System.Runtime.CompilerServices" Version="1.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.1.0" />
     <PackageReference Include="Roslynator.Analyzers" Version="3.2.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Proto.Cluster.Tests/messages.proto
+++ b/tests/Proto.Cluster.Tests/messages.proto
@@ -28,7 +28,7 @@ message Die {
 }
 
 message WhereAreYou {
-  string request_id = 1; 
+  string request_id = 1;
 }
 
 message HereIAm {
@@ -58,4 +58,14 @@ message SomeGossipState{
 
 message SomeTopologyGossipState{
   uint64 topology_hash = 1;
+}
+
+message IncCount{
+
+}
+
+message IncResponse{
+  int32 count = 1;
+  int32 expected_count = 2;
+  string session_id = 3;
 }

--- a/tests/Proto.Remote.Tests/EchoActor.cs
+++ b/tests/Proto.Remote.Tests/EchoActor.cs
@@ -14,7 +14,7 @@ namespace Proto.Remote.Tests
             switch (context.Message)
             {
                 case Started:
-                    Logger.LogDebug($"{context.Self}");
+                    Logger.LogDebug("Started {ActorPid}",context.Self);
                     break;
                 case Ping ping:
                     Logger.LogDebug("Received Ping, replying Pong");

--- a/tests/Proto.Remote.Tests/RemoteFixture.cs
+++ b/tests/Proto.Remote.Tests/RemoteFixture.cs
@@ -25,7 +25,7 @@ namespace Proto.Remote.Tests
 
     public abstract class RemoteFixture : IRemoteFixture
     {
-        private static readonly Props EchoActorProps = Props.FromProducer(() => new EchoActor());
+        public static readonly Props EchoActorProps = Props.FromProducer(() => new EchoActor());
 
         private static LogStore _logStore = new();
         public LogStore LogStore { get; } = _logStore;


### PR DESCRIPTION
Rewrite of both HashRing and Partition Identity handover.

Breaking change with regards to Rendezvous algorithm for identity ownership, so can not run with older versions of Proto.Actor.