### PR TITLE
Virtual actor spawn filtering

### DIFF
--- a/src/Proto.Actor/CancellationTokens.cs
+++ b/src/Proto.Actor/CancellationTokens.cs
@@ -15,6 +15,12 @@ public static class CancellationTokens
         
     private static readonly ConcurrentDictionary<int, TokenEntry> Tokens = new();
 
+    public static CancellationToken FromSeconds(TimeSpan duration)
+    {
+        var seconds = (int)Math.Ceiling(duration.TotalSeconds);
+        return FromSeconds(seconds);
+    }
+
     public static CancellationToken FromSeconds(int seconds)
     {
         if (seconds < 1) throw new ArgumentOutOfRangeException(nameof(seconds));

--- a/src/Proto.Cluster/ActivatedClusterKind.cs
+++ b/src/Proto.Cluster/ActivatedClusterKind.cs
@@ -11,16 +11,18 @@ public record ActivatedClusterKind
 {
     private long _count;
 
-    internal ActivatedClusterKind(string name, Props props, IMemberStrategy? strategy)
+    internal ActivatedClusterKind(string name, Props props, IMemberStrategy? strategy, CanSpawnIdentity? canSpawnIdentity)
     {
         Name = name;
         Props = props.WithClusterKind(this);
         Strategy = strategy;
+        CanSpawnIdentity = canSpawnIdentity;
     }
 
     public string Name { get; }
     public Props Props { get; }
     public IMemberStrategy? Strategy { get; }
+    public CanSpawnIdentity? CanSpawnIdentity { get; }
 
     internal long Inc() => Interlocked.Increment(ref _count);
 

--- a/src/Proto.Cluster/ClusterContracts.proto
+++ b/src/Proto.Cluster/ClusterContracts.proto
@@ -95,6 +95,7 @@ message ActivationResponse {
   actor.PID pid = 1;
   bool failed = 2;
   uint64 topology_hash = 3;
+  bool invalid_identity = 4;
 }
 
 message ReadyForRebalance {

--- a/src/Proto.Cluster/ClusterKind.cs
+++ b/src/Proto.Cluster/ClusterKind.cs
@@ -4,13 +4,13 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System;
+using System.Threading;
 using System.Threading.Tasks;
-using Google.Protobuf.WellKnownTypes;
 using JetBrains.Annotations;
 
 namespace Proto.Cluster;
 
-public delegate ValueTask<bool> CanSpawnIdentity(string identity);
+public delegate ValueTask<bool> CanSpawnIdentity(string identity, CancellationToken cancellationToken);
 
 [PublicAPI]
 public record ClusterKind(string Name, Props Props)

--- a/src/Proto.Cluster/ClusterKind.cs
+++ b/src/Proto.Cluster/ClusterKind.cs
@@ -4,17 +4,26 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System;
+using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
 using JetBrains.Annotations;
 
 namespace Proto.Cluster;
+
+public delegate ValueTask<bool> CanSpawnIdentity(string identity);
 
 [PublicAPI]
 public record ClusterKind(string Name, Props Props)
 {
     public Func<Cluster, IMemberStrategy>? StrategyBuilder { get; init; }
 
+    public CanSpawnIdentity? CanSpawnIdentity { get; init; }
+
     public ClusterKind WithMemberStrategy(Func<Cluster, IMemberStrategy> strategyBuilder)
         => this with {StrategyBuilder = strategyBuilder};
+    
+    public ClusterKind WithSpawnPredicate(CanSpawnIdentity spawnPredicate)
+        => this with {CanSpawnIdentity = spawnPredicate};
 
-    internal ActivatedClusterKind Build(Cluster cluster) => new(Name, Props, StrategyBuilder?.Invoke(cluster));
+    internal ActivatedClusterKind Build(Cluster cluster) => new(Name, Props, StrategyBuilder?.Invoke(cluster), CanSpawnIdentity);
 }

--- a/src/Proto.Cluster/DefaultClusterContext.cs
+++ b/src/Proto.Cluster/DefaultClusterContext.cs
@@ -166,7 +166,7 @@ public class DefaultClusterContext : IClusterContext
                 return pid;
             }
         }
-        catch (Exception e) when(e is not IdentityBlockedException)
+        catch (Exception e) when(e is not IdentityIsBlocked)
         {
             e.CheckFailFast();
             if (context.System.Shutdown.IsCancellationRequested) return default;

--- a/src/Proto.Cluster/DefaultClusterContext.cs
+++ b/src/Proto.Cluster/DefaultClusterContext.cs
@@ -166,7 +166,7 @@ public class DefaultClusterContext : IClusterContext
                 return pid;
             }
         }
-        catch (Exception e)
+        catch (Exception e) when(e is not IdentityBlockedException)
         {
             e.CheckFailFast();
             if (context.System.Shutdown.IsCancellationRequested) return default;

--- a/src/Proto.Cluster/ExperimentalClusterContext.cs
+++ b/src/Proto.Cluster/ExperimentalClusterContext.cs
@@ -202,7 +202,7 @@ public class ExperimentalClusterContext : IClusterContext
                 return pid;
             }
         }
-        catch (Exception e)
+        catch (Exception e) when(e is not IdentityBlockedException)
         {
             e.CheckFailFast();
             if (context.System.Shutdown.IsCancellationRequested) return default;

--- a/src/Proto.Cluster/ExperimentalClusterContext.cs
+++ b/src/Proto.Cluster/ExperimentalClusterContext.cs
@@ -202,7 +202,7 @@ public class ExperimentalClusterContext : IClusterContext
                 return pid;
             }
         }
