### PR TITLE
Cluster request timeout now throws TimeoutException

### DIFF
--- a/benchmarks/ClusterMicroBenchmarks/ConcurrentSpawnBenchmark.cs
+++ b/benchmarks/ClusterMicroBenchmarks/ConcurrentSpawnBenchmark.cs
@@ -96,7 +96,19 @@ public class ConcurrentSpawnBenchmark
             tasks[i] = _cluster.RequestAsync<Terminated>(id, PoisonPill.Instance, cts.Token);
         }
 
-        Task.WhenAll(tasks).GetAwaiter().GetResult();
+        try
+        {
+            Task.WhenAll(tasks).GetAwaiter().GetResult();
+        }
+        catch (TimeoutException)
+        {
+            // ignore
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            throw;
+        }
     }
 
     public enum IdentityLookup

--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -95,7 +95,7 @@ namespace {{CsNamespace}}
                 GrainResponseMessage grainResponse => {{#if UseReturn}}({{OutputName}}?)grainResponse.ResponseMessage{{else}}Nothing.Instance{{/if}},
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
-                //timeout
+                // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
                 _ => throw new NotSupportedException($""Unknown response type {res.GetType().FullName}"")
@@ -116,7 +116,7 @@ namespace {{CsNamespace}}
                 GrainResponseMessage grainResponse => {{#if UseReturn}}({{OutputName}}?)grainResponse.ResponseMessage{{else}}Nothing.Instance{{/if}},
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
-                //timeout
+                // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
                 _ => throw new NotSupportedException($""Unknown response type {res.GetType().FullName}"")

--- a/src/Proto.Cluster/ClusterConfig.cs
+++ b/src/Proto.Cluster/ClusterConfig.cs
@@ -157,6 +157,12 @@ public record ClusterConfig
     public PubSubConfig PubSubConfig { get; init; } = PubSubConfig.Setup();
 
     /// <summary>
+    /// Backwards compatibility. Set to true to have timed out requests return default(TResponse) instead of throwing <see cref="TimeoutException"/>
+    /// Default is false.
+    /// </summary>
+    public bool LegacyRequestTimeoutBehavior { get; init; }
+
+    /// <summary>
     /// Timeout for spawning an actor in the Partition Identity Lookup. Default is 5s.
     /// </summary>
     /// <param name="timeSpan"></param>
@@ -325,6 +331,13 @@ public record ClusterConfig
     /// </summary>
     public ClusterConfig WithPubSubConfig(PubSubConfig config) =>
         this with {PubSubConfig = config};
+
+    /// <summary>
+    /// Backwards compatibility. Set to true to have timed out requests return default(TResponse) instead of throwing <see cref="TimeoutException"/>
+    /// Default is false.
+    /// </summary>
+    public ClusterConfig WithLegacyRequestTimeoutBehavior(bool enabled = true) =>
+        this with {LegacyRequestTimeoutBehavior = enabled};
 
     /// <summary>
     /// Creates a new <see cref="ClusterConfig"/>

--- a/src/Proto.Cluster/DefaultClusterContext.cs
+++ b/src/Proto.Cluster/DefaultClusterContext.cs
@@ -112,7 +112,7 @@ public class DefaultClusterContext : IClusterContext
                             return t1;
                         }
 
-                        if (untypedResult == null) // TODO: what if request response is actually null?
+                        if (untypedResult == null) // timeout, actual valid response cannot be null 
                         {
                             return TimeoutOrThrow();
                         }

--- a/src/Proto.Cluster/DefaultClusterContext.cs
+++ b/src/Proto.Cluster/DefaultClusterContext.cs
@@ -27,6 +27,7 @@ public class DefaultClusterContext : IClusterContext
     private readonly ActorSystem _system;
     private static readonly ILogger Logger = Log.CreateLogger<DefaultClusterContext>();
     private readonly int _requestTimeoutSeconds;
+    private readonly bool _legacyTimeouts;
 
     public DefaultClusterContext(Cluster cluster)
     {
@@ -41,6 +42,7 @@ public class DefaultClusterContext : IClusterContext
             i => Logger.LogInformation("Throttled {LogCount} TryRequestAsync logs", i)
         );
         _requestTimeoutSeconds = (int) config.ActorRequestTimeout.TotalSeconds;
+        _legacyTimeouts = config.LegacyRequestTimeoutBehavior;
 #if !NET6_0_OR_GREATER
         var updateInterval = TimeSpan.FromMilliseconds(Math.Min(config.ActorRequestTimeout.TotalMilliseconds / 2, 1000));
         _clock = new TaskClock(config.ActorRequestTimeout, updateInterval, cluster.System.Shutdown);
@@ -110,15 +112,14 @@ public class DefaultClusterContext : IClusterContext
                             return t1;
                         }
 
+                        if (untypedResult == null) // TODO: what if request response is actually null?
+                        {
+                            return TimeoutOrThrow();
+                        }
+
                         if (typeof(T) == typeof(MessageEnvelope))
                         {
                             return (T) (object) MessageEnvelope.Wrap(task.Result);
-                        }
-
-                        if (untypedResult == null)
-                        {
-                            //null = timeout
-                            return default;
                         }
 
                         if (untypedResult is DeadLetterResponse)
@@ -199,7 +200,7 @@ public class DefaultClusterContext : IClusterContext
                 Logger.LogWarning("RequestAsync retried but failed for {ClusterIdentity}", clusterIdentity);
             }
 
-            return default!;
+            return TimeoutOrThrow();
         }
         finally
         {
@@ -211,6 +212,17 @@ public class DefaultClusterContext : IClusterContext
             future.Dispose();
             future = context.GetFuture();
             lastPid = null;
+        }
+
+        T? TimeoutOrThrow()
+        {
+            if (_legacyTimeouts)
+            {
+                //null = timeout
+                return default;
+            }
+
+            throw new TimeoutException("Request timed out");
         }
     }
 

