### PR TITLE
Gossip consensus abstractions

### DIFF
--- a/benchmarks/HostedService/ProtoHost.cs
+++ b/benchmarks/HostedService/ProtoHost.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Proto;
 using Proto.Cluster;
+using Proto.Utils;
 
 namespace HostedService
 {
@@ -56,10 +57,10 @@ namespace HostedService
 
         private void OnStopping()
         {
-            var shutdown = _cluster.ShutdownAsync();
-            var timeout = Task.Delay(15000);
-            Task.WhenAny(shutdown, timeout).GetAwaiter().GetResult();
-            if (timeout.IsCompleted)
+            var completedInTime = _cluster.ShutdownAsync()
+                .WaitUpTo(TimeSpan.FromSeconds(15))
+                .GetAwaiter().GetResult();
+            if (!completedInTime)
                 _logger.LogError("Shut down cluster timed out...");
         }
     }

--- a/src/Proto.Actor/Utils/TaskExtensions.cs
+++ b/src/Proto.Actor/Utils/TaskExtensions.cs
@@ -11,17 +11,30 @@ namespace Proto.Utils
 {
     public static class TaskExtensions
     {
-        public static async Task<TResult> WithTimeout<TResult>(this Task<TResult> task, TimeSpan timeout)
+        public static async Task<TResult> WithTimeout<TResult>(this Task<TResult> task, TimeSpan timeout, CancellationToken? ct = null)
         {
-            using var timeoutCancellationTokenSource = new CancellationTokenSource();
+            using var timeoutCancellationTokenSource = ct is not null ? CancellationTokenSource.CreateLinkedTokenSource(ct.Value) : new CancellationTokenSource();
 
-            var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token));
+            var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token)).ConfigureAwait(false);
             if (completedTask != task) throw new TimeoutException("The operation has timed out.");
 
             timeoutCancellationTokenSource.Cancel();
             return await task; // Very important in order to propagate exceptions
         }
 
+        /// <summary>
+        /// Waits up to given timeout, returns (true,value) if task completed, (false, default) if it timed out
+        /// </summary>
+        public static async Task<(bool, TResult)> WaitUpTo<TResult>(this Task<TResult> task, TimeSpan timeout, CancellationToken? ct = null)
+        {
+            using var timeoutCancellationTokenSource = ct is not null ? CancellationTokenSource.CreateLinkedTokenSource(ct.Value) : new CancellationTokenSource();
+
+            var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token)).ConfigureAwait(false);
+            if (completedTask != task) return (false, default);
+
+            timeoutCancellationTokenSource.Cancel();
+            return (true, await task); // Very important in order to propagate exceptions
+        }
        
     }
 }

--- a/src/Proto.Actor/Utils/TaskExtensions.cs
+++ b/src/Proto.Actor/Utils/TaskExtensions.cs
@@ -13,28 +13,62 @@ namespace Proto.Utils
     {
         public static async Task<TResult> WithTimeout<TResult>(this Task<TResult> task, TimeSpan timeout, CancellationToken? ct = null)
         {
-            using var timeoutCancellationTokenSource = ct is not null ? CancellationTokenSource.CreateLinkedTokenSource(ct.Value) : new CancellationTokenSource();
+            if (!task.IsCompleted)
+            {
+                using var timeoutCancellationTokenSource =
+                    ct is not null ? CancellationTokenSource.CreateLinkedTokenSource(ct.Value) : new CancellationTokenSource();
 
-            var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token)).ConfigureAwait(false);
-            if (completedTask != task) throw new TimeoutException("The operation has timed out.");
+                var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token)).ConfigureAwait(false);
+                if (completedTask != task) throw new TimeoutException("The operation has timed out.");
 
-            timeoutCancellationTokenSource.Cancel();
-            return await task; // Very important in order to propagate exceptions
+                timeoutCancellationTokenSource.Cancel();
+            }
+
+            return await task.ConfigureAwait(false); // Very important in order to propagate exceptions
+        }
+
+        /// <summary>
+        /// Waits up to given timeout, returns true if task completed, false if it timed out
+        /// </summary>
+        public static async Task<bool> WaitUpTo(this Task task, TimeSpan timeout, CancellationToken? ct = null)
+        {
+            if (!task.IsCompleted)
+            {
+                using var timeoutCancellationTokenSource =
+                    ct is not null ? CancellationTokenSource.CreateLinkedTokenSource(ct.Value) : new CancellationTokenSource();
+
+                var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token)).ConfigureAwait(false);
+                if (completedTask != task) return false;
+
+                timeoutCancellationTokenSource.Cancel();
+            }
+
+            await task.ConfigureAwait(false); // Very important in order to propagate exceptions
+            return true;
         }
 
         /// <summary>
         /// Waits up to given timeout, returns (true,value) if task completed, (false, default) if it timed out
         /// </summary>
