### PR TITLE
Enable override of ActorSystem.Root

### DIFF
--- a/benchmarks/ProtoActorBenchmarks/SkyNetBenchmark.cs
+++ b/benchmarks/ProtoActorBenchmarks/SkyNetBenchmark.cs
@@ -15,7 +15,7 @@ namespace ProtoActorBenchmarks;
 [InProcess]
 public class SkyNetBenchmark
 {
-    private RootContext _context;
+    private IRootContext _context;
     private ActorSystem _actorSystem;
 
     [Params(0)]

--- a/examples/Chat/Client/Program.cs
+++ b/examples/Chat/Client/Program.cs
@@ -16,7 +16,7 @@ namespace Client;
 
 static class Program
 {
-    private static RootContext context;
+    private static IRootContext context;
 
     private static PID client;
 

--- a/examples/Chat/Server/Program.cs
+++ b/examples/Chat/Server/Program.cs
@@ -17,7 +17,7 @@ namespace Server;
 
 static class Program
 {
-    private static RootContext context;
+    private static IRootContext context;
 
     private static void Main()
     {

--- a/examples/ContextDecorators/Program.cs
+++ b/examples/ContextDecorators/Program.cs
@@ -16,6 +16,8 @@ public class LoggingRootDecorator : RootContextDecorator
     {
     }
 
+    protected override IRootContext WithInnerContext(IRootContext context) => new LoggingRootDecorator(context);
+
     public override async Task<T> RequestAsync<T>(PID target, object message, CancellationToken ct)
     {
         Console.WriteLine("Enter RequestAsync");

--- a/examples/MessageHeaders/Program.cs
+++ b/examples/MessageHeaders/Program.cs
@@ -5,12 +5,21 @@ using Proto;
 namespace MessageHeaders;
 
 public record MyMessage(string SomeProperty);
-    
+
 class Program
 {
     static void Main()
     {
-        var system = new ActorSystem();
+        var headers = MessageHeader
+            .Empty
+            .With("UserId", "123")
+            .With("LanguageId", "EN");
+
+        var system = new ActorSystem(ActorSystemConfig.Setup() with
+        {
+            ConfigureRootContext = context => context.WithHeaders(headers)
+        });
+        
         var props = Props.FromFunc(ctx => {
                 if (ctx.Message is MyMessage msg)
                 {
@@ -27,28 +36,22 @@ class Program
         );
 
         var pid = system.Root.Spawn(props);
-            
-        var headers = MessageHeader
-            .Empty
-            .With("UserId", "123")
-            .With("LanguageId", "EN");
 
         //why is this needed?
         //by default, headers are not propagated, which might seem strange at first.
         //but in the case of tracing, e.g. Zipkin/OpenTracing etc. you need to be able to create new spans based on the data in the headers.
         //e.g. RootContext might contain SpanID 123. but on the outgoing data, this is now ParentSpanID 123
-            
+
         //This bit of code does a verbatim copy of all headers and pass them along
-        static Sender PropagateHeaders(Sender next) => 
-            (context, target, envelope) => 
+        static Sender PropagateHeaders(Sender next) =>
+            (context, target, envelope) =>
                 next(context, target, envelope.WithHeader(context.Headers));
 
         //set up a sender context that knows what headers to pass along.
         var context = system
             .Root
-            .WithHeaders(headers)
             .WithSenderMiddleware(PropagateHeaders);
-            
+
         //This is sent with the above specified message headers
         context.Send(pid, new MyMessage("SomeValue"));
 

--- a/examples/Patterns/Saga/Program.cs
+++ b/examples/Patterns/Saga/Program.cs
@@ -10,7 +10,7 @@ namespace Saga;
 
 class Program
 {
-    private static readonly RootContext Context = new ActorSystem().Root;
+    private static readonly IRootContext Context = new ActorSystem().Root;
 
     public static void Main(string[] args)
     {

--- a/src/Proto.Actor/ActorSystem.cs
+++ b/src/Proto.Actor/ActorSystem.cs
@@ -34,7 +34,7 @@ public sealed class ActorSystem : IAsyncDisposable
         Stopper = new();
         Config = config ?? throw new ArgumentNullException(nameof(config));
         ProcessRegistry = new ProcessRegistry(this);
-        Root = new RootContext(this);
+        Root = config.ConfigureRootContext(new RootContext(this));
         DeadLetter = new DeadLetterProcess(this);
         Guardians = new Guardians(this);
         EventStream = new EventStream(this);
@@ -53,7 +53,7 @@ public sealed class ActorSystem : IAsyncDisposable
 
     public ProcessRegistry ProcessRegistry { get; }
 
-    public RootContext Root { get; }
+    public IRootContext Root { get; }
 
     public Stopper Stopper { get; }
 

--- a/src/Proto.Actor/Configuration/ActorSystemConfig.cs
+++ b/src/Proto.Actor/Configuration/ActorSystemConfig.cs
@@ -44,6 +44,13 @@ public record ActorSystemConfig
     public bool MetricsEnabled { get; init; }
 
     /// <summary>
+    ///     Allows adding middleware to the root context exposed by the ActorSystem.
+    ///     The result from this will be used as the default sender for all requests,
+    ///     except requests overriding the sender context by parameter
+    /// </summary>
+    public Func<RootContext, IRootContext> ConfigureRootContext { get; init; } = context => context;
+    
+    /// <summary>
     ///     Allows ActorSystem-wide augmentation of any Props
     ///     All props are translated via this function
     /// </summary>
@@ -118,6 +125,7 @@ public record ActorSystemConfig
 
     public ActorSystemConfig WithDiagnosticsSerializer(Func<IActor, string> serializer) => this with {DiagnosticsSerializer = serializer};
 
+    public ActorSystemConfig WithConfigureRootContext(Func<RootContext, IRootContext> configureContext) => this with {ConfigureRootContext = configureContext};
     public ActorSystemConfig WithConfigureProps(Func<Props, Props> configureProps) => this with {ConfigureProps = configureProps};
     
     public ActorSystemConfig WithConfigureSystemProps(Func<string, Props, Props> configureSystemProps) => this with {ConfigureSystemProps = configureSystemProps};

--- a/src/Proto.Actor/Context/RootContext.cs
+++ b/src/Proto.Actor/Context/RootContext.cs
@@ -16,6 +16,7 @@ namespace Proto;
 
 public interface IRootContext : ISpawnerContext, ISenderContext, IStopperContext
 {
+    IRootContext WithSenderMiddleware(params Func<Sender, Sender>[] middleware);
 }
 
 [PublicAPI]
@@ -89,10 +90,10 @@ public sealed record RootContext : IRootContext
     public Task<T> RequestAsync<T>(PID target, object message, CancellationToken cancellationToken)
         => SenderContextExtensions.RequestAsync<T>(this, target, message, cancellationToken);
         
-    public RootContext WithHeaders(MessageHeader headers) =>
+    public IRootContext WithHeaders(MessageHeader headers) =>
         this with {Headers = headers};
 
-    public RootContext WithSenderMiddleware(params Func<Sender, Sender>[] middleware) =>
+    public IRootContext WithSenderMiddleware(params Func<Sender, Sender>[] middleware) =>
         this with
         {
             SenderMiddleware = middleware.Reverse()

--- a/src/Proto.Actor/Context/RootContextDecorator.cs
+++ b/src/Proto.Actor/Context/RootContextDecorator.cs
@@ -19,6 +19,8 @@ public abstract class RootContextDecorator : IRootContext
 
     protected RootContextDecorator(IRootContext context) => _context = context;
 
+    protected abstract IRootContext WithInnerContext(IRootContext context);
+    
     public virtual PID SpawnNamed(Props props, string name, Action<IContext>? callback = null) => _context.SpawnNamed(props, name, callback);
 
     public virtual void Send(PID target, object message) => _context.Send(target, message);
@@ -42,6 +44,8 @@ public abstract class RootContextDecorator : IRootContext
     public virtual void Poison(PID pid) => _context.Poison(pid);
 
     public virtual Task PoisonAsync(PID pid) => _context.PoisonAsync(pid);
+
+    public IRootContext WithSenderMiddleware(params Func<Sender, Sender>[] middleware) => WithInnerContext(_context.WithSenderMiddleware(middleware));
 
     public virtual PID? Parent => null;
     public virtual PID? Self => null;

--- a/src/Proto.Actor/Context/SystemContext.cs
+++ b/src/Proto.Actor/Context/SystemContext.cs
@@ -12,7 +12,7 @@ public static class SystemContext
 {
     private static readonly ILogger Logger = Log.CreateLogger(nameof(SystemContext));
 
-    public static PID SpawnNamedSystem(this RootContext self, Props props, string name)
+    public static PID SpawnNamedSystem(this IRootContext self, Props props, string name)
     {
         if (!name.StartsWith("$"))
         {

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -49,7 +49,7 @@ public class Gossiper
 
     private static readonly ILogger Logger = Log.CreateLogger<Gossiper>();
     private readonly Cluster _cluster;
-    private readonly RootContext _context;
+    private readonly IRootContext _context;
     private PID _pid = null!;
 
     public Gossiper(Cluster cluster)

--- a/src/Proto.Cluster/Partition/PartitionManager.cs
+++ b/src/Proto.Cluster/Partition/PartitionManager.cs
@@ -14,7 +14,7 @@ class PartitionManager
     private const string PartitionIdentityActorName = "$partition-identity";
     private const string PartitionPlacementActorName = "$partition-activator";
     private readonly Cluster _cluster;
-    private readonly RootContext _context;
+    private readonly IRootContext _context;
     private readonly bool _isClient;
     private readonly ActorSystem _system;
     private PID _partitionPlacementActor = null!;

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorManager.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorManager.cs
@@ -15,7 +15,7 @@ public class PartitionActivatorManager
     private readonly Cluster _cluster;
 
 
-    private readonly RootContext _context;
+    private readonly IRootContext _context;
     private readonly bool _isClient;
     private readonly ActorSystem _system;
     private PID _partitionActivatorActor = null!;

--- a/src/Proto.OpenTelemetry/OpenTelemetryDecorators.cs
+++ b/src/Proto.OpenTelemetry/OpenTelemetryDecorators.cs
@@ -19,6 +19,8 @@ class OpenTelemetryRootContextDecorator : RootContextDecorator
             sendActivitySetup(activity, message);
         };
 
+    protected override IRootContext WithInnerContext(IRootContext context) => new OpenTelemetryRootContextDecorator(context, _sendActivitySetup);
+
     public override void Send(PID target, object message)
         => OpenTelemetryMethodsDecorators.Send(target, message, _sendActivitySetup, () => base.Send(target, message));
 
@@ -186,7 +188,7 @@ static class OpenTelemetryMethodsDecorators
     internal static async Task Receive(MessageEnvelope envelope, ActivitySetup receiveActivitySetup, Func<Task> receive)
     {
         var message = envelope.Message;
-            
+
         if (message is SystemMessage)
         {
             await receive().ConfigureAwait(false);

--- a/src/Proto.OpenTelemetry/OpenTelemetryTracingExtensions.cs
+++ b/src/Proto.OpenTelemetry/OpenTelemetryTracingExtensions.cs
@@ -51,7 +51,7 @@ public static class OpenTelemetryTracingExtensions
     /// <param name="context">Root context</param>
     /// <param name="sendActivitySetup">provide a way inject send activity customization according to the message.</param>
     /// <returns>IRootContext</returns>
-    public static IRootContext WithTracing(this RootContext context, ActivitySetup? sendActivitySetup = null)
+    public static IRootContext WithTracing(this IRootContext context, ActivitySetup? sendActivitySetup = null)
     {
         sendActivitySetup ??= OpenTelemetryHelpers.DefaultSetupActivity!;
 

--- a/src/Proto.Remote/Endpoints/EndpointManager.cs
+++ b/src/Proto.Remote/Endpoints/EndpointManager.cs
@@ -200,5 +200,11 @@ public class EndpointManager
         var props = Props.FromProducer(() => new Activator(_remoteConfig, _system));
         ActivatorPid = _system.Root.SpawnNamedSystem(props, ActivatorActorName);
     }
-    private void StopActivator() => _system.Root.Stop(ActivatorPid);
+    private void StopActivator()
+    {
+        if (ActivatorPid is not null)
+        {
+            _system.Root.Stop(ActivatorPid);
+        }
+    }
 }

--- a/tests/Proto.Actor.Tests/ActorTestBase.cs
+++ b/tests/Proto.Actor.Tests/ActorTestBase.cs
@@ -10,7 +10,7 @@ namespace Proto.Tests;
 
 public abstract class ActorTestBase : IAsyncLifetime
 {
-    protected readonly RootContext Context;
+    protected readonly IRootContext Context;
     protected readonly ActorSystem System;
 
     protected ActorTestBase()

--- a/tests/Proto.Cluster.Tests/ClusterTests.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTests.cs
@@ -300,18 +300,18 @@ public abstract class ClusterTests : ClusterTestBase
     [Theory]
     [InlineData(10000, EchoActor.FilteredKind)]
     [InlineData(10000, EchoActor.AsyncFilteredKind)]
-    public async Task CanFilterActivations(int timeoutMs, string filteredKind)
-    {
-        var timeout = new CancellationTokenSource(timeoutMs).Token;
+    public async Task CanFilterActivations(int timeoutMs, string filteredKind) => await Tracing.Trace(async () => {
+            var timeout = new CancellationTokenSource(timeoutMs).Token;
 
-        var member = Members.First();
-        var invalidIdentity = ClusterIdentity.Create(Proto.Cluster.Tests.ClusterFixture.InvalidIdentity, filteredKind);
-        var message = new Ping {Message = "Hello"};
+            var member = Members.First();
+            var invalidIdentity = ClusterIdentity.Create(Proto.Cluster.Tests.ClusterFixture.InvalidIdentity, filteredKind);
+            var message = new Ping {Message = "Hello"};
 
-        await member.Invoking(async m => await m.RequestAsync<Pong>(invalidIdentity, message, timeout))
-            .Should()
-            .ThrowExactlyAsync<IdentityIsBlocked>();
-    }
+            await member.Invoking(async m => await m.RequestAsync<Pong>(invalidIdentity, message, timeout))
+                .Should()
+                .ThrowExactlyAsync<IdentityIsBlocked>();
+        }, _testOutputHelper
+    );
 
     [Theory, InlineData(10, 20000)]
     public async Task CanRespawnVirtualActors(int actorCount, int timeoutMs)

--- a/tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj
+++ b/tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj
@@ -18,7 +18,8 @@
     </PackageReference>
     <PackageReference Include="Grpc.Tools" Version="2.46.3" PrivateAssets="All" />
     <PackageReference Include="IsExternalInit.System.Runtime.CompilerServices" Version="1.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.1.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.0" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Proto.Cluster.Tests/Tracing.cs
+++ b/tests/Proto.Cluster.Tests/Tracing.cs
@@ -1,0 +1,43 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file = "TestTracing.cs" company = "Asynkron AB">
+//      Copyright (C) 2015-2022 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using OpenTelemetry.Trace;
+using Xunit.Abstractions;
+
+namespace Proto.Cluster.Tests;
+
+public static class Tracing
+{
+    public const string ActivitySourceName = "Proto.Cluster.Tests";
+
+    public static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+
+    public static Activity StartActivity([CallerMemberName] string callerName = "N/A") => ActivitySource.StartActivity(callerName);
+
+    public static async Task Trace(Func<Task> callBack, ITestOutputHelper testOutputHelper, [CallerMemberName] string callerName = "N/A")
+    {
+        using var activity = StartActivity(callerName);
+
+        if (activity is not null)
+        {
+            testOutputHelper.WriteLine("TraceId: {0}", activity.TraceId);
+        }
+
+        try
+        {
+            await callBack();
+        }
+        catch (Exception e)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+            activity?.RecordException(e);
+            throw;
+        }
+    }
+}

--- a/tests/Proto.Persistence.Tests/ExamplePersistentActorTests.cs
+++ b/tests/Proto.Persistence.Tests/ExamplePersistentActorTests.cs
@@ -272,7 +272,7 @@ public class ExamplePersistentActorTests
         Assert.Empty(snapshotStoreMessages);
     }
 
-    private (PID pid, Props props, string actorId, IProvider provider) CreateTestActor(RootContext context)
+    private (PID pid, Props props, string actorId, IProvider provider) CreateTestActor(IRootContext context)
     {
         var actorId = Guid.NewGuid().ToString();
         var inMemoryProvider = new InMemoryProvider();
@@ -283,7 +283,7 @@ public class ExamplePersistentActorTests
         return (pid, props, actorId, inMemoryProvider);
     }
 
-    private async Task<int> RestartActorAndGetState(PID pid, Props props, RootContext context)
+    private async Task<int> RestartActorAndGetState(PID pid, Props props, IRootContext context)
     {
         await context.StopAsync(pid);
         pid = context.Spawn(props);


### PR DESCRIPTION
## Description

Added `ActorSystemConfig.ConfigureRootContext` to allow ActorSystem RootContext to be decorated on startup, effectively enabling the user to choose a default IRootContext.

ActorSystem previously exposed the RootContext class directly, so some functionality which was present there is no longer available on root (such as settings headers on the context).


Also added the ability to get more detailed traces of Cluster tests, by tracing from the root context as well as internally.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