-        catch (Exception e) when(e is not IdentityBlockedException)
+        catch (Exception e) when(e is not IdentityIsBlocked)
         {
             e.CheckFailFast();
             if (context.System.Shutdown.IsCancellationRequested) return default;

--- a/src/Proto.Cluster/Identity/GetPid.cs
+++ b/src/Proto.Cluster/Identity/GetPid.cs
@@ -19,7 +19,12 @@ class GetPid : IHashable
 
 class PidResult
 {
+    public static readonly PidResult Blocked = new(true);
+
     public PidResult(PID? pid) => Pid = pid;
 
+    private PidResult(bool identityBlocked) => IdentityBlocked = identityBlocked;
+
     public PID? Pid { get; }
+    public bool IdentityBlocked { get; }
 }

--- a/src/Proto.Cluster/Identity/IdentityBlockedException.cs
+++ b/src/Proto.Cluster/Identity/IdentityBlockedException.cs
@@ -1,0 +1,18 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file = "IdentityBlockedException.cs" company = "Asynkron AB">
+//      Copyright (C) 2015-2022 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+
+namespace Proto.Cluster.Identity;
+
+/// <summary>
+/// Lets the caller know that the identity is not available to spawn.
+/// </summary>
+public class IdentityBlockedException : Exception
+{
+    public IdentityBlockedException(ClusterIdentity blockedIdentity) => BlockedIdentity = blockedIdentity;
+
+    public ClusterIdentity BlockedIdentity { get; }
+}

--- a/src/Proto.Cluster/Identity/IdentityIsBlocked.cs
+++ b/src/Proto.Cluster/Identity/IdentityIsBlocked.cs
@@ -10,9 +10,9 @@ namespace Proto.Cluster.Identity;
 /// <summary>
 /// Lets the caller know that the identity is not available to spawn.
 /// </summary>
-public class IdentityBlockedException : Exception
+public class IdentityIsBlocked : Exception
 {
-    public IdentityBlockedException(ClusterIdentity blockedIdentity) => BlockedIdentity = blockedIdentity;
+    public IdentityIsBlocked(ClusterIdentity blockedIdentity) => BlockedIdentity = blockedIdentity;
 
     public ClusterIdentity BlockedIdentity { get; }
 }

--- a/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
@@ -26,7 +26,7 @@ public class IdentityStorageLookup : IIdentityLookup
 
         if (res?.IdentityBlocked == true)
         {
-            throw new IdentityBlockedException(clusterIdentity);
+            throw new IdentityIsBlocked(clusterIdentity);
         }
         return res?.Pid;
     }

--- a/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageLookup.cs
@@ -23,6 +23,11 @@ public class IdentityStorageLookup : IIdentityLookup
         var msg = new GetPid(clusterIdentity, ct);
 
         var res = await _system.Root.RequestAsync<PidResult>(_worker, msg, ct);
+
+        if (res?.IdentityBlocked == true)
+        {
+            throw new IdentityBlockedException(clusterIdentity);
+        }
         return res?.Pid;
     }
 

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -67,7 +67,7 @@ class IdentityStorageWorker : IActor
             context.ReenterAfter(GetWithGlobalLock(context.Sender!, clusterIdentity), task => {
                     try
                     {
-                        var response = new PidResult(task.Result);
+                        var response = task.Result;
                         context.Respond(response);
                         RespondToWaitingRequests(context, clusterIdentity, response);
 
@@ -99,15 +99,15 @@ class IdentityStorageWorker : IActor
         }
     }
 
-    private Task<PID?> GetWithGlobalLock(PID sender, ClusterIdentity clusterIdentity)
+    private Task<PidResult> GetWithGlobalLock(PID sender, ClusterIdentity clusterIdentity)
     {
-        async Task<PID?> Inner()
+        async Task<PidResult> Inner()
         {
             var tries = 0;
-            PID? result = null;
+            PID? pid = null;
             SpawnLock? spawnLock = null;
 
-            while (result == null && !_cluster.System.Shutdown.IsCancellationRequested && ++tries <= MaxSpawnRetries)
+            while (pid == null && !_cluster.System.Shutdown.IsCancellationRequested && ++tries <= MaxSpawnRetries)
             {
                 try
                 {
@@ -118,7 +118,7 @@ class IdentityStorageWorker : IActor
                     if (activation != null)
                     {
                         var existingPid = await ValidateAndMapToPid(clusterIdentity, activation);
-                        if (existingPid != null) return existingPid;
+                        if (existingPid != null) return new PidResult(existingPid);
                     }
 
                     //are there any members that can spawn this kind?
@@ -135,13 +135,18 @@ class IdentityStorageWorker : IActor
                     if (spawnLock == null)
                     {
                         using var cts = new CancellationTokenSource(_cluster.Config.ActorActivationTimeout);
-                        result = await WaitForActivation(clusterIdentity, cts.Token);
+                        pid = await WaitForActivation(clusterIdentity, cts.Token);
                     }
                     else
                     {
                         using var cts = new CancellationTokenSource(_cluster.Config.ActorActivationTimeout);
                         //we have the lock, spawn and return
-                        (result, spawnLock) = await SpawnActivationAsync(activator, spawnLock, cts.Token);
+                        (var spawnResult, spawnLock) = await SpawnActivationAsync(activator, spawnLock, cts.Token);
+
+                        if (spawnResult is not null)
+                        {
+                            return spawnResult;
+                        }
                     }
                 }
                 catch (OperationCanceledException e)
@@ -164,7 +169,7 @@ class IdentityStorageWorker : IActor
                 }
             }
 
-            return result;
+            return new PidResult(pid);
         }
 
         if (!_cluster.System.Metrics.Enabled)
@@ -211,7 +216,7 @@ class IdentityStorageWorker : IActor
             );
     }
 
-    private async Task<(PID?, SpawnLock?)> SpawnActivationAsync(Member activator, SpawnLock spawnLock, CancellationToken ct)
+    private async Task<(PidResult?, SpawnLock?)> SpawnActivationAsync(Member activator, SpawnLock spawnLock, CancellationToken ct)
     {
         //we own the lock
         if (_logger.IsEnabled(LogLevel.Debug)) _logger.LogDebug("Storing placement lookup for {Identity} {Kind}", spawnLock.ClusterIdentity.Identity,
@@ -232,7 +237,12 @@ class IdentityStorageWorker : IActor
             if (resp.Pid != null)
             {
                 _cluster.PidCache.TryAdd(spawnLock.ClusterIdentity, resp.Pid!);
-                return (resp.Pid, null);
+                return (new PidResult(resp.Pid), null);
+            }
+
+            if (resp.InvalidIdentity)
+            {
+                return (PidResult.Blocked, null);
             }
         }
         //TODO: decide if we throw or return null

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -34,7 +34,7 @@ class IdentityStorageWorker : IActor
         _shouldThrottle = Throttle.Create(
             10,
             TimeSpan.FromSeconds(5),
-            i => _logger.LogInformation("Throttled {LogCount} IdentityStorageWorker logs.", i)
+            i => _logger.LogInformation("Throttled {LogCount} IdentityStorageWorker logs", i)
         );
 
         _cluster = storageLookup.Cluster;

--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -583,7 +583,7 @@ class PartitionIdentityActor : IActor
                     return;
                 }
 
