### PR TITLE
Build fix

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -100,6 +100,6 @@ jobs:
           
       - name: Create and push NuGet package
         run: |
-          dotnet pack ProtoActor.sln -c Release -o nuget -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:GenerateDocumentationFile=true -p:NoWarn=CS1591
+          dotnet pack ProtoActor.sln -c Release -o nuget -p:SymbolPackageFormat=snupkg -p:GenerateDocumentationFile=true -p:NoWarn=CS1591
           dotnet nuget push nuget/**/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
           


### PR DESCRIPTION
## Description
Removing `-p:IncludeSymbols=true` override, already included via directory props on relevant projects. Enabling it for Proto.Analyzers causes it to fail since it does not contain symbols