### PR TITLE
Fixing codegen on Visual Studio - generating deterministic cs files.

### DIFF
--- a/src/Proto.Cluster.CodeGen/OutputFileName.cs
+++ b/src/Proto.Cluster.CodeGen/OutputFileName.cs
@@ -1,0 +1,51 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="OutputFileName.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Proto.Cluster.CodeGen
+{
+    public static class OutputFileName
+    {
+        public static string GetOutputFileName(FileInfo inputFile, FileInfo? templateFile = null)
+        {
+            var baseName = Path.GetFileNameWithoutExtension(inputFile.Name);
+            
+            // hashcode is generated to avoid duplicate output file names, but also so file
+            // names are deterministic (random output file names break in Visual Studio)
+            var hash = GetHash(inputFile, templateFile);
+
+            return $"{baseName}-{hash}.cs";
+        }
+        
+        private static string GetHash(FileInfo inputFile, FileInfo? templateFile)
+        {
+            // MD5 is used as .GetHashCode() is not deterministic between runs
+            using var incrementalHash = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
+            
+            incrementalHash.AppendData(
+                Encoding.Unicode.GetBytes(inputFile.FullName)
+            );
+
+            if (templateFile is not null)
+            {
+                incrementalHash.AppendData(
+                    Encoding.Unicode.GetBytes(templateFile.FullName)
+                );
+            }
+
+            var hashCodeFormattedBytes = incrementalHash
+                .GetHashAndReset()
+                .Select(@byte => @byte.ToString("X2", CultureInfo.InvariantCulture));
+
+            return string.Concat(hashCodeFormattedBytes);
+        }
+    }
+}

--- a/src/Proto.Cluster.CodeGen/ProtoGenTask.cs
+++ b/src/Proto.Cluster.CodeGen/ProtoGenTask.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -73,24 +74,34 @@ namespace Proto.Cluster.CodeGen
             if (!templateFiles.Any())
             {
                 var template = Template.DefaultTemplate;
-                GenerateFile(projectDirectory, objDirectory, inputFileInfo, importPaths, template);
+                var outputFileName = OutputFileName.GetOutputFileName(inputFileInfo);
+                
+                GenerateFile(projectDirectory, objDirectory, inputFileInfo, importPaths, template, outputFileName);
             }
             else
             {
                 foreach (var templateFile in templateFiles)
                 {
                     var template = File.ReadAllText(templateFile.FullName, Encoding.Default);
-                    GenerateFile(projectDirectory, objDirectory, inputFileInfo, importPaths, template);
+                    var outputFileName = OutputFileName.GetOutputFileName(inputFileInfo, templateFile);
+                    
+                    GenerateFile(projectDirectory, objDirectory, inputFileInfo, importPaths, template, outputFileName);
                 }
             }
         }
 
-        private void GenerateFile(string projectDirectory, string objDirectory, FileInfo inputFileInfo, DirectoryInfo[] importPaths, string template)
+        private void GenerateFile(
+            string projectDirectory,
+            string objDirectory,
+            FileInfo inputFileInfo,
+            DirectoryInfo[] importPaths,
+            string template,
+            string outputFileName
+        )
         {
-            var guidName = Guid.NewGuid().ToString("N");
-            var outputFile = Path.Combine(objDirectory, $"{guidName}.cs");
-            Log.LogMessage(MessageImportance.High, $"Output file path: {outputFile}");
-            var outputFileInfo = new FileInfo(outputFile);
+            var outputFilePath = Path.Combine(objDirectory, outputFileName);
+            Log.LogMessage(MessageImportance.High, $"Output file path: {outputFilePath}");
+            var outputFileInfo = new FileInfo(outputFilePath);
             Generator.Generate(inputFileInfo, outputFileInfo, importPaths, Log, projectDirectory, template);
         }
 

--- a/tests/Proto.Cluster.CodeGen.Tests/OutputFileNameTests.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/OutputFileNameTests.cs
@@ -1,0 +1,55 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="OutputFileNameTests.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System.IO;
+using FluentAssertions;
+using Xunit;
+
+namespace Proto.Cluster.CodeGen.Tests
+{
+    public class OutputFileNameTests
+    {
+        [Fact]
+        public void CanGetOutputFileName()
+        {
+            var fileInfo = new FileInfo(@"Some\Namespace\Actors.proto");
+
+            var outputFileName = OutputFileName.GetOutputFileName(fileInfo);
+
+            outputFileName.Should().MatchRegex(@"Actors-[0-9A-F]+\.cs");
+        }
+        
+        [Fact]
+        public void CanGetOutputFileNameWithTemplate()
+        {
+            var inputFileInfo = new FileInfo(@"Some\Namespace\Actors.proto");
+            var templateFileInfo = new FileInfo(@"Some\Namespace\Template.cs");
+
+            var outputFileName = OutputFileName.GetOutputFileName(inputFileInfo, templateFileInfo);
+
+            outputFileName.Should().MatchRegex(@"Actors-[0-9A-F]+\.cs");
+        }
+
+        [Fact]
+        public void CanGetDifferentFileNamesForDifferentPaths()
+        {
+            var firstFileName = OutputFileName.GetOutputFileName(new FileInfo(@"First\Namespace\Actors.proto"));
+            var secondFileName = OutputFileName.GetOutputFileName(new FileInfo(@"Second\Namespace\Actors.proto"));
+
+            firstFileName.Should().NotBe(secondFileName);
+        }
+        
+        [Fact]
+        public void CanGetDifferentFileNamesForDifferentTemplates()
+        {
+            var inputFile = new FileInfo(@"First\Namespace\Actors.proto");
+            
+            var firstFileName = OutputFileName.GetOutputFileName(inputFile, new FileInfo(@"Some\Namespace\Template-1.cs"));
+            var secondFileName = OutputFileName.GetOutputFileName(inputFile, new FileInfo(@"Some\Namespace\Template-2.cs"));
+
+            firstFileName.Should().NotBe(secondFileName);
+        }
+    }
+}


### PR DESCRIPTION
## Description

`Proto.Cluster.CodeGen` works with `dotnet` and on Rider, but not on Visual Studio. VS will successfully build a project using codegen, but IDE will constantly show errors, which makes it almost unusable.

The reason for that are randomized generated `.cs` filenames. This fix makes generated filenames deterministic.

The fix was tested on:
- Windows
    - Visual Studio 2022
    - Visual Studio 2019
    - Rider
    - Visual Studio Code
    - `dotnet`
- Linux
    - `dotnet`

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