-                if (response?.Pid != null)
+                if (response.Pid != null)
                 {
                     if (_config.DeveloperLogging)
                         Console.Write("A"); //activated
@@ -613,12 +613,17 @@ class PartitionIdentityActor : IActor
 
                     return;
                 }
+                
+                // Failed, return err response
+                Respond(response);
+
             }
             catch (Exception x)
             {
                 x.CheckFailFast();
                 Logger.LogError(x, "[PartitionIdentity] Spawn failed");
                 _deltaTopology = null; // Do not use delta handover if we are not sure all spawns are OK.
+                Respond(new ActivationResponse {Failed = true});
             }
             finally
             {
@@ -629,10 +634,6 @@ class PartitionIdentityActor : IActor
                     SetReadyToRebalanceIfNoMoreWaitingSpawns();
                 }
             }
-
-            if (_config.DeveloperLogging)
-                Console.Write("F"); //failed
-            Respond(new ActivationResponse {Failed = true});
 
             // The response both responds to the initial activator, but also any other waiting reentrant requests
             void Respond(ActivationResponse response)

--- a/src/Proto.Cluster/Partition/PartitionIdentityLookup.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityLookup.cs
@@ -71,6 +71,11 @@ public class PartitionIdentityLookup : IIdentityLookup
 
             if (resp?.Pid != null) return resp.Pid;
 
+            if (resp?.InvalidIdentity == true)
+            {
+                throw new IdentityBlockedException(clusterIdentity);
+            }
+
             if (_config.DeveloperLogging)
                 Console.WriteLine("Failed");
 
@@ -107,7 +112,7 @@ public class PartitionIdentityLookup : IIdentityLookup
             Logger.LogInformation("[PartitionIdentity] Remote PID request timeout {@Request}, identity Owner {Owner}", req, identityOwner);
             return null;
         }
-        catch (Exception e)
+        catch (Exception e) when(e is not IdentityBlockedException)
         {
             e.CheckFailFast();
             Logger.LogError(e, "[PartitionIdentity] Error occured requesting remote PID {@Request}, identity Owner {Owner}", req, identityOwner);

--- a/src/Proto.Cluster/Partition/PartitionIdentityLookup.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityLookup.cs
@@ -73,7 +73,7 @@ public class PartitionIdentityLookup : IIdentityLookup
 
             if (resp?.InvalidIdentity == true)
             {
-                throw new IdentityBlockedException(clusterIdentity);
+                throw new IdentityIsBlocked(clusterIdentity);
             }
 
             if (_config.DeveloperLogging)
@@ -112,7 +112,7 @@ public class PartitionIdentityLookup : IIdentityLookup
             Logger.LogInformation("[PartitionIdentity] Remote PID request timeout {@Request}, identity Owner {Owner}", req, identityOwner);
             return null;
         }
