### PR TITLE
Ensure endpoints do not retry forever

### DIFF
--- a/src/Proto.Remote/Endpoints/ServerConnector.cs
+++ b/src/Proto.Remote/Endpoints/ServerConnector.cs
@@ -249,7 +249,7 @@ namespace Proto.Remote
 
             rs.Fail();
 
-            if (rs.NumberOfFailures(_withinTimeSpan) > _maxNrOfRetries)
+            if (rs.FailureCount > _maxNrOfRetries)
             {
                 rs.Reset();
                 return true;


### PR DESCRIPTION
The current version of the endpoint can retry forever under the correct circumstances.

Instead of the max retries being timeboxed, it will now check the raw count. Since the stats are cleared when it connects again, it will then stop on n failed attempts with no successful connections in between.