### PR TITLE
Added Root serialization for identity handovers

### DIFF
--- a/src/Proto.Cluster/ClusterContracts.proto
+++ b/src/Proto.Cluster/ClusterContracts.proto
@@ -19,12 +19,40 @@ message IdentityHandoverResponse {
   uint64 topology_hash = 4;
 }
 
+message RemoteIdentityHandoverResponse {
+  PackedActivations actors = 1;
+  int32 chunk_id = 2;
+  bool final = 3;
+  uint64 topology_hash = 4;
+}
+
 message IdentityHandover {
   repeated Activation actors = 1;
   uint32 chunk_id = 2;
   bool final = 3;
   uint64 topology_hash = 4;
   uint32 skipped = 5;
+}
+
+message RemoteIdentityHandover {
+  PackedActivations actors = 1;
+  uint32 chunk_id = 2;
+  bool final = 3;
+  uint64 topology_hash = 4;
+  uint32 skipped = 5;
+}
+
+message PackedActivations{
+  string address = 1;
+  repeated Kind actors = 2;
+  message Kind{
+    string name = 1;
+    repeated Activation activations = 2;
+  }
+  message Activation{
+    string identity = 1;
+    string activation_id = 2;
+  }
 }
 
 message IdentityHandoverAck {

--- a/src/Proto.Cluster/Messages/Messages.cs
+++ b/src/Proto.Cluster/Messages/Messages.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Google.Protobuf;
+using Proto.Remote;
 
 // ReSharper disable once CheckNamespace
 namespace Proto.Cluster
@@ -43,13 +44,97 @@ namespace Proto.Cluster
         public string Identity => ClusterIdentity.Identity;
     }
 
+    public sealed partial class IdentityHandoverResponse : IRootSerializable
+    {
+        public IRootSerialized Serialize(ActorSystem system) =>
+            new RemoteIdentityHandoverResponse
+            {
+                Actors = PackedActivations.Pack(system.Address, Actors),
+                TopologyHash = TopologyHash,
+                Final = Final,
+                ChunkId = ChunkId
+            };
+    }
+
+    public sealed partial class RemoteIdentityHandoverResponse : IRootSerialized
+    {
+        public IRootSerializable Deserialize(ActorSystem system) => new IdentityHandoverResponse
+        {
+            TopologyHash = TopologyHash,
+            Final = Final,
+            ChunkId = ChunkId,
+            Actors = {Actors.UnPack()}
+        };
+    }
+    
+    public sealed partial class IdentityHandover : IRootSerializable
+    {
+        public IRootSerialized Serialize(ActorSystem system) =>
+            new RemoteIdentityHandover
+            {
+                Actors = PackedActivations.Pack(system.Address, Actors),
+                TopologyHash = TopologyHash,
+                Final = Final,
+                Skipped = Skipped,
+                ChunkId = ChunkId
+            };
+    }
+
+    public sealed partial class RemoteIdentityHandover : IRootSerialized
+    {
+        public IRootSerializable Deserialize(ActorSystem system) => new IdentityHandover
+        {
+            TopologyHash = TopologyHash,
+            Final = Final,
+            Skipped = Skipped,
+            ChunkId = ChunkId,
+            Actors = {Actors.UnPack()}
+        };
+    }
+
+    public sealed partial class PackedActivations
+    {
+        public IEnumerable<Activation> UnPack() => Actors.SelectMany(UnpackKind);
+
+        private IEnumerable<Activation> UnpackKind(Types.Kind kind)
+            => kind.Activations.Select(packed => new Activation
+                {
+                    ClusterIdentity = ClusterIdentity.Create(packed.Identity, kind.Name),
+                    Pid = PID.FromAddress(Address, packed.ActivationId)
+                }
+            );
+
+        public static PackedActivations Pack(string address, IEnumerable<Activation> activations) => new()
+        {
+            Address = address,
+            Actors = {PackActivations(activations)}
+        };
+
+        private static IEnumerable<Types.Kind> PackActivations(IEnumerable<Activation> activations)
+            => activations.GroupBy(it => it.Kind)
+                .Select(grouping => new Types.Kind
+                    {
+                        Name = grouping.Key,
+                        Activations =
+                        {
+                            grouping.Select(activation => new PackedActivations.Types.Activation
+                                {
+                                    Identity = activation.Identity,
+                                    ActivationId = activation.Pid.Id
+                                }
+                            )
+                        }
+                    }
+                );
+    }
+
     public record Tick;
 
     public partial class ClusterTopology
     {
         //this ignores joined and left members, only the actual members are relevant
         public uint GetMembershipHashCode() => Member.TopologyHash(Members);
-        
+
         /// <summary>
         /// Topology based logic (IE partition based) can use this token to cancel any work when this topology is no longer valid
         /// </summary>

--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -286,9 +286,6 @@ namespace Proto.Cluster.Partition
                 Console.WriteLine($"{context.System.Id}: Got ownerships {msg.TopologyHash} / {_topologyHash}");
             }
 
