### PR TITLE
RemoteProcess PidCache timeout

### DIFF
--- a/src/Proto.Actor/PID.cs
+++ b/src/Proto.Actor/PID.cs
@@ -39,6 +39,8 @@ namespace Proto
             return _process;
         }
 
+        internal Process? CurrentRef => _process;
+
         internal void SendUserMessage(ActorSystem system, object message)
         {
             var reff = Ref(system) ?? system.ProcessRegistry.Get(this);

--- a/src/Proto.Cluster/ClusterConfig.cs
+++ b/src/Proto.Cluster/ClusterConfig.cs
@@ -32,10 +32,12 @@ namespace Proto.Cluster
             IdentityLookup = identityLookup;
             MemberStrategyBuilder = (_, _) => new SimpleMemberStrategy();
             PubSubBatchSize = 2000;
+            RemotePidCacheTimeToLive = TimeSpan.FromMinutes(15);
+            RemotePidCacheClearInterval = TimeSpan.FromSeconds(15);
         }
 
         public Func<Cluster, string, IMemberStrategy> MemberStrategyBuilder { get; init; }
-        
+
         public string ClusterName { get; }
 
         public ImmutableList<ClusterKind> ClusterKinds { get; init; } = ImmutableList<ClusterKind>.Empty;
@@ -50,7 +52,7 @@ namespace Proto.Cluster
         public TimeSpan RequestLogThrottlePeriod { get; init; }
         public int MaxNumberOfEventsInRequestLogThrottlePeriod { get; init; }
 
-        public int GossipFanout { get; init;  }
+        public int GossipFanout { get; init; }
 
         public IIdentityLookup IdentityLookup { get; }
         public TimeSpan GossipInterval { get; init; }
@@ -60,18 +62,21 @@ namespace Proto.Cluster
 
         public TimeSpan ClusterRequestDeDuplicationWindow { get; init; }
 
+        public TimeSpan RemotePidCacheTimeToLive { get; set; }
+        public TimeSpan RemotePidCacheClearInterval { get; set; }
+        
         public Func<Cluster, IClusterContext> ClusterContextProducer { get; init; } =
-            c => new DefaultClusterContext(c.IdentityLookup, c.PidCache, c.Config.ToClusterContextConfig(),c.System.Shutdown);
+            c => new DefaultClusterContext(c.IdentityLookup, c.PidCache, c.Config.ToClusterContextConfig(), c.System.Shutdown);
 
         public ClusterConfig WithTimeout(TimeSpan timeSpan) =>
             this with {TimeoutTimespan = timeSpan};
 
         public ClusterConfig WithActorRequestTimeout(TimeSpan timeSpan) =>
             this with {ActorRequestTimeout = timeSpan};
-        
+
         public ClusterConfig WithActorSpawnTimeout(TimeSpan timeSpan) =>
             this with {ActorSpawnTimeout = timeSpan};
-        
+
         public ClusterConfig WithActorActivationTimeout(TimeSpan timeSpan) =>
             this with {ActorActivationTimeout = timeSpan};
 
@@ -100,22 +105,24 @@ namespace Proto.Cluster
 
         public ClusterConfig WithClusterKinds(params ClusterKind[] clusterKinds)
             => this with {ClusterKinds = ClusterKinds.AddRange(clusterKinds)};
-        
+
         public ClusterConfig WithMemberStrategyBuilder(Func<Cluster, string, IMemberStrategy> builder) =>
             this with {MemberStrategyBuilder = builder};
 
         public ClusterConfig WithClusterContextProducer(Func<Cluster, IClusterContext> producer) =>
             this with {ClusterContextProducer = producer};
-        
+
         public ClusterConfig WithGossipInterval(TimeSpan interval) =>
             this with {GossipInterval = interval};
-        
+
         public ClusterConfig WithGossipFanOut(int fanout) =>
             this with {GossipFanout = fanout};
 
         public ClusterConfig WithGossipRequestTimeout(TimeSpan timeout) =>
-            this with { GossipRequestTimeout = timeout };
+            this with {GossipRequestTimeout = timeout};
 
