### PR TITLE
fix: use fully qualified global namespaces when referencing internal classes

### DIFF
--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // <copyright file="Template.cs" company="Asynkron AB">
 //      Copyright (C) 2015-2022 Asynkron AB All rights reserved
 // </copyright>
@@ -171,9 +171,12 @@ namespace {{CsNamespace}}
                         case {{Index}}:
                         {   
                             {{#if UseParameter}}
-                            if(r is {{InputName}} input){
+                            if (r is {{InputName}} input)
+                            {
                                 await _inner!.{{Name}}(input, Respond, OnError);
-                            } else {
+                            }
+                            else
+                            {
                                 OnError($""Invalid client contract. Expected {{InputName}}, received {r?.GetType().FullName}"");
                             }
                             {{else}}

--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="Template.cs" company="Asynkron AB">
 //      Copyright (C) 2015-2022 Asynkron AB All rights reserved
 // </copyright>
@@ -33,7 +33,7 @@ namespace {{CsNamespace}}
     {{#each Services}}
     public abstract class {{Name}}Base
     {
-        protected global::Proto.IContext Context {get;}
+        protected global::Proto.IContext Context { get; }
         protected global::Proto.ActorSystem System => Context.System;
         protected global::Proto.Cluster.Cluster Cluster => Context.System.Cluster();
     
@@ -109,7 +109,7 @@ namespace {{CsNamespace}}
         {
             var gr = new global::Proto.Cluster.GrainRequestMessage({{Index}}, {{#if UseParameter}}{{Parameter}}{{else}}null{{/if}});
             //request the RPC method to be invoked
-            var res = await _cluster.RequestAsync<object>(_id, {{../Name}}Actor.Kind, gr,context, ct);
+            var res = await _cluster.RequestAsync<object>(_id, {{../Name}}Actor.Kind, gr, context, ct);
 
             return res switch
             {
@@ -198,9 +198,9 @@ namespace {{CsNamespace}}
             }
         }
 
-        private void Respond<T>(T response) where T: global::Google.Protobuf.IMessage => _context!.Respond(response is not null ? response : new global::Proto.Cluster.GrainResponseMessage(response));
+        private void Respond<T>(T response) where T : global::Google.Protobuf.IMessage => _context!.Respond(response is not null ? response : new global::Proto.Cluster.GrainResponseMessage(response));
         private void Respond() => _context!.Respond( new global::Proto.Cluster.GrainResponseMessage(null));
-        private void OnError(string error) => _context!.Respond( new global::Proto.Cluster.GrainErrorResponse {Err = error } );
+        private void OnError(string error) => _context!.Respond(new global::Proto.Cluster.GrainErrorResponse { Err = error });
 
         public static global::Proto.Cluster.ClusterKind GetClusterKind(Func<global::Proto.IContext, global::Proto.Cluster.ClusterIdentity, {{Name}}Base> innerFactory)
             => new global::Proto.Cluster.ClusterKind(Kind, global::Proto.Props.FromProducer(() => new {{Name}}Actor(innerFactory)));

--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -30,7 +30,7 @@ namespace {{CsNamespace}}
         {{/each}}
     }
 
-	{{#each Services}}	
+    {{#each Services}}
     public abstract class {{Name}}Base
     {
         protected global::Proto.IContext Context {get;}
@@ -67,9 +67,9 @@ namespace {{CsNamespace}}
         }
         {{/each}}
     
-		{{#each Methods}}
+        {{#each Methods}}
         public abstract Task{{#if UseReturn}}<{{OutputName}}>{{/if}} {{Name}}({{SingleParameterDefinition}});
-		{{/each}}
+        {{/each}}
     }
 
     public class {{Name}}Client
@@ -83,7 +83,7 @@ namespace {{CsNamespace}}
             _cluster = cluster;
         }
 
-		{{#each Methods}}
+        {{#each Methods}}
         public async Task<{{OutputName}}?> {{Name}}({{LeadingParameterDefinition}}CancellationToken ct)
         {
             var gr = new global::Proto.Cluster.GrainRequestMessage({{Index}}, {{#if UseParameter}}{{Parameter}}{{else}}null{{/if}});
@@ -125,7 +125,7 @@ namespace {{CsNamespace}}
                 _ => throw new NotSupportedException($""Unknown response type {res.GetType().FullName}"")
             };
         }
-		{{/each}}
+        {{/each}}
     }
 
     public class {{Name}}Actor : global::Proto.IActor
@@ -167,7 +167,7 @@ namespace {{CsNamespace}}
                 {
                     switch (methodIndex)
                     {
-			            {{#each Methods}}
+                        {{#each Methods}}
                         case {{Index}}:
                         {   
                             {{#if UseParameter}}
@@ -182,7 +182,7 @@ namespace {{CsNamespace}}
 
                             break;
                         }
-			            {{/each}}
+                        {{/each}}
                         default:
                             OnError($""Invalid client contract. Unexpected Index {methodIndex}"");
                             break;
@@ -208,7 +208,7 @@ namespace {{CsNamespace}}
         public static global::Proto.Cluster.ClusterKind GetClusterKind<T>(global::System.IServiceProvider serviceProvider) where T : {{Name}}Base
             => new global::Proto.Cluster.ClusterKind(Kind, global::Proto.Props.FromProducer(() => new {{Name}}Actor((ctx, id) => global::Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance<T>(serviceProvider, ctx, id))));
     }
-	{{/each}}	
+    {{/each}}
 }
 ";
 }

--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -202,7 +202,7 @@ namespace {{CsNamespace}}
         }
 
         private void Respond<T>(T response) where T : global::Google.Protobuf.IMessage => _context!.Respond(response is not null ? response : new global::Proto.Cluster.GrainResponseMessage(response));
-        private void Respond() => _context!.Respond( new global::Proto.Cluster.GrainResponseMessage(null));
+        private void Respond() => _context!.Respond(new global::Proto.Cluster.GrainResponseMessage(null));
         private void OnError(string error) => _context!.Respond(new global::Proto.Cluster.GrainErrorResponse { Err = error });
 
         public static global::Proto.Cluster.ClusterKind GetClusterKind(Func<global::Proto.IContext, global::Proto.Cluster.ClusterIdentity, {{Name}}Base> innerFactory)

--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -24,20 +24,20 @@ namespace {{CsNamespace}}
     public static partial class GrainExtensions
     {
         {{#each Services}}
-        public static {{Name}}Client Get{{Name}}(this Cluster cluster, string identity) => new {{Name}}Client(cluster, identity);
+        public static {{Name}}Client Get{{Name}}(this global::Proto.Cluster.Cluster cluster, string identity) => new {{Name}}Client(cluster, identity);
 
-        public static {{Name}}Client Get{{Name}}(this IContext context, string identity) => new {{Name}}Client(context.System.Cluster(), identity);
+        public static {{Name}}Client Get{{Name}}(this global::Proto.IContext context, string identity) => new {{Name}}Client(context.System.Cluster(), identity);
         {{/each}}
     }
 
 	{{#each Services}}	
     public abstract class {{Name}}Base
     {
-        protected IContext Context {get;}
-        protected ActorSystem System => Context.System;
-        protected Cluster Cluster => Context.System.Cluster();
+        protected global::Proto.IContext Context {get;}
+        protected global::Proto.ActorSystem System => Context.System;
+        protected global::Proto.Cluster.Cluster Cluster => Context.System.Cluster();
     
-        protected {{Name}}Base(IContext context)
+        protected {{Name}}Base(global::Proto.IContext context)
         {
             Context = context;
         }
@@ -75,9 +75,9 @@ namespace {{CsNamespace}}
     public class {{Name}}Client
     {
         private readonly string _id;
-        private readonly Cluster _cluster;
+        private readonly global::Proto.Cluster.Cluster _cluster;
 
-        public {{Name}}Client(Cluster cluster, string id)
+        public {{Name}}Client(global::Proto.Cluster.Cluster cluster, string id)
         {
             _id = id;
             _cluster = cluster;
@@ -86,18 +86,18 @@ namespace {{CsNamespace}}
 		{{#each Methods}}
         public async Task<{{OutputName}}?> {{Name}}({{LeadingParameterDefinition}}CancellationToken ct)
         {
-            var gr = new GrainRequestMessage({{Index}}, {{#if UseParameter}}{{Parameter}}{{else}}null{{/if}});
+            var gr = new global::Proto.Cluster.GrainRequestMessage({{Index}}, {{#if UseParameter}}{{Parameter}}{{else}}null{{/if}});
             //request the RPC method to be invoked
             var res = await _cluster.RequestAsync<object>(_id, {{../Name}}Actor.Kind, gr, ct);
 
             return res switch
             {
                 // normal response
-                {{OutputName}} message => {{#if UseReturn}}message{{else}}Nothing.Instance{{/if}},
+                {{OutputName}} message => {{#if UseReturn}}message{{else}}global::Proto.Nothing.Instance{{/if}},
                 // enveloped response
-                GrainResponseMessage grainResponse => {{#if UseReturn}}({{OutputName}}?)grainResponse.ResponseMessage{{else}}Nothing.Instance{{/if}},
+                global::Proto.Cluster.GrainResponseMessage grainResponse => {{#if UseReturn}}({{OutputName}}?)grainResponse.ResponseMessage{{else}}global::Proto.Nothing.Instance{{/if}},
                 // error response
-                GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -105,20 +105,20 @@ namespace {{CsNamespace}}
             };
         }
         
-        public async Task<{{OutputName}}?> {{Name}}({{LeadingParameterDefinition}}ISenderContext context, CancellationToken ct)
+        public async Task<{{OutputName}}?> {{Name}}({{LeadingParameterDefinition}}global::Proto.ISenderContext context, CancellationToken ct)
         {
-            var gr = new GrainRequestMessage({{Index}}, {{#if UseParameter}}{{Parameter}}{{else}}null{{/if}});
+            var gr = new global::Proto.Cluster.GrainRequestMessage({{Index}}, {{#if UseParameter}}{{Parameter}}{{else}}null{{/if}});
             //request the RPC method to be invoked
             var res = await _cluster.RequestAsync<object>(_id, {{../Name}}Actor.Kind, gr,context, ct);
 
             return res switch
             {
                 // normal response
-                {{OutputName}} message => {{#if UseReturn}}message{{else}}Nothing.Instance{{/if}},
+                {{OutputName}} message => {{#if UseReturn}}message{{else}}global::Proto.Nothing.Instance{{/if}},
                 // enveloped response
-                GrainResponseMessage grainResponse => {{#if UseReturn}}({{OutputName}}?)grainResponse.ResponseMessage{{else}}Nothing.Instance{{/if}},
+                global::Proto.Cluster.GrainResponseMessage grainResponse => {{#if UseReturn}}({{OutputName}}?)grainResponse.ResponseMessage{{else}}global::Proto.Nothing.Instance{{/if}},
                 // error response
-                GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -128,27 +128,27 @@ namespace {{CsNamespace}}
 		{{/each}}
     }
 
-    public class {{Name}}Actor : IActor
+    public class {{Name}}Actor : global::Proto.IActor
     {
         public const string Kind = ""{{Kind}}"";
 
         private {{Name}}Base? _inner;
-        private IContext? _context;
-        private readonly Func<IContext, ClusterIdentity, {{Name}}Base> _innerFactory;
+        private global::Proto.IContext? _context;
+        private readonly Func<global::Proto.IContext, global::Proto.Cluster.ClusterIdentity, {{Name}}Base> _innerFactory;
     
-        public {{Name}}Actor(Func<IContext, ClusterIdentity, {{Name}}Base> innerFactory)
+        public {{Name}}Actor(Func<global::Proto.IContext, global::Proto.Cluster.ClusterIdentity, {{Name}}Base> innerFactory)
         {
             _innerFactory = innerFactory;
         }
 
-        public async Task ReceiveAsync(IContext context)
+        public async Task ReceiveAsync(global::Proto.IContext context)
         {
             switch (context.Message)
             {
                 case Started msg: 
                 {
                     _context = context;
-                    var id = context.Get<ClusterIdentity>()!; // Always populated on startup
+                    var id = context.Get<global::Proto.Cluster.ClusterIdentity>()!; // Always populated on startup
                     _inner = _innerFactory(context, id);
                     await _inner.OnStarted();
                     break;
@@ -198,15 +198,15 @@ namespace {{CsNamespace}}
             }
         }
 
-        private void Respond<T>(T response) where T: IMessage => _context!.Respond(response is not null ? response : new GrainResponseMessage(response));
-        private void Respond() => _context!.Respond( new GrainResponseMessage(null));
-        private void OnError(string error) => _context!.Respond( new GrainErrorResponse {Err = error } );
+        private void Respond<T>(T response) where T: global::Google.Protobuf.IMessage => _context!.Respond(response is not null ? response : new global::Proto.Cluster.GrainResponseMessage(response));
+        private void Respond() => _context!.Respond( new global::Proto.Cluster.GrainResponseMessage(null));
+        private void OnError(string error) => _context!.Respond( new global::Proto.Cluster.GrainErrorResponse {Err = error } );
 
-        public static ClusterKind GetClusterKind(Func<IContext, ClusterIdentity, {{Name}}Base> innerFactory)
-            => new ClusterKind(Kind, Props.FromProducer(() => new {{Name}}Actor(innerFactory)));
+        public static global::Proto.Cluster.ClusterKind GetClusterKind(Func<global::Proto.IContext, global::Proto.Cluster.ClusterIdentity, {{Name}}Base> innerFactory)
+            => new global::Proto.Cluster.ClusterKind(Kind, global::Proto.Props.FromProducer(() => new {{Name}}Actor(innerFactory)));
 
-        public static ClusterKind GetClusterKind<T>(IServiceProvider serviceProvider) where T : {{Name}}Base
-            => new ClusterKind(Kind, Props.FromProducer(() => new {{Name}}Actor((ctx, id) => ActivatorUtilities.CreateInstance<T>(serviceProvider, ctx, id))));
+        public static global::Proto.Cluster.ClusterKind GetClusterKind<T>(global::System.IServiceProvider serviceProvider) where T : {{Name}}Base
+            => new global::Proto.Cluster.ClusterKind(Kind, global::Proto.Props.FromProducer(() => new {{Name}}Actor((ctx, id) => global::Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance<T>(serviceProvider, ctx, id))));
     }
 	{{/each}}	
 }


### PR DESCRIPTION
## Description

This PR aims to fix compilation errors when doing source gen inside of a `Cluster` namespace. Fixes #1840 

I'm leaving this as a draft until I can get home and resign my commits with my PGP key.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

I don't believe the following need to be done for this as functionality will be confirmed by existing tests.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