-        public static async Task<(bool, TResult)> WaitUpTo<TResult>(this Task<TResult> task, TimeSpan timeout, CancellationToken? ct = null)
+        public static async Task<(bool completed, TResult result)> WaitUpTo<TResult>(
+            this Task<TResult> task,
+            TimeSpan timeout,
+            CancellationToken? ct = null
+        )
         {
-            using var timeoutCancellationTokenSource = ct is not null ? CancellationTokenSource.CreateLinkedTokenSource(ct.Value) : new CancellationTokenSource();
+            if (!task.IsCompleted)
+            {
+                using var timeoutCancellationTokenSource =
+                    ct is not null ? CancellationTokenSource.CreateLinkedTokenSource(ct.Value) : new CancellationTokenSource();
 
-            var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token)).ConfigureAwait(false);
-            if (completedTask != task) return (false, default);
+                var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token)).ConfigureAwait(false);
+                if (completedTask != task) return (false, default);
 
-            timeoutCancellationTokenSource.Cancel();
-            return (true, await task); // Very important in order to propagate exceptions
+                timeoutCancellationTokenSource.Cancel();
+            }
+
+            var result = await task.ConfigureAwait(false); // Very important in order to propagate exceptions
+            return (true, result);
         }
-       
     }
 }

--- a/src/Proto.Cluster.Identity.Redis/RedisIdentityStorage.cs
+++ b/src/Proto.Cluster.Identity.Redis/RedisIdentityStorage.cs
@@ -14,7 +14,7 @@ using StackExchange.Redis;
 
 namespace Proto.Cluster.Identity.Redis
 {
-    public class RedisIdentityStorage : IIdentityStorage
+    public sealed class RedisIdentityStorage : IIdentityStorage
     {
         private static readonly ILogger Logger = Log.CreateLogger<RedisIdentityStorage>();
 

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -93,6 +93,7 @@ namespace Proto.Cluster
             await BeginStartAsync(false);
             //gossiper must be started whenever any topology events starts flowing
             await Gossip.StartAsync();
+            MemberList.InitializeTopologyConsensus();
             await Provider.StartMemberAsync(this);
             Logger.LogInformation("Started as cluster member");
             await MemberList.Started;

--- a/src/Proto.Cluster/Gossip/Consensus.cs
+++ b/src/Proto.Cluster/Gossip/Consensus.cs
@@ -1,0 +1,78 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ClusterConsensus.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Proto.Cluster.Gossip
+{
+    public interface IConsensusHandle<T> : IDisposable
+    {
+        Task<(bool consensus, T value)> TryGetConsensus(CancellationToken ct);
+        Task<(bool consensus, T value)> TryGetConsensus(TimeSpan maxWait, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Clear any current consensus to prevent stale reads
+        /// </summary>
+        public void TryResetConsensus();
+    }
+
+    internal class GossipConsensusHandle<T> : IConsensusHandle<T>
+    {
+        private TaskCompletionSource<T> _consensus = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private readonly Action _deregister;
+
+        public GossipConsensusHandle(Action deregister) => _deregister = deregister;
+
+        internal void TrySetConsensus(object consensus)
+        {
+            if (_consensus.Task.IsCompleted && _consensus.Task.Result?.Equals(consensus) != true)
+            {
+                TryResetConsensus();
+            }
+
+            //if not set, set it, if already set, keep it set
+            _consensus.TrySetResult((T) consensus);
+        }
+
+        public void TryResetConsensus()
+        {
+            //only replace if the task is completed
+            var current = _consensus;
+
+            if (current.Task.IsCompleted)
+            {
+                var taskCompletionSource = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+                Interlocked.CompareExchange(ref _consensus, taskCompletionSource, current);
+                
+            }
+        }
+
+        public async Task<(bool consensus, T value)> TryGetConsensus(CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var t = _consensus.Task;
+                // ReSharper disable once MethodSupportsCancellation
+                await Task.WhenAny(t, Task.Delay(500));
+                if (t.IsCompleted)
+                    return (true, t.Result);
+            }
+
+            return (false, default);
+        }
+        
+        public async Task<(bool consensus, T value)> TryGetConsensus(TimeSpan maxWait, CancellationToken cancellationToken)
+        {
+            var t = _consensus.Task;
+            await Task.WhenAny(t, Task.Delay(maxWait, cancellationToken)).ConfigureAwait(false);
+            return t.IsCompleted ? (true, t.Result) : (false, default);
+        }
+
+        public void Dispose() => _deregister();
+    }
+}

--- a/src/Proto.Cluster/Gossip/Consensus.cs
+++ b/src/Proto.Cluster/Gossip/Consensus.cs
@@ -15,11 +15,6 @@ namespace Proto.Cluster.Gossip
         Task<(bool consensus, T value)> TryGetConsensus(CancellationToken ct);
 
         Task<(bool consensus, T value)> TryGetConsensus(TimeSpan maxWait, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Clear any current consensus to prevent stale reads
-        /// </summary>
-        public void TryResetConsensus();
     }
 
     internal class GossipConsensusHandle<T> : IConsensusHandle<T>

--- a/src/Proto.Cluster/Gossip/ConsensusChecks.cs
+++ b/src/Proto.Cluster/Gossip/ConsensusChecks.cs
@@ -1,0 +1,99 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ConsensusState.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Proto.Cluster.Gossip
+{
+    
+    
+    internal record ConsensusCheck(string Id, Action<GossipState, ImmutableHashSet<string>, IContext> Check, string[] AffectedKeys);
+
+    
+    internal class ConsensusChecks
+    {
+        private readonly Dictionary<string, ConsensusCheck> _consensusChecks = new();
+        private readonly Dictionary<string, HashSet<string>> _affectedChecksByStateKey = new();
+
+        public IEnumerable<ConsensusCheck> Get => _consensusChecks.Values;
+
+        public IEnumerable<ConsensusCheck> GetByUpdatedKey(string key)
+        {
+            if (_affectedChecksByStateKey.TryGetValue(key, out var affectedIds))
+            {
+                return affectedIds.Select(id => _consensusChecks[id]);
+            }
+            return ImmutableList<ConsensusCheck>.Empty;
+        }
+        
+        public IEnumerable<ConsensusCheck> GetByUpdatedKeys(IEnumerable<string> keys)
+        {
+            var ids = new HashSet<string>();
+
+            foreach (var key in keys)
+            {
+                if (_affectedChecksByStateKey.TryGetValue(key, out var affectedIds))
+                {
+                    ids.UnionWith(affectedIds);
+                }
+            }
+
+            return ids.Select(id => _consensusChecks[id]);
+        }
+
+        
+        public void Add(ConsensusCheck consensusCheck)
+        {
+            _consensusChecks[consensusCheck.Id] = consensusCheck;
+            RegisterAffectedKeys(consensusCheck.Id, consensusCheck.AffectedKeys);
+        }
+        
+        public void Remove(string id)
+        {
+            if (_consensusChecks.Remove(id))
+            {
+                UnRegisterAffectedKeys(id);
+            }
+        }
+     
+        private void RegisterAffectedKeys(string id, string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (_affectedChecksByStateKey.TryGetValue(key, out var affectedIds))
+                {
+                    affectedIds.Add(id);
+                }
+                else
+                {
+                    _affectedChecksByStateKey[key] = new HashSet<string> {id};
+                }
+            }
+        }
+
+        private void UnRegisterAffectedKeys(string id)
+        {
+            var empty = new HashSet<string>();
+
+            foreach (var (key, ids) in _affectedChecksByStateKey)
+            {
+                if (ids.Remove(id) && ids.Count == 0)
+                {
+                    empty.Add(key);
+                }
+            }
+
+            foreach (var key in empty)
+            {
+                _affectedChecksByStateKey.Remove(key);
+            }
+        }
+
+
+    }
+}

--- a/src/Proto.Cluster/Gossip/Extensions.cs
+++ b/src/Proto.Cluster/Gossip/Extensions.cs
@@ -3,6 +3,8 @@
 //      Copyright (C) 2015-2021 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Collections.Generic;
+
 namespace Proto.Cluster.Gossip
 {
     public static class Extensions
@@ -14,7 +16,7 @@ namespace Proto.Cluster.Gossip
 
             return memberState.GetTopology();
         }
-        
+
         public static ClusterTopology? GetTopology(this GossipState.Types.GossipMemberState memberState)
         {
             if (!memberState.Values.TryGetValue("topology", out var entry))
@@ -22,6 +24,21 @@ namespace Proto.Cluster.Gossip
 
             var topology = entry.Value.Unpack<ClusterTopology>();
             return topology;
+        }
+
+        internal static (bool, T?) HasConsensus<T>(this IEnumerable<T?> enumerable)
+        {
+            using var enumerator = enumerable.GetEnumerator();
+            if (!enumerator.MoveNext() || enumerator.Current is null) return default;
+
+            var first = enumerator.Current;
+
+            while (enumerator.MoveNext())
+            {
+                if (enumerator.Current?.Equals(first) != true) return default;
+            }
+
+            return (true, first);
         }
     }
 }

