### PR TITLE
Fixed TopicActor problem with nullref when loading subscribers

### DIFF
--- a/src/Proto.Actor/Utils/EmptyKeyValueStore.cs
+++ b/src/Proto.Actor/Utils/EmptyKeyValueStore.cs
@@ -14,7 +14,7 @@ namespace Proto.Utils;
 /// <typeparam name="T"></typeparam>
 public class EmptyKeyValueStore<T> : IKeyValueStore<T>
 {
-    public Task<T> GetAsync(string id, CancellationToken ct) => Task.FromResult(default(T));
+    public Task<T?> GetAsync(string id, CancellationToken ct) => Task.FromResult(default(T));
 
     public Task SetAsync(string id, T state, CancellationToken ct) => Task.CompletedTask;
 

--- a/src/Proto.Actor/Utils/IKeyValueStore.cs
+++ b/src/Proto.Actor/Utils/IKeyValueStore.cs
@@ -22,7 +22,7 @@ public interface IKeyValueStore<T>
     /// <param name="id">Key</param>
     /// <param name="ct"></param>
     /// <returns></returns>
-    Task<T> GetAsync(string id, CancellationToken ct);
+    Task<T?> GetAsync(string id, CancellationToken ct);
 
     /// <summary>
     /// Set the value for the given key.

--- a/src/Proto.Cluster/PubSub/TopicActor.cs
+++ b/src/Proto.Cluster/PubSub/TopicActor.cs
@@ -221,7 +221,7 @@ public sealed class TopicActor : IActor
             //TODO: cancellation token config?
             var state = await _subscriptionStore.GetAsync(topic, CancellationToken.None);
             Logger.LogDebug("Topic {Topic} loaded subscriptions {Subscriptions}", _topic, state);
-            return state;
+            return state ?? new Subscribers();
         }
         catch (Exception e)
         {

--- a/tests/Proto.Cluster.PubSub.Tests/PubSubClusterFixture.cs
+++ b/tests/Proto.Cluster.PubSub.Tests/PubSubClusterFixture.cs
@@ -29,9 +29,9 @@ public class PubSubClusterFixture : BaseInMemoryClusterFixture
 
     public ITestOutputHelper? Output;
 
-    public PubSubClusterFixture() : this(false) {} // xunit requires single, public, parameterless constructor
+    public PubSubClusterFixture() : this(3, false) {} // xunit requires single, public, parameterless constructor
     
-    internal PubSubClusterFixture(bool useDefaultTopicRegistration) : base(3, config =>
+    internal PubSubClusterFixture(int clusterSize, bool useDefaultTopicRegistration) : base(clusterSize, config =>
         config
             .WithActorRequestTimeout(TimeSpan.FromSeconds(1))
             .WithPubSubConfig(PubSubConfig.Setup()

--- a/tests/Proto.Cluster.PubSub.Tests/PubSubClusterFixture.cs
+++ b/tests/Proto.Cluster.PubSub.Tests/PubSubClusterFixture.cs
@@ -18,6 +18,7 @@ public record Response;
 
 public class PubSubClusterFixture : BaseInMemoryClusterFixture
 {
+    private readonly bool _useDefaultTopicRegistration;
     public const string SubscriberKind = "Subscriber";
     public const string TimeoutSubscriberKind = "TimeoutSubscriber";
 
@@ -28,26 +29,34 @@ public class PubSubClusterFixture : BaseInMemoryClusterFixture
 
     public ITestOutputHelper? Output;
 
-    public PubSubClusterFixture() : base(3, config =>
+    public PubSubClusterFixture() : this(false) {} // xunit requires single, public, parameterless constructor
+    
+    internal PubSubClusterFixture(bool useDefaultTopicRegistration) : base(3, config =>
         config
             .WithActorRequestTimeout(TimeSpan.FromSeconds(1))
             .WithPubSubConfig(PubSubConfig.Setup()
                 .WithSubscriberTimeout(TimeSpan.FromSeconds(2))
             )
-    )
-    {
-    }
+    ) => _useDefaultTopicRegistration = useDefaultTopicRegistration;
 
     private readonly InMemorySubscribersStore _subscribersStore = new();
     
     public Task<Subscribers> GetSubscribersForTopic(string topic) => _subscribersStore.GetAsync(topic, CancellationToken.None);
 
-    protected override ClusterKind[] ClusterKinds => new[]
-    {
-        new ClusterKind(TopicActor.Kind, Props.FromProducer(() => new TopicActor(_subscribersStore))),
-        new ClusterKind(SubscriberKind, SubscriberProps()),
-        new ClusterKind(TimeoutSubscriberKind, TimeoutSubscriberProps())
-    };
+    protected override ClusterKind[] ClusterKinds {
+        get {
+            var kinds = new List<ClusterKind>
+            {
+                new(SubscriberKind, SubscriberProps()),
+                new(TimeoutSubscriberKind, TimeoutSubscriberProps())
+            };
+            
+            if(!_useDefaultTopicRegistration)
+                kinds.Add(new ClusterKind(TopicActor.Kind, Props.FromProducer(() => new TopicActor(_subscribersStore))));
+
+            return kinds.ToArray();
+        }
+    }
 
     private Props SubscriberProps()
     {
@@ -136,29 +145,39 @@ public class PubSubClusterFixture : BaseInMemoryClusterFixture
 
     public async Task SubscribeTo(string topic, string identity, string kind = PubSubClusterFixture.SubscriberKind)
     {
-        var subRes = await RandomMember().Subscribe(topic, identity, kind);
+        var subRes = await RandomMember().Subscribe(topic, identity, kind, CancellationTokens.FromSeconds(5));
         if (subRes == null)
             Output?.WriteLine($"{kind}/{identity} failed to subscribe due to timeout");
+        subRes.Should().NotBeNull("subscribing should not time out");
     }
 
     public async Task UnsubscribeFrom(string topic, string identity, string kind = PubSubClusterFixture.SubscriberKind)
     {
-        var unsubRes = await RandomMember().Unsubscribe(topic, identity, kind);
+        var unsubRes = await RandomMember().Unsubscribe(topic, identity, kind, CancellationTokens.FromSeconds(5));
         if (unsubRes == null)
             Output?.WriteLine($"{kind}/{identity} failed to subscribe due to timeout");
+        unsubRes.Should().NotBeNull("unsubscribing should not time out");
     }
 
     public Task<PublishResponse?> PublishData(string topic, int data, CancellationToken cancel = default)
-        => RandomMember()
+    {
+        if(cancel == default) cancel = CancellationTokens.FromSeconds(5);
+        
+        return RandomMember()
             .Publisher()
             .Publish(topic, new DataPublished(data), cancel);
+    }
 
     public Task<PublishResponse?> PublishDataBatch(string topic, int[] data, CancellationToken cancel = default)
-        => RandomMember()
+    {
+        if (cancel == default) cancel = CancellationTokens.FromSeconds(5);
+
+        return RandomMember()
             .Publisher()
             .PublishBatch(
                 topic,
                 data.Select(d => new DataPublished(d)).ToArray(),
                 cancel
             );
+    }
 }

--- a/tests/Proto.Cluster.PubSub.Tests/PubSubDefaultTopicRegistrationTests.cs
+++ b/tests/Proto.Cluster.PubSub.Tests/PubSubDefaultTopicRegistrationTests.cs
@@ -13,7 +13,7 @@ public class PubSubDefaultTopicRegistrationTests : IAsyncLifetime
 {
     private readonly PubSubClusterFixture _fixture;
 
-    public PubSubDefaultTopicRegistrationTests() => _fixture = new PubSubClusterFixture(useDefaultTopicRegistration: true);
+    public PubSubDefaultTopicRegistrationTests() => _fixture = new PubSubClusterFixture(clusterSize: 1, useDefaultTopicRegistration: true);
 
     public Task InitializeAsync() => _fixture.InitializeAsync();
     

--- a/tests/Proto.Cluster.PubSub.Tests/PubSubDefaultTopicRegistrationTests.cs
+++ b/tests/Proto.Cluster.PubSub.Tests/PubSubDefaultTopicRegistrationTests.cs
@@ -1,0 +1,40 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file = "PubSubDefaultTopicRegistrationTests.cs" company = "Asynkron AB">
+//      Copyright (C) 2015-2022 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using FluentAssertions;
+using Xunit;
+
+namespace Proto.Cluster.PubSub.Tests;
+
+[Collection("PubSub")] // The CI is just to slow to run cluster fixture based tests in parallel
+public class PubSubDefaultTopicRegistrationTests : IAsyncLifetime
+{
+    private readonly PubSubClusterFixture _fixture;
+
+    public PubSubDefaultTopicRegistrationTests() => _fixture = new PubSubClusterFixture(useDefaultTopicRegistration: true);
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+    
+    [Fact]
+    public async Task Pub_sub_works_with_default_topic_registration()
+    {
+        var subscriberIds = _fixture.SubscriberIds("topic-default", 20);
+        const string topic = "topic-default-registration";
+        const int numMessages = 100;
+
+        await _fixture.SubscribeAllTo(topic, subscriberIds);
+
+        for (var i = 0; i < numMessages; i++)
+        {
+            var response = await _fixture.PublishData(topic, i);
+            response.Should().NotBeNull("publishing should not time out");
+            response!.Status.Should().Be(PublishStatus.Ok);
+        }
+
+        await _fixture.VerifyAllSubscribersGotAllTheData(subscriberIds, numMessages);
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+}


### PR DESCRIPTION
## Description

Latest pub-sub PR introduced problem with the default topic registration where EmptyKeyValue store is used. Also the null annotations on IKeyValueStore were incorrect.

<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
