### PR TITLE
Use an optimized version Rendezvous hashing for PartitionActivator.

### DIFF
--- a/benchmarks/ClusterMicroBenchmarks/RendezvousBenchmark.cs
+++ b/benchmarks/ClusterMicroBenchmarks/RendezvousBenchmark.cs
@@ -9,6 +9,7 @@ using BenchmarkDotNet.Attributes;
 using Proto;
 using Proto.Cluster;
 using Proto.Cluster.Partition;
+using Proto.Cluster.PartitionActivator;
 using Proto.Router;
 
 namespace ClusterMicroBenchmarks;
@@ -25,6 +26,7 @@ public class RendezvousBenchmark
     private Rendezvous _rendezvous;
     private MemberHashRing _memberHashRing;
     private HashRing<Member> _hashRing;
+    private RendezvousFast _rendezvousFast;
 
     [GlobalSetup]
     public void Setup()
@@ -38,6 +40,7 @@ public class RendezvousBenchmark
         ).ToArray();
         _rendezvous = new Rendezvous();
         _rendezvous.UpdateMembers(members);
+        _rendezvousFast = new RendezvousFast(members);
         _memberHashRing = new MemberHashRing(members);
         _hashRing = new HashRing<Member>(members, member => member.Address, MurmurHash2.Hash, 50);
     }
@@ -46,6 +49,12 @@ public class RendezvousBenchmark
     public void Rendezvous()
     {
         var owner = _rendezvous.GetOwnerMemberByIdentity(TestId());
+    }
+
+    [Benchmark]
+    public void RendezvousFast()
+    {
+        var owner = _rendezvousFast.GetOwnerMemberByIdentity(TestId());
     }
 
     [Benchmark]

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorLookup.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorLookup.cs
@@ -14,7 +14,7 @@ namespace Proto.Cluster.PartitionActivator;
 
 public class PartitionActivatorLookup : IIdentityLookup
 {
-    private static readonly ILogger Logger = Log.CreateLogger<PartitionIdentityLookup>();
+    private static readonly ILogger Logger = Log.CreateLogger<PartitionActivatorLookup>();
     private readonly TimeSpan _getPidTimeout;
     private Cluster _cluster = null!;
     private PartitionActivatorManager _partitionManager = null!;
@@ -44,8 +44,7 @@ public class PartitionActivatorLookup : IIdentityLookup
             ClusterIdentity = clusterIdentity
         };
 
-        if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug("[PartitionActivator] Requesting remote PID from {Partition}:{Remote} {@Request}", owner, remotePid, req
-        );
+        if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug("[PartitionActivator] Requesting remote PID from {Partition}:{Remote} {@Request}", owner, remotePid, req);
 
         try
         {

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorManager.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorManager.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // <copyright file="PartitionManager.cs" company="Asynkron AB">
 //      Copyright (C) 2015-2022 Asynkron AB All rights reserved
 // </copyright>
@@ -41,7 +41,7 @@ public class PartitionActivatorManager
                     if (e.TopologyHash == topologyHash) return;
 
                     topologyHash = e.TopologyHash;
-                    Selector.Update(e.Members.ToArray(),topologyHash);
+                    Selector.Update(e.Members.ToArray());
                 }
             );
         }
@@ -60,7 +60,7 @@ public class PartitionActivatorManager
 
                     topologyHash = e.TopologyHash;
 
-                    Selector.Update(e.Members.ToArray(),topologyHash);
+                    Selector.Update(e.Members.ToArray());
                     _context.Send(_partitionActivatorActor, e);
                 }
             );

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorSelector.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorSelector.cs
@@ -1,32 +1,40 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="PartitionMemberSelector.cs" company="Asynkron AB">
+// <copyright file="PartitionActivatorSelector.cs" company="Asynkron AB">
 //      Copyright (C) 2015-2022 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
-using System.Collections.Immutable;
-using Proto.Cluster.Partition;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Proto.Cluster.PartitionActivator;
 
 //this class is responsible for translating between Identity->activator member
