### PR TITLE
Made PartitionActivatorActor spawn actors just like the PartitionPlacementActor

### DIFF
--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // <copyright file="PartitionActivatorActor.cs" company="Asynkron AB">
 //      Copyright (C) 2015-2022 Asynkron AB All rights reserved
 // </copyright>
@@ -128,8 +128,9 @@ public class PartitionActivatorActor : IActor
         }
         else
         {
-            var kind = _cluster.GetClusterKind(msg.Kind);
-            var pid = context.Spawn(kind.Props);
+            var clusterKind = _cluster.GetClusterKind(msg.Kind);
+            var clusterProps = clusterKind.Props.WithClusterIdentity(msg.ClusterIdentity);
+            var pid = context.SpawnPrefix(clusterProps, msg.ClusterIdentity.Identity);
             _actors.Add(msg.ClusterIdentity, pid);
             context.Respond(new ActivationResponse
                 {


### PR DESCRIPTION
This allows for Context.ClusterIdentity() usage when PartitionActivatorActor is used and makes the spawned PIDs look identical to what PartitionPlacementActor would do.

Without ClusterIdentity() support and PID that doesn't contain ClusterIdentity in any part, it is not possible to have any real use of Proto.Cluster.

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)