### PR TITLE
Fix for PartitionActivator killing all actors upon ClusterTopology

### DIFF
--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
@@ -19,7 +19,7 @@ public class PartitionActivatorActor : IActor
     private readonly ShouldThrottle _wrongPartitionLogThrottle = Throttle.Create(1, TimeSpan.FromSeconds(1), wrongNodeCount => {
             if (wrongNodeCount > 1)
             {
-                Logger.LogWarning("Forwarded {SpawnCount} attempts to spawn on wrong node", wrongNodeCount);
+                Logger.LogWarning("[PartitionActivator] Forwarded {SpawnCount} attempts to spawn on wrong node", wrongNodeCount);
             }
         }
     );
@@ -90,7 +90,7 @@ public class PartitionActivatorActor : IActor
             return Task.CompletedTask;
         }
         //we get this via broadcast to all nodes, remove if we have it, or ignore
-        Logger.LogTrace("[PartitionIdentityActor] Terminated {Pid}", msg.Pid);
+        Logger.LogTrace("[PartitionActivator] Terminated {Pid}", msg.Pid);
         _actors.Remove(msg.ClusterIdentity);
 
         return Task.CompletedTask;
@@ -110,7 +110,7 @@ public class PartitionActivatorActor : IActor
 
             if (_wrongPartitionLogThrottle().IsOpen())
             {
-                Logger.LogWarning("Tried to spawn on wrong node, forwarding");
+                Logger.LogWarning("[PartitionActivator] Tried to spawn on wrong node, forwarding");
             }
             context.Forward(ownerPid);
 

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
@@ -65,7 +65,7 @@ public class PartitionActivatorActor : IActor
         _topologyHash = msg.TopologyHash;
             
         var toRemove = _actors
-            .Where(kvp => _manager.Selector.GetOwner(kvp.Key) != _cluster.System.Id)
+            .Where(kvp => _manager.Selector.GetOwnerAddress(kvp.Key) != _cluster.System.Address)
             .Select(kvp => kvp.Key)
             .ToList();
 
@@ -100,7 +100,7 @@ public class PartitionActivatorActor : IActor
     {
          
         //who owns this?
-        var ownerAddress = _manager.Selector.GetOwner(msg.ClusterIdentity);
+        var ownerAddress = _manager.Selector.GetOwnerAddress(msg.ClusterIdentity);
 
         //is it not me?
         if (ownerAddress != _myAddress)

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorLookup.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorLookup.cs
@@ -33,7 +33,7 @@ public class PartitionActivatorLookup : IIdentityLookup
         using var cts = new CancellationTokenSource(_getPidTimeout);
         //Get address to node owning this ID
         var owner = _partitionManager.Selector.GetOwnerAddress(clusterIdentity);
-        if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug("Identity belongs to {Address}", owner);
+        if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug("[PartitionActivator] Identity belongs to {Address}", owner);
         if (string.IsNullOrEmpty(owner)) return null;
 
         var remotePid = PartitionActivatorManager.RemotePartitionActivatorActor(owner);
@@ -44,7 +44,7 @@ public class PartitionActivatorLookup : IIdentityLookup
             ClusterIdentity = clusterIdentity
         };
 
-        if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug("Requesting remote PID from {Partition}:{Remote} {@Request}", owner, remotePid, req
+        if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug("[PartitionActivator] Requesting remote PID from {Partition}:{Remote} {@Request}", owner, remotePid, req
         );
 
         try
@@ -57,17 +57,17 @@ public class PartitionActivatorLookup : IIdentityLookup
         //TODO: decide if we throw or return null
         catch (DeadLetterException)
         {
-            Logger.LogInformation("Remote PID request deadletter {@Request}, identity Owner {Owner}", req, owner);
+            Logger.LogInformation("[PartitionActivator] Remote PID request deadletter {@Request}, identity Owner {Owner}", req, owner);
             return null;
         }
         catch (TimeoutException)
         {
-            Logger.LogInformation("Remote PID request timeout {@Request}, identity Owner {Owner}", req, owner);
+            Logger.LogInformation("[PartitionActivator] Remote PID request timeout {@Request}, identity Owner {Owner}", req, owner);
             return null;
         }
         catch (Exception e)
         {
-            Logger.LogError(e, "Error occured requesting remote PID {@Request}, identity Owner {Owner}", req, owner);
+            Logger.LogError(e, "[PartitionActivator] Error occured requesting remote PID {@Request}, identity Owner {Owner}", req, owner);
             return null;
         }
     }

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorLookup.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorLookup.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // <copyright file="PartitionActivatorLookup.cs" company="Asynkron AB">
 //      Copyright (C) 2015-2022 Asynkron AB All rights reserved
 // </copyright>
@@ -32,7 +32,7 @@ public class PartitionActivatorLookup : IIdentityLookup
     {
         using var cts = new CancellationTokenSource(_getPidTimeout);
         //Get address to node owning this ID
-        var owner = _partitionManager.Selector.GetOwner(clusterIdentity);
+        var owner = _partitionManager.Selector.GetOwnerAddress(clusterIdentity);
         if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug("Identity belongs to {Address}", owner);
         if (string.IsNullOrEmpty(owner)) return null;
 

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorSelector.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorSelector.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // <copyright file="PartitionMemberSelector.cs" company="Asynkron AB">
 //      Copyright (C) 2015-2022 Asynkron AB All rights reserved
 // </copyright>
@@ -25,7 +25,7 @@ class PartitionActivatorSelector
         }
     }
 
-    public string GetOwner(ClusterIdentity key)
+    public string GetOwnerAddress(ClusterIdentity key)
     {
         lock (_lock) return _rdv.GetOwnerMemberByIdentity(key);
     }


### PR DESCRIPTION
## Description

PartitionActivator was doing a System.Id == Address comparison to determine which actor to kill upon ClusterToplogy event. This PR fixes that.

I also added a commit for adding "[PartitionActivator]" tag to logs coming from PartitionActivator* code.

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)