-//this is the key algorithm for the distributed hash table
+//this is the key algorithm for the distribution of actors within the cluster.
 class PartitionActivatorSelector
 {
-    private readonly object _lock = new();
-    private MemberHashRing _rdv = new(ImmutableList<Member>.Empty);
-    private ulong _topologyHash;
+    private volatile ConcurrentDictionary<string, RendezvousFast> _hasherByKind = new();
 
-    public void Update(Member[] members, ulong topologyHash)
+    public void Update(Member[] members)
     {
-        lock (_lock)
-        {
-            _rdv = new MemberHashRing(members);
-            _topologyHash = topologyHash;
-        }
+        // Precreate RendezvousFast hasher instances by each Kind the cluster supports.
+        Dictionary<string, RendezvousFast> newHasherByKind = members
+            .SelectMany(member => member.Kinds.Select(kind => (member, kind)))
+            .GroupBy(v => v.kind)
+            .ToDictionary(
+                v => v.Key,
+                v => new RendezvousFast(v.Select(t => t.member)));
+
+        // Assign at-once in an atomic manner rather than doing a Clear and re-assigning Keys
+        // as that would allow _hasherByKind to be read in inconsistent states by GetOwne
+        _hasherByKind = new(newHasherByKind);
     }
 
     public string GetOwnerAddress(ClusterIdentity key)
     {
-        lock (_lock) return _rdv.GetOwnerMemberByIdentity(key);
+        if (_hasherByKind.TryGetValue(key.Kind, out var hasher))
+            return hasher.GetOwnerMemberByIdentity(key.Identity);
+        return "";
     }
 }

--- a/src/Proto.Cluster/PartitionActivator/RendezvousFast.cs
+++ b/src/Proto.Cluster/PartitionActivator/RendezvousFast.cs
@@ -1,0 +1,85 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="PartitionActivatorActor.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2022 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Proto.Cluster.PartitionActivator;
+
+/// <summary>
+/// Optimized version of the Rendezvous algorithm.
+/// Instead of calculating Hash each time for Key+Node combination,
+/// it simply precalculates Node hash, then calculates Key hash and
+/// does a basic hash combination to determine a combined hash. Uses
+/// combined hash to determine the owner.
+/// Identity distribution over nodes is just as good as Rendezvous,
+/// while being 50x faster at 1000 nodes, 25x faster at 100 nodes, and 6x faster at 10 nodes.
+/// Also, it does minimal allocations in comparison to Rendezvous, identical to MemberRing.
+///
+/// WARNING: Any modifications in this class could cause old version cluster
+/// members to be incompatible with the new version cluster members, and it
+/// would result in duplicate parallel activations.
+/// </summary>
+public class RendezvousFast
+{
+    private readonly MemberData[] _members;
+
+    public RendezvousFast(IEnumerable<Member> members)
+    {
+        _members = members
+            .OrderBy(m => m.Address)
+            .Select(x => new MemberData(x))
+            .ToArray();
+    }
+
+    public string GetOwnerMemberByIdentity(string identity)
+    {
+        switch (_members.Length)
+        {
+            case 0:
+                return "";
+            case 1:
+                return _members[0].Info.Address;
+        }
+
+        var keyBytes = Encoding.UTF8.GetBytes(identity);
+        var keyHash = MurmurHash2.Hash(keyBytes);
+
+        uint maxScore = 0;
+        Member? maxNode = null;
+
+        foreach (var member in _members)
+        {
+            var score = CombineHashes(member.Hash, keyHash);
+
+            if (score <= maxScore) continue;
+
+            maxScore = score;
+            maxNode = member.Info;
+        }
+
+        return maxNode?.Address ?? "";
+    }
+
+    private readonly struct MemberData
+    {
+        public MemberData(Member member)
+        {
+            Info = member;
+            Hash = MurmurHash2.Hash(Encoding.UTF8.GetBytes(member.Address));
+        }
+
+        public Member Info { get; }
+        public uint Hash { get; }
+    }
+
+    /// <summary>
+    /// Combines 2 hashes, with a basic XOR.
+    /// Any more complicated hash combination is simply pointless here.
+    /// </summary>
+    uint CombineHashes(uint hash1, uint hash2) => hash1 ^ hash2;
+}


### PR DESCRIPTION
Before this, the balance of Actors between nodes was not uniform (up to 40% distribution difference in a usual deployment, using Guids as identity), this makes it very uniform in comparison (down to less than 1%).
It performs as well as or better than MemberHashRing (in use by PartitionIdentity) up to 30 nodes, and comparable up to 100 nodes.

RendezvousBenchmark results:
![image](https://user-images.githubusercontent.com/519796/158398842-e2f9705c-cef6-48fa-af55-e9770975fdfa.png)

## Purpose
This pull request is a:

- [X] New feature (non-breaking change which adds functionality)