### PR TITLE
#1024 Add support for MessageEnvelope return values on ClusterRequests

### DIFF
--- a/src/Proto.Cluster/DefaultClusterContext.cs
+++ b/src/Proto.Cluster/DefaultClusterContext.cs
@@ -258,6 +258,10 @@ namespace Proto.Cluster
                 case null: return (ResponseStatus.Ok, default);
                 case T t:  return (ResponseStatus.Ok, t);
                 default:
+                    if (typeof(T) == typeof(MessageEnvelope))
+                    {
+                        return (ResponseStatus.Ok, (T) (object) MessageEnvelope.Wrap(result));
+                    }
                     Logger.LogWarning("Unexpected message. Was type {Type} but expected {ExpectedType}", message.GetType(), typeof(T));
                     return (ResponseStatus.Exception, default);
             }

--- a/src/Proto.Cluster/ExperimentalClusterContext.cs
+++ b/src/Proto.Cluster/ExperimentalClusterContext.cs
@@ -224,6 +224,10 @@ namespace Proto.Cluster
                 case null: return (ResponseStatus.Ok, default);
                 case T t:  return (ResponseStatus.Ok, t);
                 default:
+                    if (typeof(T) == typeof(MessageEnvelope))
+                    {
+                        return (ResponseStatus.Ok, (T) (object) MessageEnvelope.Wrap(result));
+                    }
                     Logger.LogError("Unexpected message. Was type {Type} but expected {ExpectedType}", message.GetType(), typeof(T));
                     return (ResponseStatus.InvalidResponse, default);
             }

--- a/tests/Proto.Cluster.Tests/ClusterTests.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTests.cs
@@ -53,6 +53,20 @@ namespace Proto.Cluster.Tests
             response.Should().NotBeNull();
             response.Message.Should().Be(msg);
         }
+        
+        [Fact]
+        public async Task SupportsMessageEnvelopeResponses()
+        {
+            var timeout = new CancellationTokenSource(20000).Token;
+
+            const string msg = "Hello-message-envelope";
+            var response = await Members.First().RequestAsync<MessageEnvelope>(CreateIdentity("message-envelope"), EchoActor.Kind,
+                new Ping() {Message = msg, }, timeout
+            );
+            response.Should().NotBeNull();
+            response.Should().BeOfType<MessageEnvelope>();
+            response.Message.Should().BeOfType<Pong>();
+        }
 
         [Fact]
         public async Task StateIsReplicatedAcrossCluster()


### PR DESCRIPTION
## Description

Allows recipient to consume message headers. This is already supported on non-clustered  RequestAsync calls

## Purpose
This pull request is a:
- [X] New feature (non-breaking change which adds functionality)


## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
