### PR TITLE
Add ReenterAfter override

### DIFF
--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -280,6 +280,23 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
         ScheduleContinuation(target, cont);
     }
 
+    public void ReenterAfter<T>(Task<T> target, Action<Task<T>> action)
+    {
+        var msg = _messageOrEnvelope;
+
+        var cont = new Continuation(
+            () =>
+            {
+                action(target);
+
+                return Task.CompletedTask;
+            },
+            msg,
+            Actor);
+
+        ScheduleContinuation(target, cont);
+    }
+
     public void ReenterAfter(Task target, Func<Task, Task> action)
     {
         var msg = _messageOrEnvelope;

--- a/src/Proto.Actor/Context/ActorContextDecorator.cs
+++ b/src/Proto.Actor/Context/ActorContextDecorator.cs
@@ -67,6 +67,8 @@ public abstract class ActorContextDecorator : IContext
 
     public void ReenterAfter(Task target, Action<Task> action) => _context.ReenterAfter(target, action);
 
+    public void ReenterAfter<T>(Task<T> target, Action<Task<T>> action) => _context.ReenterAfter(target, action);
+
     public void ReenterAfter(Task target, Func<Task, Task> action) => _context.ReenterAfter(target, action);
 
     public CapturedContext Capture() => _context.Capture();

--- a/src/Proto.Actor/Context/IContext.cs
+++ b/src/Proto.Actor/Context/IContext.cs
@@ -119,6 +119,16 @@ public interface IContext : ISenderContext, IReceiverContext, ISpawnerContext, I
     /// </summary>
     /// <param name="target">The Task to await</param>
     /// <param name="action">The continuation to call once the task is completed. The awaited task is passed in as a parameter.</param>
+    void ReenterAfter<T>(Task<T> target, Action<Task<T>> action);
+
+    /// <summary>
+    ///     Awaits the given target task and once completed, the given action is then completed within the actors concurrency
+    ///     constraint.
+    ///     The concept is called Reentrancy, where an actor can continue to process messages while also awaiting that some
+    ///     asynchronous operation completes.
+    /// </summary>
+    /// <param name="target">The Task to await</param>
+    /// <param name="action">The continuation to call once the task is completed. The awaited task is passed in as a parameter.</param>
     void ReenterAfter(Task target, Func<Task, Task> action);
 
     /// <summary>


### PR DESCRIPTION
## Description

Adds an overload to `ReenterAfter` that takes in a `Task<T>` with a result and a `Action` callback that takes in that `Task<T>`.
<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