-        catch (Exception e) when(e is not IdentityBlockedException)
+        catch (Exception e) when(e is not IdentityIsBlocked)
         {
             e.CheckFailFast();
             Logger.LogError(e, "[PartitionIdentity] Error occured requesting remote PID {@Request}, identity Owner {Owner}", req, identityOwner);

--- a/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
@@ -21,7 +21,8 @@ class PartitionPlacementActor : IActor, IDisposable
 
     //pid -> the actor that we have created here
     //kind -> the actor kind
-    private readonly Dictionary<ClusterIdentity, PID> _myActors = new();
+    private readonly Dictionary<ClusterIdentity, PID> _actors = new();
+    private readonly HashSet<ClusterIdentity> _inFlightIdentityChecks = new();
     private readonly PartitionConfig _config;
     private EventStreamSubscription<object>? _subscription;
 
@@ -48,7 +49,8 @@ class PartitionPlacementActor : IActor, IDisposable
     {
         if (_config.Mode != PartitionIdentityLookup.Mode.Push) return Task.CompletedTask;
 
-        if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug("[PartitionIdentity] Got topology {TopologyHash}, waiting for current activations to complete", msg.TopologyHash);
+        if (Logger.IsEnabled(LogLevel.Debug))
+            Logger.LogDebug("[PartitionIdentity] Got topology {TopologyHash}, waiting for current activations to complete", msg.TopologyHash);
 
         var cancellationToken = msg.TopologyValidityToken!.Value;
         // TODO: Configurable timeout
@@ -67,7 +69,8 @@ class PartitionPlacementActor : IActor, IDisposable
 
     private async Task Rebalance(IContext context, ClusterTopology msg)
     {
-        if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebug("[PartitionIdentity] Initiating rebalance publish for topology {TopologyHash}", msg.TopologyHash);
+        if (Logger.IsEnabled(LogLevel.Debug))
+            Logger.LogDebug("[PartitionIdentity] Initiating rebalance publish for topology {TopologyHash}", msg.TopologyHash);
 
         try
         {
@@ -119,12 +122,12 @@ class PartitionPlacementActor : IActor, IDisposable
             case PartitionIdentityLookup.Send.Delta:
                 var previousHashRing = _lastRebalancedTopology is null ? null : new MemberHashRing(_lastRebalancedTopology.Members);
 
-                return HandoverSource.CreateHandovers(msg, _config.HandoverChunkSize, _myActors, GetCurrentOwner,
+                return HandoverSource.CreateHandovers(msg, _config.HandoverChunkSize, _actors, GetCurrentOwner,
                     previousHashRing is null ? null : identity => previousHashRing.GetOwnerMemberByIdentity(identity)
                 );
             case PartitionIdentityLookup.Send.Full:
             default:
-                return HandoverSource.CreateHandovers(msg, _config.HandoverChunkSize, _myActors, GetCurrentOwner);
+                return HandoverSource.CreateHandovers(msg, _config.HandoverChunkSize, _actors, GetCurrentOwner);
         }
     }
 
@@ -136,13 +139,13 @@ class PartitionPlacementActor : IActor, IDisposable
 
         if (request.DeltaTopology is null)
         {
-            return HandoverSource.CreateHandovers(request.CurrentTopology.TopologyHash, _config.HandoverChunkSize, _myActors,
+            return HandoverSource.CreateHandovers(request.CurrentTopology.TopologyHash, _config.HandoverChunkSize, _actors,
                 identity => currentHashRing.GetOwnerMemberByIdentity(identity).Equals(address, StringComparison.Ordinal)
             );
         }
 
         var previousHashRing = new MemberHashRing(request.DeltaTopology.Members);
-        return HandoverSource.CreateHandovers(request.CurrentTopology.TopologyHash, _config.HandoverChunkSize, _myActors,
+        return HandoverSource.CreateHandovers(request.CurrentTopology.TopologyHash, _config.HandoverChunkSize, _actors,
             identity => currentHashRing.GetOwnerMemberByIdentity(identity).Equals(address, StringComparison.Ordinal),
             identity => previousHashRing.GetOwnerMemberByIdentity(identity).Equals(address, StringComparison.Ordinal)
         );
@@ -207,7 +210,7 @@ class PartitionPlacementActor : IActor, IDisposable
 
     private Task OnActivationTerminating(ActivationTerminating msg)
     {
-        if (!_myActors.TryGetValue(msg.ClusterIdentity, out var pid))
+        if (!_actors.TryGetValue(msg.ClusterIdentity, out var pid))
         {
             Logger.LogWarning("[PartitionIdentity] Activation not found: {ActivationTerminating}", msg);
             return Task.CompletedTask;
@@ -219,7 +222,7 @@ class PartitionPlacementActor : IActor, IDisposable
             return Task.CompletedTask;
         }
 
-        _myActors.Remove(msg.ClusterIdentity);
+        _actors.Remove(msg.ClusterIdentity);
 
         var activationTerminated = new ActivationTerminated
         {
@@ -275,7 +278,10 @@ class PartitionPlacementActor : IActor, IDisposable
         {
             if (cancelRebalance.IsCancellationRequested)
             {
-                context.Logger()?.LogInformation("[PartitionIdentity] Cancelled rebalance handover for topology: {TopologyHash}", msg.CurrentTopology.TopologyHash);
+                context.Logger()?.LogInformation("[PartitionIdentity] Cancelled rebalance handover for topology: {TopologyHash}",
+                    msg.CurrentTopology.TopologyHash
+                );
+
                 if (_config.DeveloperLogging)
                 {
                     Console.WriteLine($"Cancelled rebalance handover for topology: {msg.CurrentTopology.TopologyHash}");
@@ -304,58 +310,122 @@ class PartitionPlacementActor : IActor, IDisposable
 
     private Task OnActivationRequest(IContext context, ActivationRequest msg)
     {
+        if (_actors.TryGetValue(msg.ClusterIdentity, out var existing))
+        {
+            if (_config.DeveloperLogging)
+                Console.WriteLine($"Activator got request for existing activation {msg.RequestId}");
+            //this identity already exists
+            var response = new ActivationResponse
+            {
+                Pid = existing,
+                TopologyHash = msg.TopologyHash
+            };
+            context.Respond(response);
+            return Task.CompletedTask;
+        }
+
+        var clusterKind = _cluster.TryGetClusterKind(msg.Kind);
+
+        if (clusterKind is null)
+        {
+            Logger.LogError("Failed to spawn {Kind}/{Identity}, kind not found for member", msg.Kind, msg.Identity);
+            context.Respond(new ActivationResponse{Failed = true});
+            return Task.CompletedTask;
+        }
+
+        if (clusterKind.CanSpawnIdentity is not null)
+        {
+            // Needs to check if the identity is allowed to spawn
+            VerifyAndSpawn(msg, context, clusterKind);
+        }
+        else
+        {
+            Spawn(msg, context, clusterKind);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void VerifyAndSpawn(ActivationRequest msg, IContext context, ActivatedClusterKind clusterKind)
+    {
+        var clusterIdentity = msg.ClusterIdentity;
+
+        if (_inFlightIdentityChecks.Contains(clusterIdentity))
+        {
+            Logger.LogError("[PartitionIdentity] Duplicate activation requests for {ClusterIdentity}", clusterIdentity);
+            context.Respond(new ActivationResponse
+                {
+                    Failed = true,
+                }
+            );
+        }
+
+        var canSpawn = clusterKind.CanSpawnIdentity!(msg.Identity);
+
+        if (canSpawn.IsCompleted)
+        {
+            OnSpawnDecided(msg, context, clusterKind, canSpawn.Result);
+            return;
+        }
+
+        _inFlightIdentityChecks.Add(clusterIdentity);
+        context.ReenterAfter(canSpawn.AsTask(), task => {
+                _inFlightIdentityChecks.Remove(clusterIdentity);
+                if (task.IsCompletedSuccessfully)
+                {
+                    OnSpawnDecided(msg, context, clusterKind, task.Result);
+                }
+                else
+                {
+                    Logger.LogError("[PartitionIdentity] Error when checking {ClusterIdentity}", clusterIdentity);
+                    context.Respond(new ActivationResponse
+                        {
+                            Failed = true,
+                        }
+                    );
+                }
+
+                return Task.CompletedTask;
+            }
+        );
+    }
+
+    private void Spawn(ActivationRequest msg, IContext context, ActivatedClusterKind clusterKind)
+    {
         try
         {
-            if (_myActors.TryGetValue(msg.ClusterIdentity, out var existing))
-            {
-                if (_config.DeveloperLogging)
-                    Console.WriteLine($"Activator got request for existing activation {msg.RequestId}");
-                //this identity already exists
-                var response = new ActivationResponse
-                {
-                    Pid = existing,
-                    TopologyHash = msg.TopologyHash
-                };
-                context.Respond(response);
-            }
-            else
-            {
-                if (_config.DeveloperLogging)
-                    Console.WriteLine($"Activator got request for new activation {msg.RequestId}");
-                var clusterKind = _cluster.GetClusterKind(msg.ClusterIdentity.Kind);
-                //this actor did not exist, lets spawn a new activation
-
-                //spawn and remember this actor
-                //as this id is unique for this activation (id+counter)
-                //we cannot get ProcessNameAlreadyExists exception here
-                
-                var pid = context.SpawnPrefix(clusterKind.Props, msg.ClusterIdentity.Identity, ctx => ctx.Set(msg.ClusterIdentity));
-
-                _myActors[msg.ClusterIdentity] = pid;
-
-                var response = new ActivationResponse
+            var pid = context.SpawnPrefix(clusterKind.Props, msg.ClusterIdentity.Identity, ctx => ctx.Set(msg.ClusterIdentity));
+            _actors.Add(msg.ClusterIdentity, pid);
+            context.Respond(new ActivationResponse
                 {
                     Pid = pid,
-                    TopologyHash = msg.TopologyHash
-                };
-                context.Respond(response);
-                if (_config.DeveloperLogging)
-                    Console.WriteLine($"Activated {msg.RequestId}");
-            }
+                }
+            );
         }
         catch (Exception e)
         {
             e.CheckFailFast();
             Logger.LogError(e, "[PartitionIdentity] Failed to spawn {Kind}/{Identity}", msg.Kind, msg.Identity);
-            var response = new ActivationResponse
-            {
-                Pid = null,
-                Failed = true
-            };
-            context.Respond(response);
+            context.Respond(new ActivationResponse {Failed = true});
         }
+    }
 
-        return Task.CompletedTask;
+
+    private void OnSpawnDecided(ActivationRequest msg, IContext context, ActivatedClusterKind clusterKind, bool canSpawnIdentity)
+    {
+        if (canSpawnIdentity)
+        {
+            Spawn(msg, context, clusterKind);
+        }
+        else
+        {
+            context.Respond(new ActivationResponse
+                {
+                    Failed = true,
+                    InvalidIdentity = true
+                }
+            );
+        }
     }
 
     public void Dispose() => _subscription?.Unsubscribe();

--- a/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
@@ -360,7 +360,7 @@ class PartitionPlacementActor : IActor, IDisposable
             );
         }
 
-        var canSpawn = clusterKind.CanSpawnIdentity!(msg.Identity);
+        var canSpawn = clusterKind.CanSpawnIdentity!(msg.Identity, CancellationTokens.FromSeconds(_cluster.Config.ActorSpawnTimeout));
 
         if (canSpawn.IsCompleted)
         {

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
@@ -23,10 +23,12 @@ public class PartitionActivatorActor : IActor
             }
         }
     );
+
     private ulong _topologyHash;
     private readonly Cluster _cluster;
     private readonly PartitionActivatorManager _manager;
     private readonly Dictionary<ClusterIdentity, PID> _actors = new();
+    private readonly HashSet<ClusterIdentity> _inFlightIdentityChecks = new();
     private readonly string _myAddress;
 
     public PartitionActivatorActor(Cluster cluster, PartitionActivatorManager manager)
@@ -35,11 +37,11 @@ public class PartitionActivatorActor : IActor
         _manager = manager;
         _myAddress = cluster.System.Address;
     }
-        
+
     private Task OnStarted(IContext context)
     {
         var self = context.Self;
-        _cluster.System.EventStream.Subscribe<ActivationTerminated>(e => _cluster.System.Root.Send(self,e));
+        _cluster.System.EventStream.Subscribe<ActivationTerminated>(e => _cluster.System.Root.Send(self, e));
         _cluster.System.EventStream.Subscribe<ActivationTerminating>(e => _cluster.System.Root.Send(self, e));
 
         return Task.CompletedTask;
@@ -48,19 +50,19 @@ public class PartitionActivatorActor : IActor
     public Task ReceiveAsync(IContext context) =>
         context.Message switch
         {
-            Started                  => OnStarted(context),
-            ActivationRequest msg    => OnActivationRequest(msg, context),
-            ActivationTerminated msg => OnActivationTerminated(msg, context),
+            Started                   => OnStarted(context),
+            ActivationRequest msg     => OnActivationRequest(msg, context),
+            ActivationTerminated msg  => OnActivationTerminated(msg),
             ActivationTerminating msg => OnActivationTerminating(msg, context),
-            ClusterTopology msg      => OnClusterTopology(msg, context),
-            _                        => Task.CompletedTask
+            ClusterTopology msg       => OnClusterTopology(msg, context),
+            _                         => Task.CompletedTask
         };
 
     private async Task OnClusterTopology(ClusterTopology msg, IContext context)
     {
         if (msg.TopologyHash == _topologyHash)
             return;
-            
+
         _topologyHash = msg.TopologyHash;
 
         var toRemove = _actors
@@ -69,8 +71,9 @@ public class PartitionActivatorActor : IActor
             .ToList();
 
         //stop and remove all actors we don't own anymore
-        Logger.LogWarning("[PartitionActivator] ClusterTopology - Stopping {actorCount} actors", toRemove.Count);
+        Logger.LogWarning("[PartitionActivator] ClusterTopology - Stopping {ActorCount} actors", toRemove.Count);
         var stopping = new List<Task>();
+
         foreach (var ci in toRemove)
         {
             var pid = _actors[ci];
@@ -81,15 +84,16 @@ public class PartitionActivatorActor : IActor
 
         //await graceful shutdown of all actors we no longer own
         await Task.WhenAll(stopping);
-        Logger.LogWarning("[PartitionActivator] ClusterTopology - Stopped {actorCount} actors", toRemove.Count);
+        Logger.LogWarning("[PartitionActivator] ClusterTopology - Stopped {ActorCount} actors", toRemove.Count);
 
         // Remove all cached PIDs from PidCache that now points to
         // an address where the ClusterIdentity doesn't belong.
         _cluster.PidCache.RemoveByPredicate(cache =>
-            _manager.Selector.GetOwnerAddress(cache.Key) != cache.Value.Address);
+            _manager.Selector.GetOwnerAddress(cache.Key) != cache.Value.Address
+        );
     }
-        
-    private Task OnActivationTerminated(ActivationTerminated msg, IContext context)
+
+    private Task OnActivationTerminated(ActivationTerminated msg)
     {
         _cluster.PidCache.RemoveByVal(msg.ClusterIdentity, msg.Pid);
 
@@ -140,6 +144,7 @@ public class PartitionActivatorActor : IActor
             {
                 Logger.LogWarning("[PartitionActivator] Tried to spawn on wrong node, forwarding");
             }
+
             context.Forward(ownerPid);
 
             return Task.CompletedTask;
@@ -148,13 +153,78 @@ public class PartitionActivatorActor : IActor
         if (_actors.TryGetValue(msg.ClusterIdentity, out var existing))
         {
             context.Respond(new ActivationResponse
-            {
-                Pid = existing,
-            });
+                {
+                    Pid = existing,
+                }
+            );
         }
         else
         {
             var clusterKind = _cluster.GetClusterKind(msg.Kind);
+
+            if (clusterKind.CanSpawnIdentity is not null)
+            {
+                // Needs to check if the identity is allowed to spawn
+                VerifyAndSpawn(msg, context, clusterKind);
+            }
+            else
+            {
+                Spawn(msg, context, clusterKind);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void VerifyAndSpawn(ActivationRequest msg, IContext context, ActivatedClusterKind clusterKind)
+    {
+        var clusterIdentity = msg.ClusterIdentity;
+
+        if (_inFlightIdentityChecks.Contains(clusterIdentity))
+        {
+            Logger.LogError("[PartitionActivator] Duplicate activation requests for {ClusterIdentity}", clusterIdentity);
+            context.Respond(new ActivationResponse
+                {
+                    Failed = true,
+                }
+            );
+        }
+
+        var canSpawn = clusterKind.CanSpawnIdentity!(msg.Identity);
+
+        if (canSpawn.IsCompleted)
+        {
+            OnSpawnDecided(msg, context, clusterKind, canSpawn.Result);
+            return;
+        }
+
+        _inFlightIdentityChecks.Add(clusterIdentity);
+        context.ReenterAfter(canSpawn.AsTask(), task => {
+                _inFlightIdentityChecks.Remove(clusterIdentity);
+
+                if (task.IsCompletedSuccessfully)
+                {
+                    OnSpawnDecided(msg, context, clusterKind, task.Result);
+                }
+                else
+                {
+                    Logger.LogError("[PartitionActivator] Error when checking {ClusterIdentity}", clusterIdentity);
+                    context.Respond(new ActivationResponse
+                        {
+                            Failed = true,
+                        }
+                    );
+                }
+
+                return Task.CompletedTask;
+            }
+        );
+    }
+
+    private void Spawn(ActivationRequest msg, IContext context, ActivatedClusterKind clusterKind)
+    {
+        try
+        {
             var pid = context.SpawnPrefix(clusterKind.Props, msg.ClusterIdentity.Identity, ctx => ctx.Set(msg.ClusterIdentity));
             _actors.Add(msg.ClusterIdentity, pid);
             context.Respond(new ActivationResponse
@@ -163,7 +233,28 @@ public class PartitionActivatorActor : IActor
                 }
             );
         }
+        catch (Exception e)
+        {
+            e.CheckFailFast();
+            Logger.LogError(e, "[PartitionActivator] Failed to spawn {Kind}/{Identity}", msg.Kind, msg.Identity);
+            context.Respond(new ActivationResponse {Failed = true});
+        }
+    }
 
-        return Task.CompletedTask;
+    private void OnSpawnDecided(ActivationRequest msg, IContext context, ActivatedClusterKind clusterKind, bool canSpawnIdentity)
+    {
+        if (canSpawnIdentity)
+        {
+            Spawn(msg, context, clusterKind);
+        }
+        else
+        {
+            context.Respond(new ActivationResponse
+                {
+                    Failed = true,
+                    InvalidIdentity = true
+                }
+            );
+        }
     }
 }

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
@@ -53,7 +53,7 @@ public class PartitionActivatorActor : IActor
             Started                   => OnStarted(context),
             ActivationRequest msg     => OnActivationRequest(msg, context),
             ActivationTerminated msg  => OnActivationTerminated(msg),
-            ActivationTerminating msg => OnActivationTerminating(msg, context),
+            ActivationTerminating msg => OnActivationTerminating(msg),
             ClusterTopology msg       => OnClusterTopology(msg, context),
             _                         => Task.CompletedTask
         };
@@ -104,7 +104,7 @@ public class PartitionActivatorActor : IActor
         return Task.CompletedTask;
     }
 
-    private Task OnActivationTerminating(ActivationTerminating msg, IContext context)
+    private Task OnActivationTerminating(ActivationTerminating msg)
     {
         // ActivationTerminating is sent to the local EventStream when a
         // local cluster actor stops.
@@ -190,7 +190,7 @@ public class PartitionActivatorActor : IActor
             );
         }
 
-        var canSpawn = clusterKind.CanSpawnIdentity!(msg.Identity);
+        var canSpawn = clusterKind.CanSpawnIdentity!(msg.Identity, CancellationTokens.FromSeconds(_cluster.Config.ActorSpawnTimeout));
 
         if (canSpawn.IsCompleted)
         {

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorLookup.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorLookup.cs
@@ -49,7 +49,7 @@ public class PartitionActivatorLookup : IIdentityLookup
 
             if (resp.InvalidIdentity)
             {
-                throw new IdentityBlockedException(clusterIdentity);
+                throw new IdentityIsBlocked(clusterIdentity);
             }
 
             return resp?.Pid;
@@ -65,7 +65,7 @@ public class PartitionActivatorLookup : IIdentityLookup
             Logger.LogInformation("[PartitionActivator] Remote PID request timeout {@Request}, identity Owner {Owner}", req, owner);
             return null;
         }
-        catch (Exception e) when(e is not IdentityBlockedException)
+        catch (Exception e) when(e is not IdentityIsBlocked)
         {
             e.CheckFailFast();
             Logger.LogError(e, "[PartitionActivator] Error occured requesting remote PID {@Request}, identity Owner {Owner}", req, owner);

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorLookup.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorLookup.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Proto.Cluster.Identity;
-using Proto.Cluster.Partition;
 
 namespace Proto.Cluster.PartitionActivator;
 
@@ -23,10 +22,7 @@ public class PartitionActivatorLookup : IIdentityLookup
     {
     }
 
-    public PartitionActivatorLookup(TimeSpan getPidTimeout)
-    {
-        _getPidTimeout = getPidTimeout;
-    }
+    public PartitionActivatorLookup(TimeSpan getPidTimeout) => _getPidTimeout = getPidTimeout;
 
     public async Task<PID?> GetAsync(ClusterIdentity clusterIdentity, CancellationToken notUsed)
     {
@@ -51,6 +47,11 @@ public class PartitionActivatorLookup : IIdentityLookup
 
             var resp = await _cluster.System.Root.RequestAsync<ActivationResponse>(remotePid, req, cts.Token);
 
+            if (resp.InvalidIdentity)
+            {
+                throw new IdentityBlockedException(clusterIdentity);
+            }
+
             return resp?.Pid;
         }
         //TODO: decide if we throw or return null
@@ -64,7 +65,7 @@ public class PartitionActivatorLookup : IIdentityLookup
             Logger.LogInformation("[PartitionActivator] Remote PID request timeout {@Request}, identity Owner {Owner}", req, owner);
             return null;
         }
-        catch (Exception e)
+        catch (Exception e) when(e is not IdentityBlockedException)
         {
             e.CheckFailFast();
             Logger.LogError(e, "[PartitionActivator] Error occured requesting remote PID {@Request}, identity Owner {Owner}", req, owner);

--- a/tests/Proto.Cluster.Tests/ClusterFixture.cs
+++ b/tests/Proto.Cluster.Tests/ClusterFixture.cs
@@ -10,6 +10,7 @@ using OpenTelemetry.Trace;
 using Proto.Cluster.Cache;
 using Proto.Cluster.Identity;
 using Proto.Cluster.Partition;
+using Proto.Cluster.PartitionActivator;
 using Proto.Cluster.Testing;
 using Proto.Logging;
 using Proto.OpenTelemetry;
@@ -35,6 +36,7 @@ public interface IClusterFixture
 public abstract class ClusterFixture : IAsyncLifetime, IClusterFixture, IAsyncDisposable
 {
     private const bool EnableTracing = false;
+    public const string InvalidIdentity = "invalid";
 
     protected readonly string ClusterName;
     private readonly int _clusterSize;
@@ -74,6 +76,14 @@ public abstract class ClusterFixture : IAsyncLifetime, IClusterFixture, IAsyncDi
         new ClusterKind(EchoActor.Kind, EchoActor.Props.WithClusterRequestDeduplication()),
         new ClusterKind(EchoActor.Kind2, EchoActor.Props),
         new ClusterKind(EchoActor.LocalAffinityKind, EchoActor.Props).WithLocalAffinityRelocationStrategy(),
+        new ClusterKind(EchoActor.FilteredKind, EchoActor.Props).WithSpawnPredicate(identity
+            => new ValueTask<bool>(!identity.Equals(InvalidIdentity, StringComparison.InvariantCultureIgnoreCase))
+        ),
+        new ClusterKind(EchoActor.AsyncFilteredKind, EchoActor.Props).WithSpawnPredicate(async identity => {
+                await Task.Delay(1000);
+                return !identity.Equals(InvalidIdentity, StringComparison.InvariantCultureIgnoreCase);
+            }
+        ),
     };
 
     public async Task InitializeAsync()
@@ -177,7 +187,8 @@ public abstract class ClusterFixture : IAsyncLifetime, IClusterFixture, IAsyncDi
             HandoverChunkSize = 1000,
             RebalanceRequestTimeout = TimeSpan.FromSeconds(1),
             Mode = PartitionIdentityLookup.Mode.Pull
-        });
+        }
+    );
 
     async ValueTask IAsyncDisposable.DisposeAsync() => await DisposeAsync();
 }
