### PR TITLE
Skip ObjectDisposedException as well

### DIFF
--- a/src/Proto.Actor/Utils/TaskFactory.cs
+++ b/src/Proto.Actor/Utils/TaskFactory.cs
@@ -17,7 +17,8 @@ public static class SafeTask
     private static readonly ILogger Logger = Log.CreateLogger<TaskFactory>();
 
     /// <summary>
-    ///     Runs a task and handles exceptions. If <see cref="TaskCanceledException" /> is thrown, it is ignored.
+    ///     Runs a task and handles exceptions. If <see cref="TaskCanceledException" /> or
+    ///     <see cref="ObjectDisposedException" />is thrown, it is ignored.
     ///     If any other exception is thrown, it is logged.
     /// </summary>
     /// <param name="body"></param>
@@ -33,6 +34,10 @@ public static class SafeTask
         catch (TaskCanceledException)
         {
             // Pass. Do not log when the task is canceled.
+        }
+        catch (ObjectDisposedException)
+        {
+            // Pass. The caller disposed the CancellationTokenSource.
         }
         catch (Exception x)
         {


### PR DESCRIPTION
## Description
For cleanliness, I'm calling
```
_token.Cancel();
_token.Dispose();
```
However, due to a possible timing issue, this can lead to ObjectDisposedExceptions depending on which part of the loop the task is in when cancel is called. I would prefer it not log if possible.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
