### PR TITLE
Don't dispose Shutdown token source in ActorSystem's DisposeAsync.

### DIFF
--- a/src/Proto.Actor/ActorSystem.cs
+++ b/src/Proto.Actor/ActorSystem.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // <copyright file="ActorSystem.cs" company="Asynkron AB">
 //      Copyright (C) 2015-2022 Asynkron AB All rights reserved
 // </copyright>
@@ -119,7 +119,12 @@ namespace Proto
         public async ValueTask DisposeAsync()
         {
             await ShutdownAsync();
-            _cts.Dispose();
+
+            // NOTE: We don't dispose _cts here on purpose, as doing so causes
+            // ObjectDisposedException to be thrown from certain background task
+            // loops, such as the Gossip loop. Given our usage of the Shutdown token
+            // this is not a memory leak.
+            //_cts.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Description

Before this change ActorSystem.DisposeAsync was called, this was causing GossipLoop to throw errors because it kept trying to access the Shutdown token. We observe this issue frequently in our tests, because of creating ActorSystem in a DI container, and disposing it at the teardown of each test.

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)