--- a/src/Proto.Cluster/IClusterProvider.cs
+++ b/src/Proto.Cluster/IClusterProvider.cs
@@ -23,7 +23,8 @@ public interface IClusterProvider
     Task StartMemberAsync(Cluster cluster);
 
     /// <summary>
-    /// Starts the cluster provider in client mode. The client member does not support any kinds.
+    /// Starts the cluster provider in client mode. The client member does not host any virtual actors and it is not registered in the membership provider.
+    /// It only monitors other member's presence and allows to send messages to virtual actors hosted by other members.
     /// </summary>
     /// <param name="cluster"></param>
     /// <returns></returns>

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
@@ -111,7 +111,7 @@ namespace Acme.OtherSystem.Foo
                 GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.GetCurrentStateResponse?)grainResponse.ResponseMessage,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
-                //timeout
+                // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
                 _ => throw new NotSupportedException($"Unknown response type {res.GetType().FullName}")
@@ -132,7 +132,7 @@ namespace Acme.OtherSystem.Foo
                 GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.GetCurrentStateResponse?)grainResponse.ResponseMessage,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
-                //timeout
+                // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
                 _ => throw new NotSupportedException($"Unknown response type {res.GetType().FullName}")
@@ -152,7 +152,7 @@ namespace Acme.OtherSystem.Foo
                 GrainResponseMessage grainResponse => Nothing.Instance,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
-                //timeout
+                // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
                 _ => throw new NotSupportedException($"Unknown response type {res.GetType().FullName}")
@@ -173,7 +173,7 @@ namespace Acme.OtherSystem.Foo
                 GrainResponseMessage grainResponse => Nothing.Instance,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
-                //timeout
+                // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
                 _ => throw new NotSupportedException($"Unknown response type {res.GetType().FullName}")
@@ -193,7 +193,7 @@ namespace Acme.OtherSystem.Foo
                 GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.Response?)grainResponse.ResponseMessage,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
-                //timeout
+                // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
                 _ => throw new NotSupportedException($"Unknown response type {res.GetType().FullName}")
@@ -214,7 +214,7 @@ namespace Acme.OtherSystem.Foo
                 GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.Response?)grainResponse.ResponseMessage,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
-                //timeout
+                // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
                 _ => throw new NotSupportedException($"Unknown response type {res.GetType().FullName}")
@@ -234,7 +234,7 @@ namespace Acme.OtherSystem.Foo
                 GrainResponseMessage grainResponse => Nothing.Instance,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
-                //timeout
+                // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
                 _ => throw new NotSupportedException($"Unknown response type {res.GetType().FullName}")
@@ -255,7 +255,7 @@ namespace Acme.OtherSystem.Foo
                 GrainResponseMessage grainResponse => Nothing.Instance,
                 // error response
                 GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
-                //timeout
+                // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
                 _ => throw new NotSupportedException($"Unknown response type {res.GetType().FullName}")

--- a/tests/Proto.Cluster.Tests/ClusterTests.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTests.cs
@@ -58,14 +58,6 @@ public abstract class ClusterTests : ClusterTestBase
     }
 
     [Fact]
