### PR TITLE
Add a remark about canceling send done with the scheduler

### DIFF
--- a/src/Proto.Actor/Timers/Scheduler.cs
+++ b/src/Proto.Actor/Timers/Scheduler.cs
@@ -9,6 +9,10 @@ namespace Proto.Timers;
 ///     Scheduler can be used to schedule a message to be sent in the future. It is useful e.g., when actor needs to do
 ///     some work after a certain time.
 /// </summary>
+/// <remarks>
+///     The user is responsible for cancelling sends. They will not be automatically
+///     cancelled when this object is distroyed and will be left around in the background.
+/// </remarks>
 [PublicAPI]
 public class Scheduler
 {


### PR DESCRIPTION
## Description

It can be misleading for the user that when an actor using the scheduler is stopped or restarted the send tasks are not automatically cancelled. This can lead to resource leaks or duplicate sends when the actor is restarted.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
