### PR TITLE
Adds an optional idle timeout to BatchingProducer

### DIFF
--- a/src/Proto.Cluster/PubSub/BatchingProducer.cs
+++ b/src/Proto.Cluster/PubSub/BatchingProducer.cs
@@ -68,6 +68,10 @@ public class BatchingProducer : IAsyncDisposable
 
         try
         {
+            await _publisher.Initialize(new PublisherConfig
+            {
+                IdleTimeout = _config.PublisherIdleTimeout
+            }, _topic, cancel);
             try
             {
                 while (!cancel.IsCancellationRequested)

--- a/src/Proto.Cluster/PubSub/BatchingProducerConfig.cs
+++ b/src/Proto.Cluster/PubSub/BatchingProducerConfig.cs
@@ -23,38 +23,44 @@ public record BatchingProducerConfig
 {
     private static readonly ILogger Logger = Log.CreateLogger<BatchingProducer>();
 
-    public static readonly ShouldThrottle DefaultLogThrottle = Throttle.Create(3, TimeSpan.FromSeconds(10),
+    private static readonly ShouldThrottle DefaultLogThrottle = Throttle.Create(3, TimeSpan.FromSeconds(10),
         droppedLogs => Logger.LogInformation("[BatchingProducer] Throttled {LogCount} logs", droppedLogs)
     );
 
     /// <summary>
     ///     Maximum size of the published batch. Default: 2000.
     /// </summary>
-    public int BatchSize { get; set; } = 2000;
+    public int BatchSize { get; init; } = 2000;
 
     /// <summary>
     ///     Max size of the requests waiting in queue. If value is provided, the producer will throw
     ///     <see cref="ProducerQueueFullException" /> when queue size is exceeded. If null, the queue is unbounded. Default:
     ///     null.
     /// </summary>
-    public int? MaxQueueSize { get; set; } = null;
+    public int? MaxQueueSize { get; init; }
 
     /// <summary>
     ///     How long to wait for the publishing to complete, in seconds. Default: 5.
     /// </summary>
     /// <remarks>Seconds granularity allows for more optimized usage of cancellation tokens</remarks>
-    public int PublishTimeoutInSeconds { get; set; } = 5;
+    public int PublishTimeoutInSeconds { get; init; } = 5;
 
     /// <summary>
     ///     Error handler that can decide what to do with an error when publishing a batch. Default: Fail and stop the
     ///     <see cref="BatchingProducer" />
     /// </summary>
-    public PublishingErrorHandler OnPublishingError { get; set; } =
+    public PublishingErrorHandler OnPublishingError { get; init; } =
         (_, _, _) => Task.FromResult(PublishingErrorDecision.FailBatchAndStop);
 
     /// <summary>
     ///     A throttle for logging from this producer. By default, a throttle shared between all instances of
     ///     <see cref="BatchingProducer" /> is used, that allows for 10 events in 10 seconds.
     /// </summary>
-    public ShouldThrottle LogThrottle { get; set; } = DefaultLogThrottle;
+    public ShouldThrottle LogThrottle { get; init; } = DefaultLogThrottle;
+
+    /// <summary>
+    ///     Optional idle timeout which will specify to the `IPublisher` how long it should wait before invoking clean
+    ///     up code to recover resources.
+    /// </summary>
+    public TimeSpan? PublisherIdleTimeout { get; init; }
 }

--- a/src/Proto.Cluster/PubSub/IPublisher.cs
+++ b/src/Proto.Cluster/PubSub/IPublisher.cs
@@ -12,6 +12,15 @@ namespace Proto.Cluster.PubSub;
 public interface IPublisher
 {
     /// <summary>
+    ///     Initializes the internal mechanisms of this <see cref="Proto.Cluster.PubSub.IPublisher"></see>
+    /// </summary>
+    /// <param name="config">Configuration used to initialize this publisher</param>
+    /// <param name="topic">Topic to publish to</param>
+    /// <param name="ct"></param>
+    /// <returns></returns>
+    public Task Initialize(PublisherConfig? config, string topic, CancellationToken ct = default);
+
+    /// <summary>
     ///     Publishes a batch of messages to PubSub topic. For high throughput scenarios consider using
     ///     <see cref="Proto.Cluster.PubSub.BatchingProducer"></see>.
     /// </summary>
@@ -19,7 +28,7 @@ public interface IPublisher
     /// <param name="batch">Message batch</param>
     /// <param name="ct"></param>
     /// <returns></returns>
-    public Task<PublishResponse> PublishBatch(
+    Task<PublishResponse> PublishBatch(
         string topic,
         PubSubBatch batch,
         CancellationToken ct = default

--- a/src/Proto.Cluster/PubSub/Publisher.cs
+++ b/src/Proto.Cluster/PubSub/Publisher.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
 
 namespace Proto.Cluster.PubSub;
 
@@ -18,6 +19,22 @@ public class Publisher : IPublisher
     public Publisher(Cluster cluster)
     {
         _cluster = cluster;
+    }
+
+    /// <summary>
+    ///     Initializes the internal mechanisms of this <see cref="Proto.Cluster.PubSub.IPublisher"></see>
+    /// </summary>
+    /// <param name="config">Configuration used to initialize this publisher</param>
+    /// <param name="topic">Topic to publish to</param>
+    /// <param name="ct"></param>
+    /// <returns></returns>
+    public Task Initialize(PublisherConfig? config, string topic, CancellationToken ct = default)
+    {
+        var message = new Initialize
+        {
+            IdleTimeout = config?.IdleTimeout?.ToDuration()
+        };
+        return _cluster.RequestAsync<Acknowledge>(topic, TopicActor.Kind, message, ct);
     }
 
     /// <summary>

--- a/src/Proto.Cluster/PubSub/PublisherConfig.cs
+++ b/src/Proto.Cluster/PubSub/PublisherConfig.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Proto.Cluster.PubSub;
+
+public record PublisherConfig
+{
+  /// <summary>
+  ///     Optional idle timeout which will specify to the `IPublisher` how long it should wait before invoking clean
+  ///     up code to recover resources.
+  /// </summary>
+  public TimeSpan? IdleTimeout { get; init; }
+}

--- a/src/Proto.Cluster/PubSubContracts.proto
+++ b/src/Proto.Cluster/PubSubContracts.proto
@@ -3,6 +3,7 @@ package cluster.pubsub;
 option csharp_namespace = "Proto.Cluster.PubSub";
 import "Proto.Actor/Protos.proto";
 import "ClusterContracts.proto";
+import "google/protobuf/duration.proto";
 
 // Identifies a subscriber by either ClusterIdentity or PID
 message SubscriberIdentity {
@@ -11,6 +12,13 @@ message SubscriberIdentity {
     cluster.ClusterIdentity cluster_identity = 2;
   }
 }
+
+// First request to initialize the actor.
+message Initialize {
+  google.protobuf.Duration idleTimeout = 1;
+}
+
+message Acknowledge {}
 
 // A list of subscribers
 message Subscribers {

--- a/tests/Proto.Cluster.PubSub.Tests/PubSubBatchingProducerTests.cs
+++ b/tests/Proto.Cluster.PubSub.Tests/PubSubBatchingProducerTests.cs
@@ -325,6 +325,11 @@ public class PubSubBatchingProducerTests
             _publish = publish;
         }
 
+        public Task Initialize(PublisherConfig? config, string topic, CancellationToken ct = default)
+        {
+            return Task.CompletedTask;
+        }
+
         public Task<PublishResponse> PublishBatch(string topic, PubSubBatch batch, CancellationToken ct = default) =>
             _publish(batch);
     }
@@ -333,6 +338,11 @@ public class PubSubBatchingProducerTests
     {
         public List<PubSubBatch> SentBatches { get; } = new();
         public bool ShouldFail { get; set; }
+
+        public Task Initialize(PublisherConfig? config, string topic, CancellationToken ct = default)
+        {
+            return Task.CompletedTask;
+        }
 
         public Task<PublishResponse> PublishBatch(string topic, PubSubBatch batch, CancellationToken ct = default)
         {


### PR DESCRIPTION
## Description
The system we run can have an unbounded number of BatchingProducers created and rather than continuing to accumulate these forever, it would be nice to specify a timeout to allow for these to clean themselves up after receiving no messages.
## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
