### PR TITLE
Fix for Dockerfile smell DL3059

### DIFF
--- a/dockerfile-reader
+++ b/dockerfile-reader
@@ -6,8 +6,8 @@ COPY ./benchmarks ./benchmarks/
 RUN ls -la /sourcecode/*
 
 WORKDIR /sourcecode/benchmarks/ClusterBenchmark
-RUN dotnet restore
-RUN dotnet build -c Release -o /app
+RUN dotnet restore \
+    && dotnet build -c Release -o /app
 
 FROM base AS publish
 


### PR DESCRIPTION
## Description

Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3059](https://github.com/hadolint/hadolint/wiki/DL3059) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3059 occurs if there are multiple consecutive RUN instructions. Each RUN will correspond to a layer of the final Docker image, thus is recommended to compact them to reduce the number of layers for the final image.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, The consecutive RUN instructions have been chained until a comment or a different instruction appears.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
