### PR TITLE
Prefixing code-generated actor's Kind property with proto package

### DIFF
--- a/src/Proto.Cluster.CodeGen/CodeGenerator.cs
+++ b/src/Proto.Cluster.CodeGen/CodeGenerator.cs
@@ -63,6 +63,7 @@ public class CodeGenerator : CommonCodeGenerator
                     s => new ProtoService
                     {
                         Name = s.Name,
+                        Kind = GetKind(file.Package, s.Name),
                         Methods = s.Methods.ToArray()
                             .Select(
                                 (m, i) => new ProtoMethod
@@ -114,6 +115,11 @@ public class CodeGenerator : CommonCodeGenerator
             }
 
             return res;
+        }
+
+        static string GetKind(string? packageName, string serviceName)
+        {
+            return string.IsNullOrEmpty(packageName) ? serviceName : $"{packageName}/{serviceName}";
         }
     }
 

--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -127,7 +127,7 @@ namespace {{CsNamespace}}
 
     public class {{Name}}Actor : IActor
     {
-        public const string Kind = ""{{Name}}"";
+        public const string Kind = ""{{Kind}}"";
 
         private {{Name}}Base? _inner;
         private IContext? _context;

--- a/src/Proto.Cluster.CodeGen/model/ProtoService.cs
+++ b/src/Proto.Cluster.CodeGen/model/ProtoService.cs
@@ -8,5 +8,6 @@ namespace Proto.Cluster.CodeGen.model;
 public class ProtoService
 {
     public string Name { get; set; } = null!;
+    public string Kind { get; set; } = null!;
     public ProtoMethod[] Methods { get; set; } = null!;
 }

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutputPackageless.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutputPackageless.cs
@@ -265,7 +265,7 @@ namespace Acme.OtherSystem.Foo
 
     public class TestGrainActor : IActor
     {
-        public const string Kind = "Foo/TestGrain";
+        public const string Kind = "TestGrain";
 
         private TestGrainBase? _inner;
         private IContext? _context;

--- a/tests/Proto.Cluster.CodeGen.Tests/Proto.Cluster.CodeGen.Tests.csproj
+++ b/tests/Proto.Cluster.CodeGen.Tests/Proto.Cluster.CodeGen.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
@@ -22,11 +22,14 @@
 
     <ItemGroup>
         <Compile Remove="ExpectedOutput.cs" />
+        <Compile Remove="ExpectedOutputPackageless.cs" />
         <Content Include="foo.proto" CopyToOutputDirectory="Always" />
+        <Content Include="foo_packageless.proto" CopyToOutputDirectory="Always" />
         <Content Include="bar.proto" CopyToOutputDirectory="Always" />
         <Content Include="invalid.proto" CopyToOutputDirectory="Always" />
         <Content Include="invalid2.proto" CopyToOutputDirectory="Always" />
         <Content Include="ExpectedOutput.cs" CopyToOutputDirectory="PreserveNewest" />
+        <Content Include="ExpectedOutputPackageless.cs" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
 

--- a/tests/Proto.Cluster.CodeGen.Tests/ProtoGrainGenerationTests.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ProtoGrainGenerationTests.cs
@@ -18,28 +18,8 @@ public class ProtoGrainGenerationTests
 
     [Theory]
     [InlineData("foo.proto", "ExpectedOutput.cs")]
-    public void CanGenerateGrains(string protoDefinitionFile, string expectedOutputFile)
-    {
-        var r = new FileInfo(protoDefinitionFile).OpenText();
-        var set = new FileDescriptorSet();
-        set.AddImportPath(".");
-        set.Add(protoDefinitionFile, true, r);
-        set.Process();
-        var c = new CodeGenerator(Template.DefaultTemplate);
-        var res = c.Generate(set, NameNormalizer.Default, new Dictionary<string, string>()).ToArray();
-
-        foreach (var codeFile in res)
-        {
-            _testOutputHelper.WriteLine(codeFile.Text);
-        }
-
-        var expectedOutput = File.ReadAllText(expectedOutputFile).Trim();
-        Assert.Equal(expectedOutput, res.Single().Text.Trim());
-    }
-        
-    [Theory]
     [InlineData("foo_packageless.proto", "ExpectedOutputPackageless.cs")]
-    public void CanGenerateGrainsWithoutPackage(string protoDefinitionFile, string expectedOutputFile)
+    public void CanGenerateGrains(string protoDefinitionFile, string expectedOutputFile)
     {
         var r = new FileInfo(protoDefinitionFile).OpenText();
         var set = new FileDescriptorSet();

--- a/tests/Proto.Cluster.CodeGen.Tests/ProtoGrainGenerationTests.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ProtoGrainGenerationTests.cs
@@ -38,6 +38,27 @@ public class ProtoGrainGenerationTests
     }
         
     [Theory]
+    [InlineData("foo_packageless.proto", "ExpectedOutputPackageless.cs")]
+    public void CanGenerateGrainsWithoutPackage(string protoDefinitionFile, string expectedOutputFile)
+    {
+        var r = new FileInfo(protoDefinitionFile).OpenText();
+        var set = new FileDescriptorSet();
+        set.AddImportPath(".");
+        set.Add(protoDefinitionFile, true, r);
+        set.Process();
+        var c = new CodeGenerator(Template.DefaultTemplate);
+        var res = c.Generate(set, NameNormalizer.Default, new Dictionary<string, string>()).ToArray();
+
+        foreach (var codeFile in res)
+        {
+            _testOutputHelper.WriteLine(codeFile.Text);
+        }
+
+        var expectedOutput = File.ReadAllText(expectedOutputFile).Trim();
+        Assert.Equal(expectedOutput, res.Single().Text.Trim());
+    }
+
+    [Theory]
     [InlineData("invalid.proto","Unable to resolve return type for InvalidTestGrain.GetState")]
     [InlineData("invalid2.proto","Unable to resolve input parameter type for InvalidTestGrain2.SomeCommand")]
     public void FailsGracefully(string protoDefinitionFile, string expectedErrorMessage)

--- a/tests/Proto.Cluster.CodeGen.Tests/foo_packageless.proto
+++ b/tests/Proto.Cluster.CodeGen.Tests/foo_packageless.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+option csharp_namespace = "Acme.OtherSystem.Foo";
+import "bar.proto";
+
+import "google/protobuf/empty.proto";
+
+service TestGrain {
+  rpc GetState (google.protobuf.Empty) returns(Bar.GetCurrentStateResponse) {}
+  rpc SendCommand (Bar.SomeCommand) returns(google.protobuf.Empty) {}
+  rpc RequestResponse (Bar.Query) returns(Bar.Response) {}
+  rpc NoParameterOrReturn (google.protobuf.Empty) returns(google.protobuf.Empty) {}
+}


### PR DESCRIPTION
## Description

<!-- If your pull request solves an issue, please reference it here -->

I've prefixed code-generated actor's Kind property with the .proto file's package name. The purpose behind this is to be able to create grains with the same name in different C# namespaces. One example would be creating an Account grain in App.Security namespace and another Account grain in App.Finance namespace.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
