### PR TITLE
Display deserialization exceptions together with the error message.

### DIFF
--- a/src/Proto.Remote/Endpoints/Endpoint.cs
+++ b/src/Proto.Remote/Endpoints/Endpoint.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 //   <copyright file="Endpoint.cs" company="Asynkron AB">
 //       Copyright (C) 2015-2022 Asynkron AB All rights reserved
 //   </copyright>
@@ -136,12 +136,15 @@ namespace Proto.Remote
                             //this only applies to root level messages, and never on nested child messages
                             if (message is IRootSerialized serialized) message = serialized.Deserialize(System);
                         }
-                        catch (Exception)
+                        catch (Exception ex)
                         {
                             if (Logger.IsEnabled(_deserializationErrorLogLevel))
-                                Logger.Log(_deserializationErrorLogLevel, "[{SystemAddress}] Unable to deserialize message with {Type}",
-                                    System.Address, typeName
-                                );
+                                Logger.Log(
+                                    _deserializationErrorLogLevel,
+                                    ex,
+                                    "[{SystemAddress}] Unable to deserialize message with {Type}",
+                                    System.Address,
+                                    typeName);
                             continue;
                         }
 

--- a/src/Proto.Remote/Endpoints/RemoteMessageHandler.cs
+++ b/src/Proto.Remote/Endpoints/RemoteMessageHandler.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 //   <copyright file="RemoteMessageHandler.cs" company="Asynkron AB">
 //       Copyright (C) 2015-2022 Asynkron AB All rights reserved
 //   </copyright>
@@ -83,11 +83,15 @@ namespace Proto.Remote
                             //this only applies to root level messages, and never on nested child messages
                             if (message is IRootSerialized serialized) message = serialized.Deserialize(System);
                         }
-                        catch (Exception)
+                        catch (Exception ex)
                         {
-                            _logger.Log(_deserializationErrorLogLevel, "[{SystemAddress}] Unable to deserialize message with {Type}", System.Address,
-                                typeName
-                            );
+                            if (_logger.IsEnabled(_deserializationErrorLogLevel))
+                                _logger.Log(
+                                    _deserializationErrorLogLevel,
+                                    ex,
+                                    "[{SystemAddress}] Unable to deserialize message with {Type}",
+                                    System.Address,
+                                    typeName);
                             continue;
                         }
 


### PR DESCRIPTION
## Description

Currently, if there is an error during deserialization, an error message is displayed, but the underlying exception is not shown. This change passes the exception to the logger.

## Purpose
This pull request is a:

- [x] New feature (non-breaking change which adds functionality)