@@ -205,6 +216,16 @@ public class InMemoryClusterFixture : BaseInMemoryClusterFixture
     public InMemoryClusterFixture() : base(3, config => config.WithActorRequestTimeout(TimeSpan.FromSeconds(4)))
     {
     }
+}
+
+// ReSharper disable once ClassNeverInstantiated.Global
+public class InMemoryClusterFixtureWithPartitionActivator : BaseInMemoryClusterFixture
+{
+    public InMemoryClusterFixtureWithPartitionActivator() : base(3, config => config.WithActorRequestTimeout(TimeSpan.FromSeconds(4)))
+    {
+    }
+
+    protected override IIdentityLookup GetIdentityLookup(string clusterName) => new PartitionActivatorLookup();
 }
 
 public class InMemoryClusterFixtureAlternativeClusterContext : BaseInMemoryClusterFixture

--- a/tests/Proto.Cluster.Tests/ClusterFixture.cs
+++ b/tests/Proto.Cluster.Tests/ClusterFixture.cs
@@ -76,11 +76,11 @@ public abstract class ClusterFixture : IAsyncLifetime, IClusterFixture, IAsyncDi
         new ClusterKind(EchoActor.Kind, EchoActor.Props.WithClusterRequestDeduplication()),
         new ClusterKind(EchoActor.Kind2, EchoActor.Props),
         new ClusterKind(EchoActor.LocalAffinityKind, EchoActor.Props).WithLocalAffinityRelocationStrategy(),
