### PR TITLE
Fix for #1339, CodeGen path generation

### DIFF
--- a/src/Proto.Cluster.CodeGen/PathPolyfill.cs
+++ b/src/Proto.Cluster.CodeGen/PathPolyfill.cs
@@ -58,8 +58,6 @@ namespace Proto.Cluster.CodeGen
             var fullPath = Path.GetFullPath(path+Path.DirectorySeparatorChar);
             var pathWithDirectorySeparatorChar = AppendDirectorySeparatorChar(fullPath);
 
-            var uriBuilder = new UriBuilder(pathWithDirectorySeparatorChar);
-
             return new Uri(pathWithDirectorySeparatorChar);
         }
 

--- a/src/Proto.Cluster.CodeGen/PathPolyfill.cs
+++ b/src/Proto.Cluster.CodeGen/PathPolyfill.cs
@@ -25,7 +25,8 @@ namespace Proto.Cluster.CodeGen
                 throw new ArgumentException("value cannot be null or empty", nameof(path));
             }
 
-            var relativeToUri = GetUri(relativeTo);
+            var relativeToUri = GetUri(relativeTo.EndsWith(Path.DirectorySeparatorChar.ToString())? relativeTo : relativeTo+Path.DirectorySeparatorChar);
+
             var pathUri = GetUri(path);
 
             if (relativeToUri.Scheme != pathUri.Scheme)
@@ -54,8 +55,10 @@ namespace Proto.Cluster.CodeGen
 
         private static Uri GetUri(string path)
         {
-            var fullPath = Path.GetFullPath(path);
+            var fullPath = Path.GetFullPath(path+Path.DirectorySeparatorChar);
             var pathWithDirectorySeparatorChar = AppendDirectorySeparatorChar(fullPath);
+
+            var uriBuilder = new UriBuilder(pathWithDirectorySeparatorChar);
 
             return new Uri(pathWithDirectorySeparatorChar);
         }

--- a/tests/Proto.Cluster.CodeGen.Tests/PathPolyfillTests.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/PathPolyfillTests.cs
@@ -13,26 +13,34 @@ namespace Proto.Cluster.CodeGen.Tests
     public class PathPolyfillTests
     {
         [Theory]
-        [InlineData(@"some\other\path")]
-        [InlineData(@"some\other\path\")]
-        [InlineData(@".\some\other\path")]
-        [InlineData(@".\some\other\path\")]
-        [InlineData(@".\foo\..\some\other\path")]
-        [InlineData(@".\foo\..\some\other\path\")]
-        public void CanGetRelativePath(string unadjustedPath)
+        [InlineData(@"./..", @"./..")]
+        [InlineData(@"same", @"same")]
+        [InlineData(@"..\dir", @"some\other\path")]
+        [InlineData(@".\dir", @"some\other\path")]
+        [InlineData(@".\root\dir", @"some\other\path")]
+        [InlineData(@"root\dir", @"some\other\path")]
+        [InlineData(@"root\dir", @"some\other\path.dot")]
+        [InlineData(@"root\dir", @"some\other\path\")]
+        [InlineData(@"root\dir", @".\some\other\path")]
+        [InlineData(@"root\dir\", @".\some\other\path")]
+        [InlineData(@"root\dir", @".\some\other\path\")]
+        [InlineData(@"root\dir", @".\foo\..\some\other\path")]
+        [InlineData(@"root\dir", @".\foo\..\some\other\path\")]
+        [InlineData(@"root\dir.something\else", @"some\other\path")]
+        [InlineData(@"root\dir.some.thing", @"some\other\path")]
+        [InlineData(@"root\dir.something", @"some\other\path")]
+        [InlineData(@"root\dir.something\", @"some\other\path")]
+        public void CanGetRelativePath(string basePath, string unadjustedPath)
         {
-            var relativeTo = AdjustToCurrentOs(@"root\dir");
+            var relativeTo = AdjustToCurrentOs(basePath);
             var path = AdjustToCurrentOs(unadjustedPath);
             
             var relativePath = PathPolyfill.GetRelativePath(relativeTo, path);
 
+            var expected = Path.GetRelativePath(relativeTo, path);
             relativePath
                 .Should()
-                .Be(AdjustToCurrentOs(@"..\..\some\other\path"));
-
-            relativePath
-                .Should()
-                .Be(Path.GetRelativePath(relativeTo, path));
+                .Be(expected, "Should match the Path.GetRelativePath poly-filled behavior");
         }
 
         [Theory]


### PR DESCRIPTION
## Description

Workaround for Uri handling of directories with '.' included. 

Addressing #1339, PathPolyfill.GetRelativePath had incorrect behavior for project directories which included a dot, caused by Uri's treating the last directory as a file. This PR should fix the issue, added tests which should cover any regressions.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
