### PR TITLE
More system actors and more consistent system actor naming

### DIFF
--- a/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
@@ -148,7 +148,7 @@ public class KubernetesProvider : IClusterProvider
             .FromProducer(() => new KubernetesClusterMonitor(_cluster, _config))
             .WithGuardianSupervisorStrategy(Supervision.AlwaysRestartStrategy);
 
-        _clusterMonitor = _cluster.System.Root.SpawnNamed(props, "kubernetes-cluster-monitor");
+        _clusterMonitor = _cluster.System.Root.SpawnNamedSystem(props, "$kubernetes-cluster-monitor");
         _podName = KubernetesExtensions.GetPodName();
 
         _cluster.System.Root.Send(

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -45,7 +45,7 @@ public record GetGossipStateSnapshot;
 [PublicAPI]
 public class Gossiper
 {
-    public const string GossipActorName = "gossip";
+    public const string GossipActorName = "$gossip";
 
     private static readonly ILogger Logger = Log.CreateLogger<Gossiper>();
     private readonly Cluster _cluster;

--- a/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
@@ -6,7 +6,7 @@ namespace Proto.Cluster.Identity;
 public class IdentityStorageLookup : IIdentityLookup
 {
     private const string WorkerActorName = "$identity-storage-worker";
-    private const string PlacementActorName = "placement-activator";
+    private const string PlacementActorName = "$placement-activator";
     private bool _isClient;
     private string _memberId = string.Empty;
     private PID _placementActor = null!;

--- a/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
@@ -5,6 +5,7 @@ namespace Proto.Cluster.Identity;
 
 public class IdentityStorageLookup : IIdentityLookup
 {
+    private const string WorkerActorName = "$identity-storage-worker";
     private const string PlacementActorName = "placement-activator";
     private bool _isClient;
     private string _memberId = string.Empty;
@@ -36,7 +37,7 @@ public class IdentityStorageLookup : IIdentityLookup
         await Storage.Init();
 
         var workerProps = Props.FromProducer(() => new IdentityStorageWorker(this));
-        _worker = _system.Root.Spawn(workerProps);
+        _worker = _system.Root.SpawnNamedSystem(workerProps, WorkerActorName);
 
         //hook up events
         cluster.System.EventStream.Subscribe<ClusterTopology>(e => {

--- a/src/Proto.Cluster/Partition/PartitionManager.cs
+++ b/src/Proto.Cluster/Partition/PartitionManager.cs
@@ -11,8 +11,8 @@ namespace Proto.Cluster.Partition;
 //helper to interact with partition actors on this and other members
 class PartitionManager
 {
-    private const string PartitionIdentityActorName = "partition-identity";
-    private const string PartitionPlacementActorName = "partition-activator";
+    private const string PartitionIdentityActorName = "$partition-identity";
+    private const string PartitionPlacementActorName = "$partition-activator";
     private readonly Cluster _cluster;
     private readonly RootContext _context;
     private readonly bool _isClient;

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorManager.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorManager.cs
@@ -11,7 +11,7 @@ namespace Proto.Cluster.PartitionActivator;
 //helper to interact with partition actors on this and other members
 public class PartitionActivatorManager
 {
-    private const string PartitionActivatorActorName = "partition-activator";
+    private const string PartitionActivatorActorName = "$partition-activator";
     private readonly Cluster _cluster;
 
 

--- a/src/Proto.Cluster/Seed/SeedClientNodeActor.cs
+++ b/src/Proto.Cluster/Seed/SeedClientNodeActor.cs
@@ -13,7 +13,7 @@ namespace Proto.Cluster.Seed;
 
 public class SeedClientNodeActor : IActor
 {
-    public const string Name = "client_seed";
+    public const string Name = "$client_seed";
     public static Props Props(SeedNodeClusterProviderOptions options) => Proto.Props.FromProducer(() => new SeedClientNodeActor(options));
     private static readonly ILogger Logger = Log.CreateLogger<SeedClientNodeActor>();
     private ImmutableDictionary<string, Member> _members = ImmutableDictionary<string, Member>.Empty;

--- a/src/Proto.Cluster/Seed/SeedNodeActor.cs
+++ b/src/Proto.Cluster/Seed/SeedNodeActor.cs
@@ -15,7 +15,7 @@ namespace Proto.Cluster.Seed;
 
 public class SeedNodeActor : IActor
 {
-    public const string Name = "server_seed";
+    public const string Name = "$server_seed";
     private static readonly ILogger Logger = Log.CreateLogger<SeedNodeActor>();
     private ImmutableDictionary<string, Member> _members = ImmutableDictionary<string, Member>.Empty;
     private ImmutableList<PID> _clients = ImmutableList<PID>.Empty;

--- a/src/Proto.Remote/Endpoints/EndpointManager.cs
+++ b/src/Proto.Remote/Endpoints/EndpointManager.cs
@@ -15,6 +15,8 @@ namespace Proto.Remote;
 
 public class EndpointManager
 {
+    public const string ActivatorActorName = "$activator";
+
     private static readonly ILogger Logger = Log.CreateLogger<EndpointManager>();
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly IChannelProvider _channelProvider;
@@ -196,7 +198,7 @@ public class EndpointManager
     private void SpawnActivator()
     {
         var props = Props.FromProducer(() => new Activator(_remoteConfig, _system));
-        ActivatorPid = _system.Root.SpawnNamedSystem(props, "$activator");
+        ActivatorPid = _system.Root.SpawnNamedSystem(props, ActivatorActorName);
     }
     private void StopActivator() => _system.Root.Stop(ActivatorPid);
 }

--- a/src/Proto.Remote/Endpoints/EndpointManager.cs
+++ b/src/Proto.Remote/Endpoints/EndpointManager.cs
@@ -196,7 +196,7 @@ public class EndpointManager
     private void SpawnActivator()
     {
         var props = Props.FromProducer(() => new Activator(_remoteConfig, _system));
-        ActivatorPid = _system.Root.SpawnNamedSystem(props, "activator");
+        ActivatorPid = _system.Root.SpawnNamedSystem(props, "$activator");
     }
     private void StopActivator() => _system.Root.Stop(ActivatorPid);
 }

--- a/src/Proto.Remote/IRemoteExtensions.cs
+++ b/src/Proto.Remote/IRemoteExtensions.cs
@@ -41,6 +41,6 @@ public static class IRemoteExtensions
 
         return res;
 
-        static PID ActivatorForAddress(string address) => PID.FromAddress(address, "activator");
+        static PID ActivatorForAddress(string address) => PID.FromAddress(address, EndpointManager.ActivatorActorName);
     }
 }


### PR DESCRIPTION
## Description

<!-- If your pull request solves an issue, please reference it here -->
This PR intends to solve issues #1604 and #1603.

* kubernetes-cluster-monitorand and IdentityStorageWorker now spawned as system actors
* Add '$' prefix to system actor names   
## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
