### PR TITLE
Fix ReenterAfter still sending messages after the ActorSystem gets shutdown.

### DIFF
--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -401,9 +401,15 @@ namespace Proto.Context
 
         //Note to self, the message must be sent no-matter if the task failed or not.
         //do not mess this up by first awaiting and then sending on success only
-        private void ScheduleContinuation(Task target, Continuation cont) =>
+        private void ScheduleContinuation(Task target, Continuation cont)
+        {
+            // We pass System.Shutdown to ContinueWith so that when the ActorSystem is shutdown,
+            // continuations will not execute anymore.
             // ReSharper disable once MethodSupportsCancellation
-            _ = target.ContinueWith(_ => Self.SendSystemMessage(System, cont));
+            _ = target.ContinueWith(
+                _ => Self.SendSystemMessage(System, cont),
+                System.Shutdown);
+        }
 
         private static ValueTask HandleUnknownSystemMessage(object msg)
         {


### PR DESCRIPTION
## Description

Without this, when Context.ReenterAfter is used, this ends up keeping the while actor system alive and running even after it is shutdown.

This is still not the most ideal implementation, as Task.ContinueWith will still keep a reference to System because of the closure created with `_ => Self.SendSystemMessage(System, cont)` therefore not allowing ActorSystem and all things it contains to be GC'ed. We run into this problem when running tests with the unit.
The ideal implementation would register to System.Shutdown cancellation and early cancel the ContinueWith. However, I didn't attempt that fix, as I noticed a few other places in the code also use ContinueWith, and not sure how to fix those without changing their APIs significantly:
- ExponentialBackoffStrategy.HandleFailure
- LocalAffinityExtensions.WithRelocateOnRemoteSender

If you like I could do the more ideal implementation for this. I prefer not touching the 2 other usages of ContinueWith though.

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)