-            //remove all identities we do no longer own.
-            _partitionLookup.Clear();
-
             Logger.LogInformation("{SystemId} Got  ownerships of {Count} activations, for topology {TopologyHash}, ", context.System.Id,
                 msg.OwnedActivations.Count, _topologyHash
             );
@@ -310,11 +307,7 @@ namespace Proto.Cluster.Partition
 
             var existingActivation = _partitionLookup[clusterIdentity];
 
-            if (existingActivation.Equals(activation))
-            {
-                Logger.LogDebug("Got the same activations twice {ClusterIdentity}: {Activation}", clusterIdentity, existingActivation);
-            }
-            else
+            if (!existingActivation.Equals(activation))
             {
                 // Already present, duplicate?
                 Logger.LogError("Got duplicate activations of {ClusterIdentity}: {Activation1}, {Activation2}",
@@ -323,6 +316,10 @@ namespace Proto.Cluster.Partition
                     activation
                 );
             }
+            // else
+            // {
+            //     Logger.LogDebug("Got the same activations twice {ClusterIdentity}: {Activation}", clusterIdentity, existingActivation);
+            // }
         }
 
         private Task OnActivationTerminated(ActivationTerminated msg)

--- a/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
@@ -23,7 +23,7 @@ namespace Proto.Cluster.Partition
         private readonly PartitionConfig _config;
         private EventStreamSubscription<object>? _subscription;
 
-        private ClusterTopology? _lastRebalancedTopology = null;
+        private ClusterTopology? _lastRebalancedTopology;
 
         public PartitionPlacementActor(Cluster cluster, PartitionConfig config)
         {
@@ -128,7 +128,6 @@ namespace Proto.Cluster.Partition
             private readonly IContext _context;
             private readonly ClusterTopology _topology;
             private readonly int _chunkSize;
-            private readonly bool _isLocal;
 
             private IdentityHandover _identityHandover;
             private uint _chunkId;
@@ -140,7 +139,6 @@ namespace Proto.Cluster.Partition
                 _topology = msg;
                 _chunkSize = config.HandoverChunkSize;
                 _target = PartitionManager.RemotePartitionIdentityActor(member.Address);
-                _isLocal = member.Address.Equals(context.System.Address, StringComparison.OrdinalIgnoreCase);
                 _identityHandover = new IdentityHandover
                 {
                     ChunkId = ++_chunkId,

--- a/tests/Proto.Cluster.Tests/ClusterFixture.cs
+++ b/tests/Proto.Cluster.Tests/ClusterFixture.cs
@@ -164,7 +164,7 @@ namespace Proto.Cluster.Tests
         protected abstract IClusterProvider GetClusterProvider();
 
         protected virtual IIdentityLookup GetIdentityLookup(string clusterName) => new PartitionIdentityLookup(TimeSpan.FromSeconds(3),
-            TimeSpan.FromSeconds(2), new PartitionConfig(true, 1000, TimeSpan.FromSeconds(1), PartitionIdentityLookup.Mode.Push)
+            TimeSpan.FromSeconds(2), new PartitionConfig(false, 1000, TimeSpan.FromSeconds(1), PartitionIdentityLookup.Mode.Push)
         );
 
         async ValueTask IAsyncDisposable.DisposeAsync() => await DisposeAsync();


### PR DESCRIPTION
This utilizes the natural duplication in the messages and avoids duplicate values like address and kind, which otherwise would be need to be serialized for every activation.

End result here should be smaller serialized payloads and faster partition rebalancing when we have a lot of activations.