### PR TITLE
Dependabot should ignore CouchbaseNetClient 3.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     interval: weekly
     time: "04:00"
   open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: CouchbaseNetClient
+    versions:
+    - ">=3.0.0"


### PR DESCRIPTION
3.x is a breaking version, so it can't be automatically updated by Dependabot.