### PR TITLE
Updated template in case we want to pass additional parameters

### DIFF
--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -208,8 +208,8 @@ namespace {{CsNamespace}}
         public static global::Proto.Cluster.ClusterKind GetClusterKind(Func<global::Proto.IContext, global::Proto.Cluster.ClusterIdentity, {{Name}}Base> innerFactory)
             => new global::Proto.Cluster.ClusterKind(Kind, global::Proto.Props.FromProducer(() => new {{Name}}Actor(innerFactory)));
 
-        public static global::Proto.Cluster.ClusterKind GetClusterKind<T>(global::System.IServiceProvider serviceProvider) where T : {{Name}}Base
-            => new global::Proto.Cluster.ClusterKind(Kind, global::Proto.Props.FromProducer(() => new {{Name}}Actor((ctx, id) => global::Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance<T>(serviceProvider, ctx, id))));
+        public static global::Proto.Cluster.ClusterKind GetClusterKind<T>(global::System.IServiceProvider serviceProvider, params object[] parameters) where T : {{Name}}Base
+            => new global::Proto.Cluster.ClusterKind(Kind, global::Proto.Props.FromProducer(() => new {{Name}}Actor((ctx, id) => global::Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance<T>(serviceProvider, ctx, id, parameters))));
     }
     {{/each}}
 }

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
@@ -364,7 +364,7 @@ namespace Acme.OtherSystem.Foo
         public static global::Proto.Cluster.ClusterKind GetClusterKind(Func<global::Proto.IContext, global::Proto.Cluster.ClusterIdentity, TestGrainBase> innerFactory)
             => new global::Proto.Cluster.ClusterKind(Kind, global::Proto.Props.FromProducer(() => new TestGrainActor(innerFactory)));
 
-        public static global::Proto.Cluster.ClusterKind GetClusterKind<T>(global::System.IServiceProvider serviceProvider) where T : TestGrainBase
-            => new global::Proto.Cluster.ClusterKind(Kind, global::Proto.Props.FromProducer(() => new TestGrainActor((ctx, id) => global::Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance<T>(serviceProvider, ctx, id))));
+        public static global::Proto.Cluster.ClusterKind GetClusterKind<T>(global::System.IServiceProvider serviceProvider, params object[] parameters) where T : TestGrainBase
+            => new global::Proto.Cluster.ClusterKind(Kind, global::Proto.Props.FromProducer(() => new TestGrainActor((ctx, id) => global::Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance<T>(serviceProvider, ctx, id, parameters))));
     }
 }

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutputPackageless.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutputPackageless.cs
@@ -364,7 +364,7 @@ namespace Acme.OtherSystem.Foo
         public static global::Proto.Cluster.ClusterKind GetClusterKind(Func<global::Proto.IContext, global::Proto.Cluster.ClusterIdentity, TestGrainBase> innerFactory)
             => new global::Proto.Cluster.ClusterKind(Kind, global::Proto.Props.FromProducer(() => new TestGrainActor(innerFactory)));
 
-        public static global::Proto.Cluster.ClusterKind GetClusterKind<T>(global::System.IServiceProvider serviceProvider) where T : TestGrainBase
-            => new global::Proto.Cluster.ClusterKind(Kind, global::Proto.Props.FromProducer(() => new TestGrainActor((ctx, id) => global::Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance<T>(serviceProvider, ctx, id))));
+        public static global::Proto.Cluster.ClusterKind GetClusterKind<T>(global::System.IServiceProvider serviceProvider, params object[] parameters) where T : TestGrainBase
+            => new global::Proto.Cluster.ClusterKind(Kind, global::Proto.Props.FromProducer(() => new TestGrainActor((ctx, id) => global::Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance<T>(serviceProvider, ctx, id, parameters))));
     }
 }


### PR DESCRIPTION
## Description

The existing overload for `GetClusterKind` injects `IContext` and `ClusterIdentity` but doesn't allow us to inject our own parameters. In case we have additional parameters which are not registered in the DI framework, we would need that additional parameter I added.