### PR TITLE
Allow grains to return messages without the envelope if the return value is non-null

### DIFF
--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -90,6 +90,8 @@ namespace {{CsNamespace}}
             return res switch
             {
                 // normal response
+                {{OutputName}} message => {{#if UseReturn}}message{{else}}Nothing.Instance{{/if}},
+                // enveloped response
                 GrainResponseMessage grainResponse => {{#if UseReturn}}({{OutputName}}?)grainResponse.ResponseMessage{{else}}Nothing.Instance{{/if}},
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
@@ -109,6 +111,8 @@ namespace {{CsNamespace}}
             return res switch
             {
                 // normal response
+                {{OutputName}} message => {{#if UseReturn}}message{{else}}Nothing.Instance{{/if}},
+                // enveloped response
                 GrainResponseMessage grainResponse => {{#if UseReturn}}({{OutputName}}?)grainResponse.ResponseMessage{{else}}Nothing.Instance{{/if}},
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
@@ -196,7 +200,7 @@ namespace {{CsNamespace}}
             }
         }
 
-        private void Respond<T>(T response) where T: IMessage => _context!.Respond( new GrainResponseMessage(response));
+        private void Respond<T>(T response) where T: IMessage => _context!.Respond(response is not null ? response : new GrainResponseMessage(response));
         private void Respond() => _context!.Respond( new GrainResponseMessage(null));
         private void OnError(string error) => _context!.Respond( new GrainErrorResponse {Err = error } );
 

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
@@ -106,6 +106,8 @@ namespace Acme.OtherSystem.Foo
             return res switch
             {
                 // normal response
+                Acme.Mysystem.Bar.GetCurrentStateResponse message => message,
+                // enveloped response
                 GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.GetCurrentStateResponse?)grainResponse.ResponseMessage,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
@@ -125,6 +127,8 @@ namespace Acme.OtherSystem.Foo
             return res switch
             {
                 // normal response
+                Acme.Mysystem.Bar.GetCurrentStateResponse message => message,
+                // enveloped response
                 GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.GetCurrentStateResponse?)grainResponse.ResponseMessage,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
@@ -143,6 +147,8 @@ namespace Acme.OtherSystem.Foo
             return res switch
             {
                 // normal response
+                Google.Protobuf.WellKnownTypes.Empty message => Nothing.Instance,
+                // enveloped response
                 GrainResponseMessage grainResponse => Nothing.Instance,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
@@ -162,6 +168,8 @@ namespace Acme.OtherSystem.Foo
             return res switch
             {
                 // normal response
+                Google.Protobuf.WellKnownTypes.Empty message => Nothing.Instance,
+                // enveloped response
                 GrainResponseMessage grainResponse => Nothing.Instance,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
@@ -180,6 +188,8 @@ namespace Acme.OtherSystem.Foo
             return res switch
             {
                 // normal response
+                Acme.Mysystem.Bar.Response message => message,
+                // enveloped response
                 GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.Response?)grainResponse.ResponseMessage,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
@@ -199,6 +209,8 @@ namespace Acme.OtherSystem.Foo
             return res switch
             {
                 // normal response
+                Acme.Mysystem.Bar.Response message => message,
+                // enveloped response
                 GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.Response?)grainResponse.ResponseMessage,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
@@ -217,6 +229,8 @@ namespace Acme.OtherSystem.Foo
             return res switch
             {
                 // normal response
+                Google.Protobuf.WellKnownTypes.Empty message => Nothing.Instance,
+                // enveloped response
                 GrainResponseMessage grainResponse => Nothing.Instance,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
@@ -236,6 +250,8 @@ namespace Acme.OtherSystem.Foo
             return res switch
             {
                 // normal response
+                Google.Protobuf.WellKnownTypes.Empty message => Nothing.Instance,
+                // enveloped response
                 GrainResponseMessage grainResponse => Nothing.Instance,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
@@ -338,7 +354,7 @@ namespace Acme.OtherSystem.Foo
             }
         }
 
-        private void Respond<T>(T response) where T: IMessage => _context!.Respond( new GrainResponseMessage(response));
+        private void Respond<T>(T response) where T: IMessage => _context!.Respond(response is not null ? response : new GrainResponseMessage(response));
         private void Respond() => _context!.Respond( new GrainResponseMessage(null));
         private void OnError(string error) => _context!.Respond( new GrainErrorResponse {Err = error } );
 


### PR DESCRIPTION
## Description

Drops the requirement for the grain responses to be enveloped. Since it does not need to dispatch on method on the response side, this just makes the payloads cheaper. It also allows the grain to forward the request message to other actors which can respond directly with the type instead of having to wrap the response.