### PR TITLE
log labels in k8s provider

### DIFF
--- a/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
@@ -135,8 +135,8 @@ namespace Proto.Cluster.Kubernetes
                 await _kubernetes.ReplacePodLabels(_podName, KubernetesExtensions.GetKubeNamespace(), labels);
             }
             catch (HttpOperationException e)
-            {
-                Logger.LogError(e, "[Cluster][KubernetesProvider] Unable to update pod labels, registration failed");
+            {            
+                Logger.LogError(e, "[Cluster][KubernetesProvider] Unable to update pod labels, registration failed. Labels : {Labels}", labels);
                 throw;
             }
         }


### PR DESCRIPTION
The Kubernetes API is problematic to debug. operations can fail with "bad request" and no more information than that.
This PR aims to add some debug information to this