### PR TITLE
ActorLoggingContext shouldn't log Terminated and Touch messages.

### DIFF
--- a/src/Proto.Actor/Context/ActorLoggingContext.cs
+++ b/src/Proto.Actor/Context/ActorLoggingContext.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // <copyright file="ActorLoggingDecorator.cs" company="Asynkron AB">
 //      Copyright (C) 2015-2022 Asynkron AB All rights reserved
 // </copyright>
@@ -147,6 +147,10 @@ public class ActorLoggingContext : ActorContextDecorator
 
     private LogLevel GetLogLevel(object message)
     {
+        // Don't log certain messages, as the Partition*Actor ends up spamming logs without this.
+        if (message is Terminated or Touch)
+            return LogLevel.None;
+
         var logLevel = message is InfrastructureMessage ? _infrastructureLogLevel : _logLevel;
         return logLevel;
     }


### PR DESCRIPTION
## Description

Without this change, we get a lot of spam logs of Terminated messages from PartitionActivatorActor (the same would apply to PartitionIdentityActor too).

The reason for ignoring Touch is that we use that to do health checks on certain internal Proto.Actor's actors. That also causes log spam.

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)