### PR TITLE
Added BoundedChannelFullMode overload to the bounded mailbox overloads

### DIFF
--- a/src/Proto.Actor/Mailbox/BoundedMailboxQueue.cs
+++ b/src/Proto.Actor/Mailbox/BoundedMailboxQueue.cs
@@ -15,9 +15,12 @@ public class BoundedMailboxQueue : IMailboxQueue
     private volatile bool _hasMessages;
     private long _length;
 
-    public BoundedMailboxQueue(int size)
+    public BoundedMailboxQueue(int size, BoundedChannelFullMode fullMode = BoundedChannelFullMode.Wait)
     {
-        _messages = Channel.CreateBounded<object>(size);
+        _messages = Channel.CreateBounded<object>(new BoundedChannelOptions(size)
+        {
+            FullMode = fullMode
+        });
     }
 
     public int Length => (int)Interlocked.Read(ref _length);

--- a/src/Proto.Actor/Mailbox/Mailbox.cs
+++ b/src/Proto.Actor/Mailbox/Mailbox.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 
 namespace Proto.Mailbox;
@@ -34,6 +35,9 @@ public static class BoundedMailbox
 {
     public static IMailbox Create(int size, params IMailboxStatistics[] stats) =>
         new DefaultMailbox(new LockingUnboundedMailboxQueue(4), new BoundedMailboxQueue(size), stats);
+
+    public static IMailbox Create(int size, BoundedChannelFullMode fullMode, params IMailboxStatistics[] stats) =>
+        new DefaultMailbox(new LockingUnboundedMailboxQueue(4), new BoundedMailboxQueue(size, fullMode), stats);
 }
 
 public static class UnboundedMailbox


### PR DESCRIPTION
## Description

According to the documentation, the bounded mailbox should let the user choose a strategy when the mailbox queue is full.

- Dropping Tail Mailbox = `BoundedChannelFullMode.DropNewest`
- Dropping Head Mailbox = `BoundedChannelFullMode.DropOldest`

However, there was only one overload where you could select the `size`, but not the `fullMode`.