### PR TITLE
use dispatcher if needed

### DIFF
--- a/src/Proto.Actor/Mailbox/Mailbox.cs
+++ b/src/Proto.Actor/Mailbox/Mailbox.cs
@@ -305,11 +305,18 @@ public sealed class DefaultMailbox : IMailbox
     {
         if (Interlocked.CompareExchange(ref _status, MailboxStatus.Busy, MailboxStatus.Idle) == MailboxStatus.Idle)
         {
+            if (_dispatcher == Dispatchers.DefaultDispatcher)
+            {
 #if NET5_0_OR_GREATER
-            ThreadPool.UnsafeQueueUserWorkItem(this, false);
+                ThreadPool.UnsafeQueueUserWorkItem(this, false);
 #else
-            ThreadPool.UnsafeQueueUserWorkItem(RunWrapper, this);
+                ThreadPool.UnsafeQueueUserWorkItem(RunWrapper, this);
 #endif
+            }
+            else
+            {
+                _dispatcher.Schedule(() => RunAsync(this));
+            }
         }
     }
 


### PR DESCRIPTION
Fix scheduler issue https://github.com/asynkron/protoactor-dotnet/issues/1952
At some point, some experimental code just replaced the proper dispatcher code for the default mailbox.
This PR fixes that, without causing any additional allocations for the default dispatcher