### PR TITLE
Adding some graceful shutdown handling to ProtoActorLifecycleHost

### DIFF
--- a/src/Proto.Cluster/ServiceCollectionExtensions.cs
+++ b/src/Proto.Cluster/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Proto.Cluster;
 using Proto.Cluster.Identity;
@@ -36,7 +37,6 @@ public static class ServiceCollectionExtensions
             var loggerFactory = p.GetRequiredService<ILoggerFactory>();
             Log.SetLoggerFactory(loggerFactory);
 
-    
             configure(p, boot);
 
             var s = new ActorSystemConfig();
@@ -60,11 +60,15 @@ public static class ServiceCollectionExtensions
 
         self.AddSingleton(p => p.GetRequiredService<ActorSystem>().Cluster());
         self.AddSingleton(p => p.GetRequiredService<ActorSystem>().Root);
-        self.AddHostedService(p => new ProtoActorLifecycleHost(p.GetRequiredService<Cluster>(), boot.RunAsClient));
+        self.AddHostedService(p =>
+            new ProtoActorLifecycleHost(
+                p.GetRequiredService<ActorSystem>(),
+                p.GetRequiredService<IHostApplicationLifetime>(),
+                boot.RunAsClient));
 
         return self;
     }
-    
+
     public static IServiceCollection AddProtoCluster(this IServiceCollection self, string clusterName,
         string bindToHost = "localhost", int port = 0,
         Func<ActorSystemConfig, ActorSystemConfig>? configureSystem = null,
@@ -101,7 +105,11 @@ public static class ServiceCollectionExtensions
 
         self.AddSingleton(p => p.GetRequiredService<ActorSystem>().Cluster());
         self.AddSingleton(p => p.GetRequiredService<ActorSystem>().Root);
-        self.AddHostedService(p => new ProtoActorLifecycleHost(p.GetRequiredService<Cluster>(), runAsClient));
+        self.AddHostedService(p =>
+            new ProtoActorLifecycleHost(
+                p.GetRequiredService<ActorSystem>(),
+                p.GetRequiredService<IHostApplicationLifetime>(),
+                runAsClient));
 
         return self;
     }


### PR DESCRIPTION
## Description

Since the proto.actor cluster has the ability to shut itself down when other nodes in the system believe that it should be shutdown, I believe it makes sense for this to also trigger a process shutdown. Perhaps this should be made optional?

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
