### PR TITLE
Reorder cluster shutdown to reflect the reverse order of startup

### DIFF
--- a/src/Proto.Actor/ActorSystem.cs
+++ b/src/Proto.Actor/ActorSystem.cs
@@ -128,7 +128,13 @@ public sealed class ActorSystem : IAsyncDisposable
     /// <summary>
     ///     Stops the actor system with reason = "Disposed"
     /// </summary>
-    public async ValueTask DisposeAsync() => await ShutdownAsync("Disposed");
+    public async ValueTask DisposeAsync()
+    {
+        if (!Shutdown.IsCancellationRequested)
+        {
+            await ShutdownAsync("Disposed");
+        }
+    }
 
     // NOTE: We don't dispose _cts here on purpose, as doing so causes
     // ObjectDisposedException to be thrown from certain background task

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -31,7 +31,7 @@ namespace Proto.Cluster;
 public class Cluster : IActorSystemExtension<Cluster>
 {
     private Func<IEnumerable<Measurement<long>>>? _clusterKindObserver;
-    private Dictionary<string, ActivatedClusterKind> _clusterKinds = new();
+    private readonly Dictionary<string, ActivatedClusterKind> _clusterKinds = new();
     private Func<IEnumerable<Measurement<long>>>? _clusterMembersObserver;
     private readonly TaskCompletionSource<bool> _shutdownCompletedTcs = new();
 

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -243,7 +243,7 @@ public class Cluster : IActorSystemExtension<Cluster>
     /// <param name="reason">Provide the reason for the shutdown, that can be used for diagnosing problems</param>
     public async Task ShutdownAsync(bool graceful = true, string reason = "")
     {
-        await Gossip.SetStateAsync("cluster:left", new Empty());
+        await Gossip.SetStateAsync(GossipKeys.GracefullyLeft, new Empty());
 
         //TODO: improve later, await at least two gossip cycles
 

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -455,12 +455,10 @@ public class Gossiper
         }
     }
 
-    internal Task ShutdownAsync()
+    internal async Task ShutdownAsync()
     {
         Logger.LogInformation("Shutting down heartbeat");
-        _context.Stop(_pid);
+        await _context.StopAsync(_pid);
         Logger.LogInformation("Shut down heartbeat");
-
-        return Task.CompletedTask;
     }
 }

--- a/src/Proto.Cluster/Member/MemberList.cs
+++ b/src/Proto.Cluster/Member/MemberList.cs
@@ -57,7 +57,6 @@ public record MemberList
     private int _nextMemberIndex;
 
     private TaskCompletionSource<bool> _startedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private bool _stopping;
     private IConsensusHandle<ulong>? _topologyConsensus;
 
     public MemberList(Cluster cluster)
@@ -284,12 +283,12 @@ public record MemberList
 
     private void SelfBlocked()
     {
-        if (_stopping)
+        // If already shutting down, nothing to do.
+        if (_system.Shutdown.IsCancellationRequested)
         {
             return;
         }
 
-        _stopping = true;
         Logger.LogCritical("I have been blocked, exiting {Id}", MemberId);
         _ = _cluster.ShutdownAsync(reason: "Blocked by MemberList");
     }


### PR DESCRIPTION
## Description

I also added a mechanism for calling code to await the completion of cluster shutdown. This should allow for a smoother shutdown w.r.t. any provider registration/deregistration code.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
