### PR TITLE
Don't execute older Continuations on older Actor instance after the actor is recreated.

### DIFF
--- a/src/Proto.Actor/Messages/Messages.cs
+++ b/src/Proto.Actor/Messages/Messages.cs
@@ -126,14 +126,18 @@ namespace Proto
 
     public class Continuation : SystemMessage
     {
-        public Continuation(Func<Task>? fun, object? message)
+        public Continuation(Func<Task>? fun, object? message, IActor actor)
         {
             Action = fun ?? throw new ArgumentNullException(nameof(fun));
             Message = message ?? throw new ArgumentNullException(nameof(message));
+            Actor = actor ?? throw new ArgumentNullException(nameof(actor));
         }
 
         public Func<Task> Action { get; }
         public object Message { get; }
+        // This is used to track if actor was re-created or not.
+        // If set to null, continuation always executes.
+        public IActor Actor { get; }
     }
 
     public record ProcessDiagnosticsRequest(TaskCompletionSource<string> Result) : SystemMessage;

--- a/tests/Proto.Actor.Tests/ReenterTests.cs
+++ b/tests/Proto.Actor.Tests/ReenterTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -190,6 +190,53 @@ namespace Proto.Tests
             await Context.PoisonAsync(pid);
             Assert.True(correct);
             Assert.Equal(100000, counter);
+        }
+
+        [Fact]
+        public async Task DropReenterContinuationAfterRestart()
+        {
+            bool restarted = false;
+            bool completionExecuted = false;
+            var props = Props.FromFunc(async ctx => {
+                switch (ctx.Message)
+                {
+                    case "start":
+                        CancellationTokenSource cts = new();
+                        ctx.ReenterAfter(
+                            Task.Delay(-1, cts.Token),
+                            () => {
+                                completionExecuted = true;
+                            });
+                        ctx.Self.SendSystemMessage(ctx.System, new Restart(new Exception()));
+                        // Release the cancellation token after restart gets processed.
+                        cts.Cancel();
+                        ctx.Respond(true);
+                        break;
+                    case Restarting:
+                        restarted = true;
+                        break;
+                    case "waitstate":
+                        // Wait a while to 
+                        Task.Delay(50);
+                        while (!ctx.CancellationToken.IsCancellationRequested)
+                        {
+                            await Task.Yield();
+                            if (restarted && !completionExecuted)
+                            {
+                                ctx.Respond(true);
+                                break;
+                            }
+                        }
+                        break;
+                }
+            }
+            );
+
+            var pid = Context.Spawn(props);
+
+            await Context.RequestAsync<bool>(pid, "start", TimeSpan.FromSeconds(5));
+            var res = await Context.RequestAsync<bool>(pid, "waitstate", TimeSpan.FromSeconds(5));
+            Assert.True(res);
         }
 
         private class ReenterAfterCancellationActor : IActor

--- a/tests/Proto.Actor.Tests/ReenterTests.cs
+++ b/tests/Proto.Actor.Tests/ReenterTests.cs
@@ -216,7 +216,7 @@ namespace Proto.Tests
                         restarted = true;
                         break;
                     case "waitstate":
-                        // Wait a while to 
+                        // Wait a while to make sure that Completion really didn't execute.
                         Task.Delay(50);
                         while (!ctx.CancellationToken.IsCancellationRequested)
                         {


### PR DESCRIPTION
## Description
Before this change, a `ReenterAfter(Task.Delay(5000), () => SaveInternalStateToDB());` line followed immediately by a `Restart` by the supervisor, that SaveInternalStateToDB() would execute on the previous Actor instance, as a result saving the old state into DB.

With this change each Continuation stores the Actor instance it was created for, if it is different when the Continuation message is received, it simply ignores it and logs this.

I would overall consider this a critical bug, given that, in production scenarios, it could cause issues that would be very very hard to debug.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works