### PR TITLE
Align poison async to work the same way as stop async

### DIFF
--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -422,8 +422,6 @@ namespace Proto.Context
 
         private Task HandlePoisonPill()
         {
-            if (Sender != null) HandleWatch(new Watch(Sender));
-
             Stop(Self);
             return Task.CompletedTask;
         }

--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -201,28 +201,6 @@ namespace Proto.Context
             return DefaultReceive();
         }
 
-        public void Stop(PID pid)
-        {
-            if (System.Metrics.Enabled)
-                ActorMetrics.ActorStoppedCount.Add(1, _metricTags);
-
-            pid.Stop(System);
-        }
-
-        public Task StopAsync(PID pid)
-        {
-            var future = System.Future.Get();
-
-            pid.SendSystemMessage(System, new Watch(future.Pid));
-            Stop(pid);
-            // ReSharper disable once MethodSupportsCancellation
-            return future.Task;
-        }
-
-        public void Poison(PID pid) => pid.SendUserMessage(System, PoisonPill.Instance);
-
-        public Task PoisonAsync(PID pid) => RequestAsync<Terminated>(pid, PoisonPill.Instance, CancellationToken.None);
-
         public IFuture GetFuture() => System.Future.Get();
 
         public CancellationTokenSource? CancellationTokenSource => _extras?.CancellationTokenSource;
@@ -649,5 +627,33 @@ namespace Proto.Context
         public CapturedContext Capture() => new(MessageEnvelope.Wrap(_messageOrEnvelope!), this);
 
         public void Apply(CapturedContext capturedContext) => _messageOrEnvelope = capturedContext.MessageEnvelope;
+        
+        public void Stop(PID pid)
+        {
+            if (System.Metrics.Enabled)
+                ActorMetrics.ActorStoppedCount.Add(1, _metricTags);
+
+            pid.Stop(System);
+        }
+
+        public Task StopAsync(PID pid)
+        {
+            var future = System.Future.Get();
+
+            pid.SendSystemMessage(System, new Watch(future.Pid));
+            Stop(pid);
+            return future.Task;
+        }
+        
+        public void Poison(PID pid) => pid.SendUserMessage(System, PoisonPill.Instance);
+
+        public Task PoisonAsync(PID pid)
+        {
+            var future = System.Future.Get();
+
+            pid.SendSystemMessage(System, new Watch(future.Pid));
+            Poison(pid);
+            return future.Task;
+        }
     }
 }

--- a/src/Proto.Actor/Context/RootContext.cs
+++ b/src/Proto.Actor/Context/RootContext.cs
@@ -75,28 +75,7 @@ namespace Proto
         //because DecoratorContexts needs to go this way if we want to intercept this method for the context
         public Task<T> RequestAsync<T>(PID target, object message, CancellationToken cancellationToken)
             => SenderContextExtensions.RequestAsync<T>(this, target, message, cancellationToken);
-
-        public void Stop(PID? pid)
-        {
-            if (pid is null) return;
-
-            var reff = System.ProcessRegistry.Get(pid);
-            reff.Stop(pid);
-        }
-
-        public Task StopAsync(PID pid)
-        {
-            var future = System.Future.Get();
-            pid.SendSystemMessage(System, new Watch(future.Pid));
-            Stop(pid);
-
-            return future.Task;
-        }
-
-        public void Poison(PID pid) => pid.SendUserMessage(System, PoisonPill.Instance);
-
-        public Task PoisonAsync(PID pid) => RequestAsync<Terminated>(pid, PoisonPill.Instance, CancellationToken.None);
-
+        
         public RootContext WithHeaders(MessageHeader headers) =>
             this with {Headers = headers};
 
@@ -130,5 +109,33 @@ namespace Proto
         }
 
         public IFuture GetFuture() => System.Future.Get();
+        
+        public void Stop(PID? pid)
+        {
+            if (pid is null) return;
+
+            var reff = System.ProcessRegistry.Get(pid);
+            reff.Stop(pid);
+        }
+
+        public Task StopAsync(PID pid)
+        {
+            var future = System.Future.Get();
+            pid.SendSystemMessage(System, new Watch(future.Pid));
+            Stop(pid);
+
+            return future.Task;
+        }
+        
+        public void Poison(PID pid) => pid.SendUserMessage(System, PoisonPill.Instance);
+
+        public Task PoisonAsync(PID pid)
+        {
+            var future = System.Future.Get();
+            pid.SendSystemMessage(System, new Watch(future.Pid));
+            Poison(pid);
+
+            return future.Task;
+        }
     }
 }


### PR DESCRIPTION
This PR aligns PoisonAsync to work the same way as StopAsync.
It seems strange that they should have different logic