### PR TITLE
Allow ISenderContext.Request to propagate headers

### DIFF
--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -192,7 +192,7 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
 
     public void Request(PID target, object message, PID? sender)
     {
-        var messageEnvelope = new MessageEnvelope(message, sender);
+        var messageEnvelope = MessageEnvelope.WithSender(message, sender);
         SendUserMessage(target, messageEnvelope);
     }
 

--- a/src/Proto.Actor/Context/RootContext.cs
+++ b/src/Proto.Actor/Context/RootContext.cs
@@ -102,7 +102,7 @@ public sealed record RootContext : IRootContext
 
     public void Request(PID target, object message, PID? sender)
     {
-        var envelope = new MessageEnvelope(message, sender);
+        var envelope = MessageEnvelope.WithSender(message, sender);
         Send(target, envelope);
     }
 

--- a/src/Proto.Actor/Messages/MessageEnvelope.cs
+++ b/src/Proto.Actor/Messages/MessageEnvelope.cs
@@ -72,6 +72,16 @@ public record MessageEnvelope : IDiagnosticsTypeName
     public MessageEnvelope WithSender(PID sender) => this with { Sender = sender };
 
     /// <summary>
+    ///     Adds a sender <see cref="PID" /> if the message is an envelope, otherwise creates a new envelope with the given sender.
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="sender"></param>
+    /// <returns>New envelope</returns>
+    public static MessageEnvelope WithSender(object message, PID sender) => message is MessageEnvelope env
+        ? env.WithSender(sender)
+        : new MessageEnvelope(message, sender);
+
+    /// <summary>
     ///     Adds the wrapped message to the message envelope.
     /// </summary>
     /// <param name="message"></param>


### PR DESCRIPTION
## Description

Previously `ISenderContext.Request` would wrap the passed in MessageEnvelope in a new message envelope even if it already was one. This will send an updated MessageEnvelope which retains the existing headers.

## Purpose
This pull request is a:

- [X] Bugfix (breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Breaking change
If people have worked around the behaviour and un-nested envelopes in the actor, this will change nested `MessageEnvelope`s to ble flattened to a single instance. 

## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
