### PR TITLE
Ensure that `WithSenderMiddleware` actually chains middleware calls

### DIFF
--- a/examples/ContextDecorators/Program.cs
+++ b/examples/ContextDecorators/Program.cs
@@ -17,8 +17,6 @@ public class LoggingRootDecorator : RootContextDecorator
     {
     }
 
-    protected override IRootContext WithInnerContext(IRootContext context) => new LoggingRootDecorator(context);
-
     public override async Task<T> RequestAsync<T>(PID target, object message, CancellationToken ct)
     {
         Console.WriteLine("Enter RequestAsync");

--- a/src/Proto.Actor/Context/RootContextDecorator.cs
+++ b/src/Proto.Actor/Context/RootContextDecorator.cs
@@ -19,7 +19,7 @@ namespace Proto;
 [PublicAPI]
 public abstract class RootContextDecorator : IRootContext
 {
-    private readonly IRootContext _context;
+    private IRootContext _context;
 
     protected RootContextDecorator(IRootContext context)
     {
@@ -49,7 +49,7 @@ public abstract class RootContextDecorator : IRootContext
     public virtual Task PoisonAsync(PID pid) => _context.PoisonAsync(pid);
 
     public IRootContext WithSenderMiddleware(params Func<Sender, Sender>[] middleware) =>
-        WithInnerContext(_context.WithSenderMiddleware(middleware));
+        _context = _context.WithSenderMiddleware(middleware);
 
     public virtual PID? Parent => null;
     public virtual PID Self => null!;
@@ -64,8 +64,6 @@ public abstract class RootContextDecorator : IRootContext
     public virtual void Remove<T>() => _context.Remove<T>();
 
     public IFuture GetFuture() => _context.GetFuture();
-
-    protected abstract IRootContext WithInnerContext(IRootContext context);
 
     public virtual void Request(PID target, object message) => _context.Request(target, message);
 }

--- a/src/Proto.OpenTelemetry/OpenTelemetryDecorators.cs
+++ b/src/Proto.OpenTelemetry/OpenTelemetryDecorators.cs
@@ -28,9 +28,6 @@ internal class OpenTelemetryRootContextDecorator : RootContextDecorator
 
     private static string Source => "Root";
 
-    protected override IRootContext WithInnerContext(IRootContext context) =>
-        new OpenTelemetryRootContextDecorator(context, _sendActivitySetup);
-
     public override void Send(PID target, object message) =>
         OpenTelemetryMethodsDecorators.Send(Source, target, message, _sendActivitySetup,
             () => base.Send(target, message));


### PR DESCRIPTION
I also removed `WithInnerContext` since it seems a little silly to have to allocate another decorator object when `WithSenderMiddleware` could just set the inner context. I'm happy to revert that bit if you feel it's necessary.

## Description

<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
