### PR TITLE
Prevent scheduled task cancelation from emitting error logs

### DIFF
--- a/src/Proto.Actor/Utils/TaskFactory.cs
+++ b/src/Proto.Actor/Utils/TaskFactory.cs
@@ -24,15 +24,13 @@ public static class SafeTask
     /// <param name="name"></param>
     public static async Task Run(Func<Task> body, CancellationToken cancellationToken = default, [CallerMemberName] string name = "")
     {
-        Task? t = null;
         try
         {
-            t = Task.Run(body, cancellationToken);
-            await t;
+            await Task.Run(body, cancellationToken);
         }
-        catch (TaskCanceledException e) when (e.Task == t)
+        catch (TaskCanceledException)
         {
-            //pass. do not log if our own task was cancelled
+            // Pass. Do not log when the task is canceled.
         }
         catch (Exception x)
         {


### PR DESCRIPTION
## Description
When trying to cancel scheduled tasks with their corresponding `CancelationSource`, I noticed error logs were constantly being emitted. The root cause of this turned out to be that the inner `Task.Delay` ends up being the task that is canceled rather than the outer `Task.run` so it would always throw an exception. I'm fairly convinced that it isn't necessary to check since no caller could possibly have access to the running task to catch the cancelation exception anyway.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
