### PR TITLE
attempt to fix k8s provider for later KubernetesClients

### DIFF
--- a/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
@@ -132,7 +132,7 @@ namespace Proto.Cluster.Kubernetes
 
             try
             {
-                await _kubernetes.ReplacePodLabels(_podName, KubernetesExtensions.GetKubeNamespace(), labels);
+                await _kubernetes.ReplacePodLabels(_podName, KubernetesExtensions.GetKubeNamespace(), pod, labels);
             }
             catch (HttpOperationException e)
             {            
@@ -180,12 +180,13 @@ namespace Proto.Cluster.Kubernetes
 
             var pod = await _kubernetes.ReadNamespacedPodAsync(_podName, kubeNamespace);
 
+            var labels = new Dictionary<string, string>();
             foreach (var kind in _kinds)
             {
                 try
                 {
                     var labelKey = $"{LabelKind}-{kind}";
-                    pod.SetLabel(labelKey, null);
+                    labels.TryAdd(labelKey, null);
                 }
                 catch (Exception x)
                 {
@@ -193,9 +194,9 @@ namespace Proto.Cluster.Kubernetes
                 }
             }
 
-            pod.SetLabel(LabelCluster, null);
+            labels.TryAdd(LabelCluster, null);
 
-            await _kubernetes.ReplacePodLabels(_podName, kubeNamespace, pod.Labels());
+            await _kubernetes.ReplacePodLabels(_podName, kubeNamespace,pod, labels);
 
             cluster.System.Root.Send(_clusterMonitor, new DeregisterMember());
         }

--- a/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
@@ -180,13 +180,13 @@ namespace Proto.Cluster.Kubernetes
 
             var pod = await _kubernetes.ReadNamespacedPodAsync(_podName, kubeNamespace);
 
-            var labels = new Dictionary<string, string>();
+            var labels = new Dictionary<string, string>(pod.Metadata.Labels);
             foreach (var kind in _kinds)
             {
                 try
                 {
                     var labelKey = $"{LabelKind}-{kind}";
-                    labels.TryAdd(labelKey, null);
+                    labels.Remove(labelKey);
                 }
                 catch (Exception x)
                 {
@@ -194,7 +194,7 @@ namespace Proto.Cluster.Kubernetes
                 }
             }
 
-            labels.TryAdd(LabelCluster, null);
+            labels.Remove(LabelCluster);
 
             await _kubernetes.ReplacePodLabels(_podName, kubeNamespace,pod, labels);
 

--- a/src/Proto.Cluster.Kubernetes/Proto.Cluster.Kubernetes.csproj
+++ b/src/Proto.Cluster.Kubernetes/Proto.Cluster.Kubernetes.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="KubernetesClient" Version="6.0.8" />
-        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.1" />
+        <PackageReference Include="JsonPatch.Net" Version="1.1.2" />
+        <PackageReference Include="KubernetesClient" Version="7.0.12" />
         <PackageReference Include="Roslynator.Analyzers" Version="4.0.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This PR upgrades the KubernetesClient to v7+, which uses the System.Text.Json serializer.
To allow us to do this, we have replaced the Asp.NET JsonPatch with JsonPatch.NET package.