--- a/src/Proto.Cluster/Gossip/GossipStateManagement.cs
+++ b/src/Proto.Cluster/Gossip/GossipStateManagement.cs
@@ -100,6 +100,7 @@ namespace Proto.Cluster.Gossip
             return sequenceNo;
         }
 
+        
         public static (ImmutableDictionary<string, long> pendingOffsets, GossipState state) FilterGossipStateForMember(
             GossipState state,
             ImmutableDictionary<string, long> offsets,
@@ -143,9 +144,8 @@ namespace Proto.Cluster.Gossip
                 if (newMemberState.Values.Count > 0)
                 {
                     newState.Members.Add(memberId, newMemberState);
+                    pendingOffsets = pendingOffsets.SetItem(watermarkKey, newWatermark);
                 }
-
-                pendingOffsets = pendingOffsets.SetItem(watermarkKey, newWatermark);
             }
 
             //make sure to clone to make it a separate copy, avoid race conditions on mutate
@@ -166,7 +166,7 @@ namespace Proto.Cluster.Gossip
             string myId,
             ImmutableHashSet<string> members,
             string valueKey,
-            Func<T, TV> extractValue    
+            Func<T, TV> extractValue
         ) where T : IMessage, new()
         {
             var logger = ctx?.Logger()?.BeginMethodScope();

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -4,7 +4,10 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
@@ -13,15 +16,25 @@ using Proto.Logging;
 
 namespace Proto.Cluster.Gossip
 {
+    public delegate (bool, T) ConsensusCheck<T>(GossipState state, IImmutableSet<string> memberIds, IContext context);
+
     public record GossipUpdate(string MemberId, string Key, Any Value, long SequenceNumber);
+
     public record GetGossipStateRequest(string Key);
 
-    public record GetGossipStateResponse(ImmutableDictionary<string,Any> State);
+    public record GetGossipStateResponse(ImmutableDictionary<string, Any> State);
 
     public record SetGossipStateKey(string Key, IMessage Value);
 
+    public record SetGossipStateResponse;
+
     public record SendGossipStateRequest;
+
     public record SendGossipStateResponse;
+
+    internal record AddConsensusCheck(ConsensusCheck Check);
+
+    internal record RemoveConsensusCheck(string Id);
 
     public class Gossiper
     {
@@ -38,7 +51,7 @@ namespace Proto.Cluster.Gossip
             _context = _cluster.System.Root;
         }
 
-        public async Task<ImmutableDictionary<string,T>> GetState<T>(string key) where T : IMessage, new()
+        public async Task<ImmutableDictionary<string, T>> GetState<T>(string key) where T : IMessage, new()
         {
             _context.System.Logger()?.LogDebug("Gossiper getting state from {Pid}", _pid);
 
@@ -51,28 +64,46 @@ namespace Proto.Cluster.Gossip
             {
                 typed = typed.SetItem(k, value.Unpack<T>());
             }
-            
+
             return typed;
         }
 
+        // Send message to update member state
+        // Will not wait for completed state update
         public void SetState(string key, IMessage value)
         {
             Logger.LogDebug("Gossiper setting state to {Pid}", _pid);
             _context.System.Logger()?.LogDebug("Gossiper setting state to {Pid}", _pid);
+
             if (_pid == null)
             {
                 return;
             }
-            
+
             _context.Send(_pid, new SetGossipStateKey(key, value));
+        }
+
+        public Task SetStateAsync(string key, IMessage value)
+        {
+            Logger.LogDebug("Gossiper setting state to {Pid}", _pid);
+            _context.System.Logger()?.LogDebug("Gossiper setting state to {Pid}", _pid);
+
+            if (_pid == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            return _context.RequestAsync<SetGossipStateResponse>(_pid, new SetGossipStateKey(key, value));
         }
 
         internal Task StartAsync()
         {
             var props = Props.FromProducer(() => new GossipActor(_cluster.Config.GossipRequestTimeout));
             _pid = _context.SpawnNamed(props, GossipActorName);
+            _cluster.System.EventStream.Subscribe<ClusterTopology>(topology => _context.Send(_pid, topology));
             Logger.LogInformation("Started Cluster Gossip");
             _ = SafeTask.Run(GossipLoop);
+
             return Task.CompletedTask;
         }
 
@@ -80,15 +111,14 @@ namespace Proto.Cluster.Gossip
         {
             Logger.LogInformation("Starting gossip loop");
             await Task.Yield();
-        
+
             while (!_cluster.System.Shutdown.IsCancellationRequested)
             {
                 try
                 {
-                    await Task.Delay((int)_cluster.Config.GossipInterval.TotalMilliseconds);
+                    await Task.Delay((int) _cluster.Config.GossipInterval.TotalMilliseconds);
                     SetState("heartbeat", new MemberHeartbeat());
                     await SendStateAsync();
-                    
                 }
                 catch (Exception x)
                 {
@@ -97,9 +127,148 @@ namespace Proto.Cluster.Gossip
             }
         }
 
+        public class ConsensusCheckBuilder<T>
+        {
+            private readonly ImmutableList<(string, Func<Any, T?>)> _getConsensusValues;
+
+            private readonly Lazy<ConsensusCheck<T>> _check;
+            public ConsensusCheck<T> Check => _check.Value;
+
+            public string[] AffectedKeys => _getConsensusValues.Select(it => it.Item1).Distinct().ToArray();
+
+            private ConsensusCheckBuilder(ImmutableList<(string, Func<Any, T?>)> getValues)
+            {
+                _getConsensusValues = getValues;
+                _check = new Lazy<ConsensusCheck<T>>(Build);
+            }
+
+            public ConsensusCheckBuilder(string key, Func<Any, T?> getValue)
+            {
+                _getConsensusValues = ImmutableList.Create<(string, Func<Any, T?>)>((key, getValue));
+                _check = new Lazy<ConsensusCheck<T>>(this.Build, LazyThreadSafetyMode.PublicationOnly);
+            }
+
+            public static ConsensusCheckBuilder<T> Create<TE>(string key, Func<TE, T?> getValue) where TE : IMessage, new()
+                => new(key, MapFromAny(getValue));
+
+            private static Func<Any, T?> MapFromAny<TE>(Func<TE, T?> getValue) where TE : IMessage, new()
+                => any => any.TryUnpack<TE>(out var envelope) ? getValue(envelope) : default;
+
+            public ConsensusCheckBuilder<T> InConsensusWith<TE>(string key, Func<TE, T> getValue) where TE : IMessage, new()
+                => new(_getConsensusValues.Add((key, MapFromAny(getValue))));
+
+            private static Func<KeyValuePair<string, GossipState.Types.GossipMemberState>, (string member, string key, T value)> MapToValue(
+                (string, Func<Any, T?>) valueTuple
+            )
+            {
+                var (key, unpack) = valueTuple;
+                return (kv) => {
+                    var (member, state) = kv;
+                    var value = state.Values.TryGetValue(key, out var any) ? unpack(any.Value) : default;
+                    return (member, key, value);
+                };
+            }
+
+            private ConsensusCheck<T> Build()
+            {
+                if (_getConsensusValues.Count == 1)
+                {
+                    var mapToValue = MapToValue(_getConsensusValues.Single());
+                    return (state, ids, context) => {
+                        var memberStates = GetValidMemberStates(state, ids);
+
+                        // Missing state, cannot have consensus
+                        if (memberStates.Length < ids.Count)
+                        {
+                            return default;
+                        }
+
+                        var valueTuples = memberStates.Select(mapToValue);
+                        // ReSharper disable PossibleMultipleEnumeration
+                        var result = valueTuples.Select(it => it.value).HasConsensus();
+
+                        if (context.System.Config.DeveloperSupervisionLogging)
+                        {
+                            Logger.LogDebug("{SystemId}, consensus {Consensus}: {Values}", context.System.Id, result.Item1, valueTuples
+                                .GroupBy(it => (it.key, it.value), tuple => tuple.member).Select(
+                                    grouping => $"{grouping.Key.key}:{grouping.Key.value}, " +
+                                                (grouping.Count() > 1 ? grouping.Count() + " nodes" : grouping.First())
+                                )
+                            );
+                        }
+
+                        return result;
+                    };
+                }
+
+                var mappers = _getConsensusValues.Select(MapToValue).ToArray();
+
+                return (state, ids, context) => {
+                    var memberStates = GetValidMemberStates(state, ids);
+
+                    if (memberStates.Length < ids.Count) // Not all members have state..
+                    {
+                        return default;
+                    }
+
+                    var valueTuples = memberStates
+                        .SelectMany(memberState => mappers.Select(mapper => mapper(memberState)));
+                    var consensus = valueTuples.Select(it => it.value).HasConsensus();
+
+                    if (context.System.Config.DeveloperSupervisionLogging)
+                    {
+                        Logger.LogDebug("{SystemId}, consensus {Consensus}: {Values}", context.System.Id, consensus.Item1, valueTuples
+                            .GroupBy(it => (it.key, it.value), tuple => tuple.member).Select(
+                                grouping => $"{grouping.Key.key}:{grouping.Key.value}, " +
+                                            (grouping.Count() > 1 ? grouping.Count() + " nodes" : grouping.First())
+                            )
+                        );
+                    }
+
+                    // ReSharper enable PossibleMultipleEnumeration
+                    return consensus;
+                };
+
+                KeyValuePair<string, GossipState.Types.GossipMemberState>[] GetValidMemberStates(GossipState state, IImmutableSet<string> ids)
+                    => state.Members
+                        .Where(member => ids.Contains(member.Key))
+                        .Select(member => member).ToArray();
+            }
+        }
+
+        public IConsensusHandle<TV> RegisterConsensusCheck<T, TV>(string key, Func<T, TV?> getValue) where T : IMessage, new()
+            => RegisterConsensusCheck(ConsensusCheckBuilder<TV>.Create(key, getValue));
+
+        public IConsensusHandle<T> RegisterConsensusCheck<T>(ConsensusCheckBuilder<T> builder)
+            => RegisterConsensusCheck(builder.Check, builder.AffectedKeys);
+
+        public IConsensusHandle<T> RegisterConsensusCheck<T>(ConsensusCheck<T> hasConsensus, string[] affectedKeys)
+        {
+            var id = Guid.NewGuid().ToString("N");
+            var handle = new GossipConsensusHandle<T>(() => _context.Send(_pid, new RemoveConsensusCheck(id))
+            );
+
+            _context.Send(_pid, new AddConsensusCheck(new ConsensusCheck(id, CheckConsensus, affectedKeys)));
+
+            return handle;
+
+            void CheckConsensus(GossipState state, IImmutableSet<string> members, IContext context)
+            {
+                var (consensus, value) = hasConsensus(state, members, context);
+
+                if (consensus)
+                {
+                    handle.TrySetConsensus(value!);
+                }
+                else
+                {
+                    handle.TryResetConsensus();
+                }
+            }
+        }
+
         private async Task SendStateAsync()
         {
-            
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
             if (_pid == null)
             {

--- a/src/Proto.Cluster/GossipContracts.proto
+++ b/src/Proto.Cluster/GossipContracts.proto
@@ -13,6 +13,9 @@ message GossipResponse {
   GossipState state = 1;
 }
 
+message GossipResponseAck { // Or just use empty GossipResponse?
+}
+
 //two GossipState objects can be merged
 //key + member_id gets it's own entry, if collision, highest version is selected
 message GossipState {

--- a/tests/Proto.Actor.Tests/PoisonTests.cs
+++ b/tests/Proto.Actor.Tests/PoisonTests.cs
@@ -3,6 +3,7 @@
 //      Copyright (C) 2015-2020 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
+using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
@@ -25,7 +26,7 @@ namespace Proto.Tests
         public async Task PoisonReturnsIfPidDoesNotExist()
         {
             var deadPid = PID.FromAddress(System.Address, "nowhere");
-            var timeout = Task.Delay(2000);
+            var timeout = Task.Delay(TimeSpan.FromSeconds(10));
 
             var poisonTask = Context.PoisonAsync(deadPid);
 
@@ -42,7 +43,7 @@ namespace Proto.Tests
             const string message = "hello";
             (await Context.RequestAsync<string>(pid, message)).Should().Be(message);
 
-            var timeout = Task.Delay(5000);
+            var timeout = Task.Delay(TimeSpan.FromSeconds(10));
             var poisonTask = Context.PoisonAsync(pid);
             await Task.WhenAny(timeout, poisonTask);
 

--- a/tests/Proto.Cluster.Tests/GossipTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTests.cs
@@ -1,0 +1,178 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="GossipTests.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2021 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClusterTest.Messages;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Proto.Cluster.Gossip;
+using Proto.Logging;
+using Xunit;
+
+namespace Proto.Cluster.Tests
+{
+    public class GossipTests
+    {
+        // private readonly ITestOutputHelper _testOutputHelper;
+        //
+        // protected GossipTests(ITestOutputHelper testOutputHelper) => _testOutputHelper = testOutputHelper;
+
+        private const string GossipStateKey = "test-state";
+        private const string TopologyStateKey = "topology-test-state";
+
+        [Fact]
+        public async Task CanGetConsensus()
+        {
+            await using var clusterFixture = new InMemoryClusterFixture();
+            await clusterFixture.InitializeAsync().ConfigureAwait(false);
+
+            const string initialValue = "hello consensus";
+
+            var fixtureMembers = clusterFixture.Members;
+            var consensusChecks = fixtureMembers.Select(CreateConsensusCheck).ToList();
+
+            SetGossipState(fixtureMembers, initialValue);
+
+            await ShouldBeInConsensusAboutValue(consensusChecks, initialValue);
+        }
+
+        [Fact]
+        public async Task CompositeConsensusWorks()
+        {
+            await using var clusterFixture = new InMemoryClusterFixture();
+            await clusterFixture.InitializeAsync().ConfigureAwait(false);
+
+            var (consensus, initialTopologyHash) =
+                await clusterFixture.Members.First().MemberList.TopologyConsensus(CancellationTokens.FromSeconds(5));
+            consensus.Should().BeTrue();
+
+            var fixtureMembers = clusterFixture.Members;
+            var consensusChecks = fixtureMembers.Select(CreateCompositeConsensusCheck).ToList();
+
+            var firstNodeCheck = consensusChecks[0];
+            var notConsensus = await firstNodeCheck.TryGetConsensus(TimeSpan.FromMilliseconds(200), CancellationTokens.FromSeconds(1));
+
+            notConsensus.consensus.Should().BeFalse("We have not set the correct topology hash in the state yet");
+
+            SetTopologyGossipState(fixtureMembers, initialTopologyHash);
+
+            var afterSettingMatchingState = await firstNodeCheck.TryGetConsensus(TimeSpan.FromMilliseconds(500), CancellationTokens.FromSeconds(1));
+
+            afterSettingMatchingState.consensus.Should().BeTrue("After assigning the matching topology hash, there should be consensus");
+            afterSettingMatchingState.value.Should().Be(initialTopologyHash);
+
+            await clusterFixture.SpawnNode();
+            await Task.Delay(300); // Allow topology state to propagate
+
+            var afterChangingTopology =
+                await firstNodeCheck.TryGetConsensus(TimeSpan.FromMilliseconds(200), CancellationTokens.FromSeconds(1));
+
+            afterChangingTopology.consensus.Should().BeFalse("The state does no longer match the current topology");
+        }
+
+        [Fact]
+        public async Task CanFallOutOfConsensus()
+        {
+            await using var clusterFixture = new InMemoryClusterFixture();
+            await clusterFixture.InitializeAsync();
+
+            const string initialValue = "hello consensus";
+            const string otherValue = "hi";
+
+            var consensusChecks = clusterFixture.Members.Select(CreateConsensusCheck).ToList();
+
+            SetGossipState(clusterFixture.Members, initialValue);
+
+            await ShouldBeInConsensusAboutValue(consensusChecks, initialValue);
+
+            var firstMember = clusterFixture.Members[0];
+            var firstMemberConsensus = consensusChecks[0];
+
+            var logStore = new LogStore();
+            firstMember.System.Extensions.Register(new InstanceLogger(LogLevel.Debug, logStore));
+
+            // Sets a now inconsistent state on the first node
+            firstMember.Gossip.SetState(GossipStateKey, new SomeGossipState {Key = otherValue});
+
+            var afterSettingDifferingState = await GetCurrentConsensus(firstMember, TimeSpan.FromMilliseconds(500));
+
+            afterSettingDifferingState.Should()
+                .BeEquivalentTo((false, (string) null), "We should be able to read our writes, and locally we do not have consensus");
+
+            await Task.Delay(300);
+            await ShouldBeNotHaveConsensus(consensusChecks);
+        }
+
+        private static async Task ShouldBeInConsensusAboutValue(List<IConsensusHandle<string>> consensusChecks, string initialValue)
+        {
+            var results = await Task.WhenAll(consensusChecks.Select(it => it.TryGetConsensus(CancellationTokens.FromSeconds(1))))
+                .ConfigureAwait(false);
+
+            foreach (var (consensus, consensusValue) in results)
+            {
+                consensus.Should().BeTrue("Since all nodes have the same value, they should agree on a consensus");
+
+                consensusValue.Should().Be(initialValue);
+            }
+        }
+
+        [Fact]
+        private void EnumerableExtensionIsCorrect()
+        {
+            new[] {1, 2, 3}.HasConsensus().Item1.Should().BeFalse();
+            new[] {1, 1, 1}.HasConsensus().Item1.Should().BeTrue();
+            new int[] { }.HasConsensus().Item1.Should().BeFalse();
+        }
+
+        private static async Task ShouldBeNotHaveConsensus(List<IConsensusHandle<string>> consensusChecks)
+        {
+            var results = await Task.WhenAll(consensusChecks.Select(it => it.TryGetConsensus(CancellationTokens.FromSeconds(1))))
+                .ConfigureAwait(false);
+
+            foreach (var (consensus, _) in results)
+            {
+                consensus.Should().BeFalse("The cluster is not in consensus");
+            }
+        }
+
+        private static void SetGossipState(IList<Cluster> members, string value)
+        {
+            foreach (var member in members)
+            {
+                member.Gossip.SetState(GossipStateKey, new SomeGossipState {Key = value});
+            }
+        }
+
+        private static void SetTopologyGossipState(IList<Cluster> members, ulong value)
+        {
+            foreach (var member in members)
+            {
+                member.Gossip.SetState(TopologyStateKey, new SomeTopologyGossipState {TopologyHash = value});
+            }
+        }
+
+        private static IConsensusHandle<string> CreateConsensusCheck(Cluster member) => member.Gossip.RegisterConsensusCheck<SomeGossipState, string>(
+            GossipStateKey,
+            rebalance => rebalance.Key
+        );
+
+        private static IConsensusHandle<ulong> CreateCompositeConsensusCheck(Cluster member) =>
+            member.Gossip.RegisterConsensusCheck<ulong>(Gossiper.ConsensusCheckBuilder<ulong>
+                .Create<SomeTopologyGossipState>(TopologyStateKey, state => state.TopologyHash)
+                .InConsensusWith<ClusterTopology>("topology", topology => topology.TopologyHash)
+            );
+
+        private static async Task<(bool consensus, string value)> GetCurrentConsensus(Cluster member, TimeSpan timeout)
+        {
+            using var check = CreateConsensusCheck(member);
+
+            return await check.TryGetConsensus(timeout, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Proto.Cluster.Tests/GossipTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTests.cs
@@ -63,7 +63,7 @@ namespace Proto.Cluster.Tests
 
             await SetTopologyGossipStateAsync(fixtureMembers, initialTopologyHash);
 
-            var afterSettingMatchingState = await firstNodeCheck.TryGetConsensus(TimeSpan.FromSeconds(10), timeout);
+            var afterSettingMatchingState = await firstNodeCheck.TryGetConsensus(TimeSpan.FromSeconds(20), timeout);
 
             afterSettingMatchingState.consensus.Should().BeTrue("After assigning the matching topology hash, there should be consensus");
             afterSettingMatchingState.value.Should().Be(initialTopologyHash);

--- a/tests/Proto.Cluster.Tests/GossipTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTests.cs
@@ -62,16 +62,16 @@ namespace Proto.Cluster.Tests
 
             SetTopologyGossipState(fixtureMembers, initialTopologyHash);
 
-            var afterSettingMatchingState = await firstNodeCheck.TryGetConsensus(TimeSpan.FromMilliseconds(500), CancellationTokens.FromSeconds(1));
+            var afterSettingMatchingState = await firstNodeCheck.TryGetConsensus(TimeSpan.FromMilliseconds(3000), CancellationTokens.FromSeconds(1));
 
             afterSettingMatchingState.consensus.Should().BeTrue("After assigning the matching topology hash, there should be consensus");
             afterSettingMatchingState.value.Should().Be(initialTopologyHash);
 
             await clusterFixture.SpawnNode();
-            await Task.Delay(300); // Allow topology state to propagate
+            await Task.Delay(1000); // Allow topology state to propagate
 
             var afterChangingTopology =
-                await firstNodeCheck.TryGetConsensus(TimeSpan.FromMilliseconds(200), CancellationTokens.FromSeconds(1));
+                await firstNodeCheck.TryGetConsensus(TimeSpan.FromMilliseconds(500), CancellationTokens.FromSeconds(1));
 
             afterChangingTopology.consensus.Should().BeFalse("The state does no longer match the current topology");
         }

--- a/tests/Proto.Cluster.Tests/GossipTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTests.cs
@@ -48,6 +48,8 @@ namespace Proto.Cluster.Tests
             await using var clusterFixture = new InMemoryClusterFixture();
             await clusterFixture.InitializeAsync().ConfigureAwait(false);
 
+            await Task.Delay(TimeSpan.FromSeconds(1)); // Tolerate slow CI servers
+            
             var (consensus, initialTopologyHash) =
                 await clusterFixture.Members.First().MemberList.TopologyConsensus(CancellationTokens.FromSeconds(5));
             consensus.Should().BeTrue();
@@ -62,13 +64,13 @@ namespace Proto.Cluster.Tests
 
             await SetTopologyGossipStateAsync(fixtureMembers, initialTopologyHash);
 
-            var afterSettingMatchingState = await firstNodeCheck.TryGetConsensus(TimeSpan.FromMilliseconds(3000), CancellationTokens.FromSeconds(1));
+            var afterSettingMatchingState = await firstNodeCheck.TryGetConsensus(TimeSpan.FromSeconds(10), CancellationTokens.FromSeconds(1));
 
             afterSettingMatchingState.consensus.Should().BeTrue("After assigning the matching topology hash, there should be consensus");
             afterSettingMatchingState.value.Should().Be(initialTopologyHash);
 
             await clusterFixture.SpawnNode();
-            await Task.Delay(1000); // Allow topology state to propagate
+            await Task.Delay(2000); // Allow topology state to propagate
 
             var afterChangingTopology =
                 await firstNodeCheck.TryGetConsensus(TimeSpan.FromMilliseconds(500), CancellationTokens.FromSeconds(1));

--- a/tests/Proto.Cluster.Tests/GossipTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTests.cs
@@ -49,6 +49,8 @@ namespace Proto.Cluster.Tests
             await using var clusterFixture = new InMemoryClusterFixture();
             await clusterFixture.InitializeAsync().ConfigureAwait(false);
 
+            await Task.Delay(1000);
+            
             var (consensus, initialTopologyHash) =
                 await clusterFixture.Members.First().MemberList.TopologyConsensus(timeout);
             consensus.Should().BeTrue();

--- a/tests/Proto.Cluster.Tests/GossipTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTests.cs
@@ -48,8 +48,6 @@ namespace Proto.Cluster.Tests
             await using var clusterFixture = new InMemoryClusterFixture();
             await clusterFixture.InitializeAsync().ConfigureAwait(false);
 
-            await Task.Delay(TimeSpan.FromSeconds(1)); // Tolerate slow CI servers
-            
             var (consensus, initialTopologyHash) =
                 await clusterFixture.Members.First().MemberList.TopologyConsensus(CancellationTokens.FromSeconds(5));
             consensus.Should().BeTrue();
@@ -102,7 +100,7 @@ namespace Proto.Cluster.Tests
             // Sets a now inconsistent state on the first node
             await firstMember.Gossip.SetStateAsync(GossipStateKey, new SomeGossipState {Key = otherValue});
 
-            var afterSettingDifferingState = await GetCurrentConsensus(firstMember, TimeSpan.FromMilliseconds(3000));
+            var afterSettingDifferingState = await GetCurrentConsensus(firstMember, TimeSpan.FromMilliseconds(2000));
 
             afterSettingDifferingState.Should()
                 .BeEquivalentTo((false, (string) null), "We should be able to read our writes, and locally we do not have consensus");

--- a/tests/Proto.Cluster.Tests/GossipTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTests.cs
@@ -100,18 +100,18 @@ namespace Proto.Cluster.Tests
             // Sets a now inconsistent state on the first node
             firstMember.Gossip.SetState(GossipStateKey, new SomeGossipState {Key = otherValue});
 
-            var afterSettingDifferingState = await GetCurrentConsensus(firstMember, TimeSpan.FromMilliseconds(500));
+            var afterSettingDifferingState = await GetCurrentConsensus(firstMember, TimeSpan.FromMilliseconds(3000));
 
             afterSettingDifferingState.Should()
                 .BeEquivalentTo((false, (string) null), "We should be able to read our writes, and locally we do not have consensus");
 
-            await Task.Delay(300);
+            await Task.Delay(1000);
             await ShouldBeNotHaveConsensus(consensusChecks);
         }
 
         private static async Task ShouldBeInConsensusAboutValue(List<IConsensusHandle<string>> consensusChecks, string initialValue)
         {
-            var results = await Task.WhenAll(consensusChecks.Select(it => it.TryGetConsensus(CancellationTokens.FromSeconds(1))))
+            var results = await Task.WhenAll(consensusChecks.Select(it => it.TryGetConsensus(CancellationTokens.FromSeconds(2))))
                 .ConfigureAwait(false);
 
             foreach (var (consensus, consensusValue) in results)

--- a/tests/Proto.Cluster.Tests/messages.proto
+++ b/tests/Proto.Cluster.Tests/messages.proto
@@ -51,3 +51,11 @@ message AggregatorResult{
   int32 sequence_key_count = 3;
   int32 sender_key_count = 4;
 }
+
+message SomeGossipState{
+  string key = 1;
+}
+
+message SomeTopologyGossipState{
+  uint64 topology_hash = 1;
+}


### PR DESCRIPTION
Adds the ability to register new consensus checks on demand.

This is useful when the cluster needs to agree on an event happening on all nodes, ex the topology is in consensus or all nodes are in a certain state.

Initial draft only implements full consensus since that is what is used internally.