-        new ClusterKind(EchoActor.FilteredKind, EchoActor.Props).WithSpawnPredicate(identity
+        new ClusterKind(EchoActor.FilteredKind, EchoActor.Props).WithSpawnPredicate((identity, _)
             => new ValueTask<bool>(!identity.Equals(InvalidIdentity, StringComparison.InvariantCultureIgnoreCase))
         ),
-        new ClusterKind(EchoActor.AsyncFilteredKind, EchoActor.Props).WithSpawnPredicate(async identity => {
-                await Task.Delay(1000);
+        new ClusterKind(EchoActor.AsyncFilteredKind, EchoActor.Props).WithSpawnPredicate(async (identity, ct) => {
+                await Task.Delay(1000, ct);
                 return !identity.Equals(InvalidIdentity, StringComparison.InvariantCultureIgnoreCase);
             }
         ),

--- a/tests/Proto.Cluster.Tests/ClusterTests.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTests.cs
@@ -310,7 +310,7 @@ public abstract class ClusterTests : ClusterTestBase
 
         await member.Invoking(async m => await m.RequestAsync<Pong>(invalidIdentity, message, timeout))
             .Should()
-            .ThrowExactlyAsync<IdentityBlockedException>();
+            .ThrowExactlyAsync<IdentityIsBlocked>();
     }
 
     [Theory, InlineData(10, 20000)]

--- a/tests/Proto.Cluster.Tests/ClusterTestsWithLocalAffinity.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTestsWithLocalAffinity.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClusterTest.Messages;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Proto.Cluster.Tests;
+
+public abstract class ClusterTestsWithLocalAffinity : ClusterTests
+{
+    protected ClusterTestsWithLocalAffinity(ITestOutputHelper testOutputHelper, IClusterFixture clusterFixture)
+        : base(testOutputHelper, clusterFixture) {}
+
+    [Fact]
+    public async Task LocalAffinityMovesActivationsOnRemoteSender()
+    {
+        var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(20)).Token;
+        var firstNode = Members[0];
+        var secondNode = Members[1];
+
+        await PingAndVerifyLocality(firstNode, timeout, "1:1", firstNode.System.Address,
+            "Local affinity to sending node means that actors should spawn there"
+        );
+        LogProcessCounts();
+        await PingAndVerifyLocality(secondNode, timeout, "2:1", firstNode.System.Address,
+            "As the current instances exist on the 'wrong' node, these should respond before being moved"
+        );
+        LogProcessCounts();
+
+        _testOutputHelper.WriteLine("Allowing time for actors to respawn..");
+        await Task.Delay(200, timeout);
+        LogProcessCounts();
+
+        await PingAndVerifyLocality(secondNode, timeout, "2.2", secondNode.System.Address,
+            "Relocation should be triggered, and the actors should be respawned on the local node"
+        );
+        LogProcessCounts();
+
+        void LogProcessCounts() => _testOutputHelper.WriteLine(
+            $"Processes: {firstNode.System.Address}: {firstNode.System.ProcessRegistry.ProcessCount}, {secondNode.System.Address}: {secondNode.System.ProcessRegistry.ProcessCount}"
+        );
+    }
+
+    private async Task PingAndVerifyLocality(
+        Cluster cluster,
+        CancellationToken token,
+        string requestId,
+        string expectResponseFrom = null,
+        string because = null
+    )
+    {
+        _testOutputHelper.WriteLine("Sending requests from " + cluster.System.Address);
+
+        await Task.WhenAll(
+            Enumerable.Range(0, 100).Select(async i => {
+                    var response = await cluster.RequestAsync<HereIAm>(CreateIdentity(i.ToString()), EchoActor.LocalAffinityKind, new WhereAreYou
+                        {
+                            RequestId = requestId
+                        }, token
+                    );
+
+                    response.Should().NotBeNull();
+
+                    if (expectResponseFrom != null)
+                    {
+                        response.Address.Should().Be(expectResponseFrom, because);
+                    }
+                }
+            )
+        );
+    }
+
+}
+
+// ReSharper disable once UnusedType.Global
+public class InMemoryClusterTests : ClusterTestsWithLocalAffinity, IClassFixture<InMemoryClusterFixture>
+{
+    // ReSharper disable once SuggestBaseTypeForParameter
+    public InMemoryClusterTests(ITestOutputHelper testOutputHelper, InMemoryClusterFixture clusterFixture) : base(
+        testOutputHelper, clusterFixture
+    )
+    {
+    }
+}
+
+// ReSharper disable once UnusedType.Global
+public class InMemoryClusterTestsAlternativeClusterContext : ClusterTestsWithLocalAffinity, IClassFixture<InMemoryClusterFixtureAlternativeClusterContext>
+{
+    // ReSharper disable once SuggestBaseTypeForParameter
+    public InMemoryClusterTestsAlternativeClusterContext(
+        ITestOutputHelper testOutputHelper,
+        InMemoryClusterFixtureAlternativeClusterContext clusterFixture
+    ) : base(
+        testOutputHelper, clusterFixture
+    )
+    {
+    }
+}
+
+// ReSharper disable once UnusedType.Global
+public class InMemoryClusterTestsSharedFutures : ClusterTestsWithLocalAffinity, IClassFixture<InMemoryClusterFixtureSharedFutures>
+{
+    // ReSharper disable once SuggestBaseTypeForParameter
+    public InMemoryClusterTestsSharedFutures(ITestOutputHelper testOutputHelper, InMemoryClusterFixtureSharedFutures clusterFixture) : base(
+        testOutputHelper, clusterFixture
+    )
+    {
+    }
+}
+
+// ReSharper disable once UnusedType.Global
+public class InMemoryClusterTestsPidCacheInvalidation : ClusterTestsWithLocalAffinity, IClassFixture<InMemoryPidCacheInvalidationClusterFixture>
+{
+    // ReSharper disable once SuggestBaseTypeForParameter
+    public InMemoryClusterTestsPidCacheInvalidation(
+        ITestOutputHelper testOutputHelper,
+        InMemoryPidCacheInvalidationClusterFixture clusterFixture
+    ) : base(
+        testOutputHelper, clusterFixture
+    )
+    {
+    }
+}

--- a/tests/Proto.Cluster.Tests/EchoActor.cs
+++ b/tests/Proto.Cluster.Tests/EchoActor.cs
@@ -8,7 +8,9 @@ public class EchoActor : IActor
 {
     public const string Kind = "echo";
     public const string Kind2 = "echo2";
-    public const string LocalAffinityKind = "echo3";
+    public const string LocalAffinityKind = "localAffinityEcho";
+    public const string FilteredKind = "filteredEcho";
+    public const string AsyncFilteredKind = "asyncFilteredEcho";
 
     public static readonly Props Props = Props.FromProducer(() => new EchoActor());
     private static readonly ILogger Logger = Log.CreateLogger<EchoActor>();


### PR DESCRIPTION
## Description

Adresses #1310, adds the ability to filter which identities can be spawned as a virtual actor per kind. The IdentityLookup will throw IdentityIsBlocked when attempting to spawn an identity which for the CanSpawnIdentity predicate returns false.
This will need to be set for each ClusterKind one wants to have spawn filtering.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
