### PR TITLE
More shutdown fixes

### DIFF
--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -243,7 +243,10 @@ public class Cluster : IActorSystemExtension<Cluster>
     /// <param name="reason">Provide the reason for the shutdown, that can be used for diagnosing problems</param>
     public async Task ShutdownAsync(bool graceful = true, string reason = "")
     {
+        // Inform all members of the cluster that this node intends to leave. Also, let the MemberList know that this
+        // node was the one that initiated the shutdown to prevent another shutdown from being called.
         await Gossip.SetStateAsync(GossipKeys.GracefullyLeft, new Empty());
+        MemberList.Stopping = true;
 
         //TODO: improve later, await at least two gossip cycles
 

--- a/src/Proto.Cluster/Member/MemberList.cs
+++ b/src/Proto.Cluster/Member/MemberList.cs
@@ -220,7 +220,7 @@ public record MemberList
 
             if (topology.Left.Any())
             {
-                Logger.LogInformation("[MemberList] Cluster members left {MembersJoined}", topology.Left);
+                Logger.LogInformation("[MemberList] Cluster members left {MembersLeft}", topology.Left);
             }
 
             BroadcastTopologyChanges(topology);

--- a/src/Proto.Cluster/Member/MemberList.cs
+++ b/src/Proto.Cluster/Member/MemberList.cs
@@ -313,7 +313,7 @@ public record MemberList
 
     private void TerminateMember(Member memberThatLeft)
     {
-        var endpointTerminated = new EndpointTerminatedEvent(false, memberThatLeft.Address, memberThatLeft.Id);
+        var endpointTerminated = new EndpointTerminatedEvent(true, memberThatLeft.Address, memberThatLeft.Id);
 
         if (Logger.IsEnabled(LogLevel.Information))
         {

--- a/src/Proto.Cluster/Member/MemberList.cs
+++ b/src/Proto.Cluster/Member/MemberList.cs
@@ -112,6 +112,8 @@ public record MemberList
 
     public string MemberId => _system.Id;
 
+    public bool Stopping { get; internal set; }
+
     /// <summary>
     ///     Gets a list of member ids (same as <see cref="ActorSystem.Id" />) that are currently active in the cluster.
     /// </summary>
@@ -284,7 +286,7 @@ public record MemberList
     private void SelfBlocked()
     {
         // If already shutting down, nothing to do.
-        if (_system.Shutdown.IsCancellationRequested)
+        if (Stopping || _system.Shutdown.IsCancellationRequested)
         {
             return;
         }

--- a/src/Proto.Remote/Endpoints/EndpointManager.cs
+++ b/src/Proto.Remote/Endpoints/EndpointManager.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //   <copyright file="EndpointManager.cs" company="Asynkron AB">
 //       Copyright (C) 2015-2022 Asynkron AB All rights reserved
 //   </copyright>
@@ -99,7 +99,7 @@ public sealed class EndpointManager
             {
                 endpoint.DisposeAsync().GetAwaiter().GetResult();
 
-                if (evt.OnError && _remoteConfig.WaitAfterEndpointTerminationTimeSpan.HasValue &&
+                if (evt.ShouldBlock && _remoteConfig.WaitAfterEndpointTerminationTimeSpan.HasValue &&
                     _blockedAddresses.TryAdd(evt.Address, DateTime.UtcNow))
                 {
                     _ = SafeTask.Run(async () =>
@@ -107,7 +107,7 @@ public sealed class EndpointManager
                         await Task.Delay(_remoteConfig.WaitAfterEndpointTerminationTimeSpan.Value)
                             .ConfigureAwait(false);
 
-                        _blockedAddresses.TryRemove(evt.Address, out var _);
+                        _blockedAddresses.TryRemove(evt.Address, out _);
                     });
                 }
             }
@@ -116,7 +116,7 @@ public sealed class EndpointManager
             {
                 endpoint.DisposeAsync().GetAwaiter().GetResult();
 
-                if (evt.OnError && _remoteConfig.WaitAfterEndpointTerminationTimeSpan.HasValue &&
+                if (evt.ShouldBlock && _remoteConfig.WaitAfterEndpointTerminationTimeSpan.HasValue &&
                     _blockedClientSystemIds.TryAdd(evt.ActorSystemId, DateTime.UtcNow))
                 {
                     _ = SafeTask.Run(async () =>
@@ -124,7 +124,7 @@ public sealed class EndpointManager
                         await Task.Delay(_remoteConfig.WaitAfterEndpointTerminationTimeSpan.Value)
                             .ConfigureAwait(false);
 
-                        _blockedClientSystemIds.TryRemove(evt.ActorSystemId, out var _);
+                        _blockedClientSystemIds.TryRemove(evt.ActorSystemId, out _);
                     });
                 }
             }
@@ -134,7 +134,7 @@ public sealed class EndpointManager
             evt.Address ?? evt.ActorSystemId);
     }
 
-    internal IEndpoint GetOrAddServerEndpoint(string address)
+    internal IEndpoint GetOrAddServerEndpoint(string? address)
     {
         if (address is null)
         {

--- a/src/Proto.Remote/Endpoints/ServerConnector.cs
+++ b/src/Proto.Remote/Endpoints/ServerConnector.cs
@@ -52,7 +52,7 @@ public sealed class ServerConnector
         _endpoint = endpoint;
         _maxNrOfRetries = remoteConfig.EndpointWriterOptions.MaxRetries;
         _backoff = remoteConfig.EndpointWriterOptions.RetryBackOff;
-        _runner = Task.Run(() => RunAsync());
+        _runner = Task.Run(RunAsync);
 
         if (_system.Metrics.Enabled)
         {
@@ -130,7 +130,7 @@ public sealed class ServerConnector
                 await call.ResponseStream.MoveNext().ConfigureAwait(false);
                 var response = call.ResponseStream.Current;
 
-                if (response.MessageTypeCase != RemoteMessage.MessageTypeOneofCase.ConnectResponse)
+                if (response?.MessageTypeCase != RemoteMessage.MessageTypeOneofCase.ConnectResponse)
                 {
                     throw new Exception("Expected ConnectResponse");
                 }

--- a/src/Proto.Remote/Messages.cs
+++ b/src/Proto.Remote/Messages.cs
@@ -6,7 +6,7 @@
 
 namespace Proto.Remote;
 
-public sealed record EndpointTerminatedEvent(bool OnError, string? Address, string? ActorSystemId)
+public sealed record EndpointTerminatedEvent(bool ShouldBlock, string? Address, string? ActorSystemId)
 {
     public override string ToString() => $"EndpointTerminatedEvent: {Address ?? ActorSystemId}";
 }


### PR DESCRIPTION
## Description
As it turns out, timing shutdowns is very hard to manage. I ended up putting the "stopping" variable back into the member list to ensure that it doesn't call `Cluster().ShutdownAsync()` again before it actually gets to the `System.ShutdownAsync()`. This will ensure that it is only called once if it's initiated by itself. The next thing I did was to change `EndpointTerminatedEvent`'s `OnError` property to `ShouldBlock` because I found that even in a graceful termination, the code right now will attempt to reconnect to a node that it "just" terminated because the gossip actor likely has messages in its mailbox where the "Respond" PID includes the node that should be removed. By pausing reconnections, the errors I was seeing around reconnects seem to have disappeared.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
