### PR TITLE
Retry request on DeadLetterResponse

### DIFF
--- a/tests/Proto.Cluster.Tests/RetryOnDeadLetterTests.cs
+++ b/tests/Proto.Cluster.Tests/RetryOnDeadLetterTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using ClusterTest.Messages;
+using FluentAssertions;
+using Xunit;
+
+namespace Proto.Cluster.Tests;
+
+public class RetryOnDeadLetterTests
+{
+    [Fact]
+    public async Task ShouldRetryRequestOnDeadLetterResponseRegardlessOfResponseType()
+    {
+        await using var fixture = new Fixture(1);
+        await fixture.InitializeAsync();
+
+        var member = fixture.Members.First();
+        var identity = CreateIdentity("dead-letter-test");
+
+        // make sure the actor is created and the PID is cached
+        await member.RequestAsync<Pong>(identity, EchoActor.Kind, new Ping(), CancellationTokens.FromSeconds(1));
+
+        // pretend we have an invalid PID in the cache
+        var otherMember = await fixture.SpawnNode();
+        if (member.PidCache.TryGet(ClusterIdentity.Create(identity, EchoActor.Kind), out var pid))
+        {
+            var newPid = PID.FromAddress(otherMember.System.Address, pid.Id);
+            if (!member.PidCache.TryUpdate(ClusterIdentity.Create(identity, EchoActor.Kind), newPid, pid))
+            {
+                Assert.Fail("Failed to replace actor's pid with a fake one in the pid cache");
+            }
+        }
+        else
+        {
+            Assert.Fail("Did not find expected actor identity in the pid cache");
+        }
+
+        // check if the correct response type is returned
+        var response = await member.RequestAsync<object>(identity, EchoActor.Kind, new Ping(), CancellationTokens.FromSeconds(1));
+        response.Should().BeOfType<Pong>();
+
+    }
+
+    private string CreateIdentity(string baseId) => $"{Guid.NewGuid().ToString("N").Substring(0, 6)}-{baseId}-";
+    
+    private class Fixture : BaseInMemoryClusterFixture
+    {
+        public Fixture(int clusterSize)
+            : base(clusterSize, cc => cc
+                .WithActorRequestTimeout(TimeSpan.FromSeconds(1))
+            )
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Description

Instead of failing virtual actor request when DeadLetterResponse is received, retry the request.

Also make sure that DeadLetterResponse is not returned to client when request is called with object as type parameter.
Fixes #1799

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
