### PR TITLE
Fixed topic kind name for Kubernetes

### DIFF
--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -113,7 +113,7 @@ public class Cluster : IActorSystemExtension<Cluster>
 
     private async Task BeginStartAsync(bool client)
     {
-        InitClusterKinds();
+        InitClusterKinds(client);
         Provider = Config.ClusterProvider;
         //default to partition identity lookup
         IdentityLookup = Config.IdentityLookup;
@@ -147,14 +147,15 @@ public class Cluster : IActorSystemExtension<Cluster>
         }
     }
 
-    private void InitClusterKinds()
+    private void InitClusterKinds(bool client)
     {
         foreach (var clusterKind in Config.ClusterKinds)
         {
             _clusterKinds.Add(clusterKind.Name, clusterKind.Build(this));
         }
 
-        EnsureTopicKindRegistered();
+        if(!client)
+            EnsureTopicKindRegistered();
 
         if (System.Metrics.Enabled)
         {

--- a/src/Proto.Cluster/PubSub/TopicActor.cs
+++ b/src/Proto.Cluster/PubSub/TopicActor.cs
@@ -15,7 +15,7 @@ namespace Proto.Cluster.PubSub;
 
 public sealed class TopicActor : IActor
 {
-    public const string Kind = "$topic";
+    public const string Kind = "prototopic"; // only alphanum in the name, to maximize chances it works on all clustering providers
 
     private static readonly ILogger Logger = Log.CreateLogger<TopicActor>();
     private ImmutableHashSet<SubscriberIdentity> _subscribers = ImmutableHashSet<SubscriberIdentity>.Empty;


### PR DESCRIPTION
## Description

This is a hotfix for Kubernetes provider error `k8s.Autorest.HttpOperationException: Operation returned an invalid status code 'UnprocessableEntity'` 

The TopicActor kind changed from `$topic` to `prototopic` .
Topics are now not registered automatically on client members.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
