### PR TITLE
Prefixed code-generated actor's Kind property with C# namespace

### DIFF
--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -127,7 +127,7 @@ namespace {{CsNamespace}}
 
     public class {{Name}}Actor : IActor
     {
-        public const string Kind = ""{{Name}}"";
+        public const string Kind = ""{{../CsNamespace}}/{{Name}}"";
 
         private {{Name}}Base? _inner;
         private IContext? _context;

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
@@ -265,7 +265,7 @@ namespace Acme.OtherSystem.Foo
 
     public class TestGrainActor : IActor
     {
-        public const string Kind = "TestGrain";
+        public const string Kind = "Acme.OtherSystem.Foo/TestGrain";
 
         private TestGrainBase? _inner;
         private IContext? _context;


### PR DESCRIPTION
## Description

<!-- If your pull request solves an issue, please reference it here -->

I've prefixed code-generated actor's Kind property with the C# namespace. The purpose behind this is to be able to create grains with the same name in different namespaces. One example would be creating an Account grain in App.Security namespace and another Account grain in App.Finance namespace.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