-    public async Task ThrowsWhenTimeoutExceeded()
-        => await Members.First()
-            .Invoking(m => m.RequestAsync<Pong>(CreateIdentity("slow-test"), EchoActor.Kind,
-                    new SlowPing {Message = "hi", DelayMs = 5000}, new CancellationTokenSource(2000).Token
-                )
-            ).Should().ThrowAsync<TimeoutException>();
-
-    [Fact]
     public async Task SupportsMessageEnvelopeResponses()
     {
         var timeout = new CancellationTokenSource(20000).Token;

--- a/tests/Proto.Cluster.Tests/LegacyTimeoutTests.cs
+++ b/tests/Proto.Cluster.Tests/LegacyTimeoutTests.cs
@@ -1,0 +1,43 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file = "LegacyTimeoutTests.cs" company = "Asynkron AB">
+//      Copyright (C) 2015-2022 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClusterTest.Messages;
+using FluentAssertions;
+using Xunit;
+
+namespace Proto.Cluster.Tests;
+
+public class LegacyTimeoutTests
+{
+    [Fact]
+    public async Task ReturnsNullOnTimeoutInLegacyMode()
+    {
+        await using var fixture = new Fixture(1);
+        await fixture.InitializeAsync();
+
+        var response = await fixture.Members.First().RequestAsync<Pong>(CreateIdentity("slow-test"), EchoActor.Kind,
+            new SlowPing {Message = "hi", DelayMs = 5000}, new CancellationTokenSource(2000).Token
+        );
+
+        response.Should().BeNull();
+    }
+
+    private string CreateIdentity(string baseId) => $"{Guid.NewGuid().ToString("N").Substring(0, 6)}-{baseId}-";
+
+    private class Fixture : BaseInMemoryClusterFixture
+    {
+        public Fixture(int clusterSize)
+            : base(clusterSize, cc => cc
+                .WithActorRequestTimeout(TimeSpan.FromSeconds(3))
+                .WithLegacyRequestTimeoutBehavior()
+            )
+        {
+        }
+    }
+}

--- a/tests/Proto.Cluster.Tests/LegacyTimeoutTests.cs
+++ b/tests/Proto.Cluster.Tests/LegacyTimeoutTests.cs
@@ -22,7 +22,7 @@ public class LegacyTimeoutTests
         await fixture.InitializeAsync();
 
         var response = await fixture.Members.First().RequestAsync<Pong>(CreateIdentity("slow-test"), EchoActor.Kind,
-            new SlowPing {Message = "hi", DelayMs = 2000}, new CancellationTokenSource(500).Token
+            new SlowPing {Message = "hi", DelayMs = 4000}, new CancellationTokenSource(500).Token
         );
 
         response.Should().BeNull();

--- a/tests/Proto.Cluster.Tests/TimeoutTests.cs
+++ b/tests/Proto.Cluster.Tests/TimeoutTests.cs
@@ -23,7 +23,7 @@ public class TimeoutTests
 
         await fixture.Members.First()
             .Invoking(m => m.RequestAsync<Pong>(CreateIdentity("slow-test"), EchoActor.Kind,
-                    new SlowPing {Message = "hi", DelayMs = 2000}, new CancellationTokenSource(500).Token
+                    new SlowPing {Message = "hi", DelayMs = 4000}, new CancellationTokenSource(500).Token
                 )
             ).Should().ThrowAsync<TimeoutException>();
     }

--- a/tests/Proto.Cluster.Tests/TimeoutTests.cs
+++ b/tests/Proto.Cluster.Tests/TimeoutTests.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file = "LegacyTimeoutTests.cs" company = "Asynkron AB">
+// <copyright file = "TimeoutTests.cs" company = "Asynkron AB">
 //      Copyright (C) 2015-2022 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
@@ -13,19 +13,19 @@ using Xunit;
 
 namespace Proto.Cluster.Tests;
 
-public class LegacyTimeoutTests
+public class TimeoutTests
 {
     [Fact]
-    public async Task ReturnsNullOnRequestTimeoutInLegacyMode()
+    public async Task ThrowsTimeoutExceptionOnRequestTimeout()
     {
         await using var fixture = new Fixture(1);
         await fixture.InitializeAsync();
 
-        var response = await fixture.Members.First().RequestAsync<Pong>(CreateIdentity("slow-test"), EchoActor.Kind,
-            new SlowPing {Message = "hi", DelayMs = 2000}, new CancellationTokenSource(500).Token
-        );
-
-        response.Should().BeNull();
+        await fixture.Members.First()
+            .Invoking(m => m.RequestAsync<Pong>(CreateIdentity("slow-test"), EchoActor.Kind,
+                    new SlowPing {Message = "hi", DelayMs = 2000}, new CancellationTokenSource(500).Token
+                )
+            ).Should().ThrowAsync<TimeoutException>();
     }
 
     private string CreateIdentity(string baseId) => $"{Guid.NewGuid().ToString("N").Substring(0, 6)}-{baseId}-";
@@ -35,7 +35,6 @@ public class LegacyTimeoutTests
         public Fixture(int clusterSize)
             : base(clusterSize, cc => cc
                 .WithActorRequestTimeout(TimeSpan.FromSeconds(1))
-                .WithLegacyRequestTimeoutBehavior()
             )
         {
         }


### PR DESCRIPTION
## Description

Closes #1712 

Cluster requests now throw TimeoutException on timeout. This is a breaking change. Old behavior can be enabled via `ClusterConfig.WithLegacyRequestTimeoutBehavior()`

<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
