### PR TITLE
Fix PartitionActivator leaking memory in case of cluster actors being stopped

### DIFF
--- a/src/Proto.Cluster/PidCache.cs
+++ b/src/Proto.Cluster/PidCache.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // <copyright file="PidCache.cs" company="Asynkron AB">
 //      Copyright (C) 2015-2022 Asynkron AB All rights reserved
 // </copyright>
@@ -106,7 +106,7 @@ public class PidCache
     public int RemoveByMember(Member member)
         => RemoveByPredicate(pair => member.Address.Equals(pair.Value.Address, StringComparison.InvariantCulture));
 
-    private int RemoveByPredicate(Func<KeyValuePair<ClusterIdentity, PID>, bool> predicate)
+    internal int RemoveByPredicate(Func<KeyValuePair<ClusterIdentity, PID>, bool> predicate)
     {
         var toBeRemoved = _cacheDict.Where(predicate).ToList();
         if (toBeRemoved.Count == 0) return 0;


### PR DESCRIPTION
## Description

Before this fix, when PartitionActivator is in use and many cluster actors are created and destroyed (for example: because of timeout), PartitionActivator's `Dictionary<ClusterIdentity, PID> _actors` map were forever growing in size. Also the PidCache were not cleaned correctly. This fix solves these problems.

I verified the fix to be working by making a sample app (which manages to increase memory usage by 1GB/s, all while having no alive virtual actors). PartitionIdentity codes do not suffer from the same issue at all.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
