### PR TITLE
allow reregistration of protos

### DIFF
--- a/src/Proto.Remote/Serialization/Serialization.cs
+++ b/src/Proto.Remote/Serialization/Serialization.cs
@@ -85,7 +85,10 @@ namespace Proto.Remote
         {
             foreach (var msg in fd.MessageTypes)
             {
-                TypeLookup.Add(msg.FullName, msg.Parser);
+                if (!TypeLookup.ContainsKey(msg.FullName))
+                {
+                    TypeLookup.Add(msg.FullName, msg.Parser);
+                }
             }
         }
 


### PR DESCRIPTION
Don't throw if same proto descriptor is already registered