### PR TITLE
Fix for empty grain response  deseriaslized to null

### DIFF
--- a/src/Proto.Cluster/Grain/GrainResponse.cs
+++ b/src/Proto.Cluster/Grain/GrainResponse.cs
@@ -14,9 +14,11 @@ namespace Proto.Cluster;
 /// </summary>
 public partial class GrainResponse : IRootSerialized
 {
+    //deserialize into the in-process message type that the grain actors understands
     public IRootSerializable Deserialize(ActorSystem system)
     {
-        if (MessageData.IsEmpty)
+        //special case for null messages
+        if (MessageData.IsEmpty && string.IsNullOrEmpty(MessageTypeName))
         {
             return new GrainResponseMessage(null);
         }


### PR DESCRIPTION
## Description
Bug: when a grain responses with empty class or class containing all default data, it will be deserialized  to 'null' on the receiving end.
After fix - it will be deserialized to empty class
<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