+        public ClusterConfig WithRemotePidCacheTimeToLive(TimeSpan timeout) =>
+            this with {RemotePidCacheTimeToLive = timeout};
 
         public static ClusterConfig Setup(
             string clusterName,

--- a/src/Proto.Cluster/PidCache.cs
+++ b/src/Proto.Cluster/PidCache.cs
@@ -93,7 +93,7 @@ namespace Proto.Cluster
         /// <returns></returns>
         public int RemoveIdleRemoteProcessesOlderThan(TimeSpan age)
         {
-            var cutoff = Stopwatch.GetTimestamp() - age.Ticks;
+            var cutoff = Stopwatch.GetTimestamp() - (long)(Stopwatch.Frequency * age.TotalSeconds);
             return RemoveByPredicate(pair => pair.Value.CurrentRef is RemoteProcess remoteProcess && remoteProcess.LastUsedTick < cutoff);
         }
 

--- a/src/Proto.Cluster/PidCache.cs
+++ b/src/Proto.Cluster/PidCache.cs
@@ -6,8 +6,10 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Proto.Remote;
 
 namespace Proto.Cluster
 {
@@ -22,8 +24,7 @@ namespace Proto.Cluster
             _cacheCollection = _cacheDict;
         }
 
-        
-        public bool TryGet(ClusterIdentity clusterIdentity,[NotNullWhen(true)] out PID? pid)
+        public bool TryGet(ClusterIdentity clusterIdentity, [NotNullWhen(true)] out PID? pid)
         {
             if (clusterIdentity is null) throw new ArgumentNullException(nameof(clusterIdentity));
 
@@ -33,6 +34,7 @@ namespace Proto.Cluster
                 pid = identityCachedPid;
                 return true;
             }
+
             return _cacheDict.TryGetValue(clusterIdentity, out pid);
         }
 
@@ -77,25 +79,41 @@ namespace Proto.Cluster
                 clusterIdentity.CachedPid = null;
             }
 
-            if (_cacheDict.TryGetValue(clusterIdentity, out var existingPid) && existingPid.Id == pid.Id &&
-                existingPid.Address == pid.Address)
+            if (_cacheDict.TryGetValue(clusterIdentity, out var existingPid) && existingPid.Id == pid.Id && existingPid.Address == pid.Address)
                 return _cacheCollection.Remove(new KeyValuePair<ClusterIdentity, PID>(clusterIdentity, existingPid));
 
             return false;
         }
 
-        public void RemoveByMember(Member member) => RemoveByPredicate(pair => member.Address.Equals(pair.Value.Address, StringComparison.InvariantCulture));
+        
+        /// <summary>
+        /// Remove cached remote activations which have not been used since
+        /// </summary>
+        /// <param name="age"></param>
+        /// <returns></returns>
+        public int RemoveIdleRemoteProcessesOlderThan(TimeSpan age)
+        {
+            var cutoff = Stopwatch.GetTimestamp() - age.Ticks;
+            return RemoveByPredicate(pair => pair.Value.CurrentRef is RemoteProcess remoteProcess && remoteProcess.LastUsedTick < cutoff);
+        }
 
-        private void RemoveByPredicate(Func<KeyValuePair<ClusterIdentity, PID>, bool> predicate)
+        public int RemoveByMember(Member member)
+            => RemoveByPredicate(pair => member.Address.Equals(pair.Value.Address, StringComparison.InvariantCulture));
+
+        private int RemoveByPredicate(Func<KeyValuePair<ClusterIdentity, PID>, bool> predicate)
         {
             var toBeRemoved = _cacheDict.Where(predicate).ToList();
-            if (toBeRemoved.Count == 0) return;
+            if (toBeRemoved.Count == 0) return 0;
+
+            var removed = 0;
 
             foreach (var item in toBeRemoved)
             {
                 item.Key.CachedPid = null;
-                _cacheCollection.Remove(item);
+                if (_cacheCollection.Remove(item)) removed++;
             }
+
+            return removed;
         }
     }
 }

--- a/src/Proto.Remote/InternalsVisibleTo.cs
+++ b/src/Proto.Remote/InternalsVisibleTo.cs
@@ -1,0 +1,8 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="InternalsVisibleTo.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Proto.Cluster")]

--- a/src/Proto.Remote/RemoteProcess.cs
+++ b/src/Proto.Remote/RemoteProcess.cs
@@ -4,6 +4,8 @@
 //   </copyright>
 // -----------------------------------------------------------------------
 
+using System.Diagnostics;
+
 namespace Proto.Remote
 {
     public class RemoteProcess : Process
@@ -11,11 +13,13 @@ namespace Proto.Remote
         private readonly EndpointManager _endpointManager;
         private readonly PID _pid;
         private PID? _endpoint;
+        private long _lastUsedTick;
 
         public RemoteProcess(ActorSystem system, EndpointManager endpointManager, PID pid) : base(system)
         {
             _endpointManager = endpointManager;
             _pid = pid;
+            _lastUsedTick = Stopwatch.GetTimestamp();
         }
 
         protected internal override void SendUserMessage(PID _, object message) => Send(message);
@@ -57,6 +61,9 @@ namespace Proto.Remote
             }
 
             System.Root.Send(_endpoint, message);
+            _lastUsedTick = Stopwatch.GetTimestamp();
         }
+
+        internal long LastUsedTick => _lastUsedTick;
     }
 }


### PR DESCRIPTION
## Description

Background cleanup of RemoteProcess  PidCache items. Runs on an interval and clears RemoteProcesses which has not been used recently.

Introduces 

```
ClusterConfig.RemotePidCacheTimeToLive = TimeSpan.FromMinutes(15);
ClusterConfig.RemotePidCacheClearInterval = TimeSpan.FromSeconds(15);
```



## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
