### PR TITLE
PartitionIdentity: Resolve duplicates, ensure lastRebalancedTopology is consistent

### DIFF
--- a/ProtoActor.sln.DotSettings
+++ b/ProtoActor.sln.DotSettings
@@ -2,6 +2,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=deadletter/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Asynkron/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=eventstream/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=liveness/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pids/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=protoactor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=protocluster/@EntryIndexedValue">True</s:Boolean>

--- a/src/Proto.Cluster/ClusterContracts.proto
+++ b/src/Proto.Cluster/ClusterContracts.proto
@@ -58,6 +58,11 @@ message PackedActivations{
 message IdentityHandoverAck {
   uint32 chunk_id = 1;
   uint64 topology_hash = 2;
+  State processing_state = 3;
+  enum State {
+    processed = 0;
+    incorrect_topology = 1;
+  }
 }
 
 message ClusterIdentity{

--- a/src/Proto.Cluster/Partition/PartitionIdentityLookup.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityLookup.cs
@@ -141,14 +141,14 @@ namespace Proto.Cluster.Partition
         public enum Send
         {
             /// <summary>
-            /// Only identities which have changed owner since the last completed topology rebalance are sent
+            /// Only identities which have changed owner since the last completed topology rebalance are sent.
             /// </summary>
             Delta,
 
             /// <summary>
             /// All activations are sent on every topology rebalance
             /// </summary>
-            Everything
+            Full
         }
     }
 }

--- a/tests/Proto.Actor.Tests/Futures/BatchFutureTests.cs
+++ b/tests/Proto.Actor.Tests/Futures/BatchFutureTests.cs
@@ -116,9 +116,9 @@ namespace Proto.Tests
                     }
                 )
             );
-            const int size = 1000;
+            const int size = 100;
 
-            var cancellationToken = CancellationTokens.FromSeconds(1);
+            var cancellationToken = CancellationTokens.FromSeconds(5);
             using var batchContext = System.Root.CreateBatchContext(size, cancellationToken);
 
             var tasks = new Task<object>[size];
@@ -130,7 +130,7 @@ namespace Proto.Tests
 
             var replies = await Task.WhenAll(tasks);
 
-            replies.Should().BeInAscendingOrder().And.HaveCount(1000);
+            replies.Should().BeInAscendingOrder().And.HaveCount(size);
         }
     }
 }


### PR DESCRIPTION
Hardening of the handover implementation. Ensures that duplicate activations are dropped, and that Delta sends are consistent with what is already transmitted to the identity owners.