### PR TITLE
Marten ProviderUpdate and Persistence provider test 

### DIFF
--- a/src/Proto.Persistence.Marten/Event.cs
+++ b/src/Proto.Persistence.Marten/Event.cs
@@ -1,6 +1,6 @@
 ﻿namespace Proto.Persistence.Marten;
 
-internal class Event
+public class Event
 {
     public Event(string actorName, long index, object data)
     {

--- a/src/Proto.Persistence.Marten/MartenProvider.cs
+++ b/src/Proto.Persistence.Marten/MartenProvider.cs
@@ -16,7 +16,7 @@ public class MartenProvider : IProvider
 
     public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
     {
-        var session = _store.OpenSession();
+        var session = _store.IdentitySession();
         await using var _ = session.ConfigureAwait(false);
 
         var events = await session.Query<Event>()
@@ -35,7 +35,7 @@ public class MartenProvider : IProvider
 
     public async Task<(object Snapshot, long Index)> GetSnapshotAsync(string actorName)
     {
-        var session = _store.OpenSession();
+        var session = _store.IdentitySession();
         await using var _ = session.ConfigureAwait(false);
 
         var snapshot = await session.Query<Snapshot>()
@@ -48,7 +48,7 @@ public class MartenProvider : IProvider
 
     public async Task<long> PersistEventAsync(string actorName, long index, object @event)
     {
-        using var session = _store.OpenSession();
+        var session = _store.IdentitySession();
 
         session.Store(new Event(actorName, index, @event));
 
@@ -59,7 +59,7 @@ public class MartenProvider : IProvider
 
     public async Task PersistSnapshotAsync(string actorName, long index, object snapshot)
     {
-        using var session = _store.OpenSession();
+        var session = _store.IdentitySession();
 
         session.Store(new Snapshot(actorName, index, snapshot));
 
@@ -68,7 +68,7 @@ public class MartenProvider : IProvider
 
     public async Task DeleteEventsAsync(string actorName, long inclusiveToIndex)
     {
-        using var session = _store.OpenSession();
+        var session = _store.IdentitySession();
 
         session.DeleteWhere<Event>(x =>
             x.ActorName == actorName &&
@@ -80,7 +80,7 @@ public class MartenProvider : IProvider
 
     public async Task DeleteSnapshotsAsync(string actorName, long inclusiveToIndex)
     {
-        using var session = _store.OpenSession();
+        var session = _store.IdentitySession();
 
         session.DeleteWhere<Snapshot>(x =>
             x.ActorName == actorName &&

--- a/src/Proto.Persistence.Marten/Proto.Persistence.Marten.csproj
+++ b/src/Proto.Persistence.Marten/Proto.Persistence.Marten.csproj
@@ -3,7 +3,7 @@
         <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Marten" Version="4.3.1" />
+        <PackageReference Include="Marten" Version="6.0.2" />
 
     </ItemGroup>
     <ItemGroup>

--- a/src/Proto.Persistence.Marten/Snapshot.cs
+++ b/src/Proto.Persistence.Marten/Snapshot.cs
@@ -1,6 +1,6 @@
 ﻿namespace Proto.Persistence.Marten;
 
-internal class Snapshot
+public class Snapshot
 {
     public Snapshot(string actorName, long index, object data)
     {

--- a/tests/Proto.Persistence.Tests/PersistenceWithSnapshotStrategiesTests.cs
+++ b/tests/Proto.Persistence.Tests/PersistenceWithSnapshotStrategiesTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Threading.Tasks;
+using Marten;
+using Proto.Persistence.Marten;
 using Proto.Persistence.SnapshotStrategies;
 using Xunit;
 

--- a/tests/Proto.Persistence.Tests/Proto.Persistence.Tests.csproj
+++ b/tests/Proto.Persistence.Tests/Proto.Persistence.Tests.csproj
@@ -5,12 +5,22 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Testcontainers" Version="3.2.0" />
-        <PackageReference Include="Testcontainers.PostgreSql" Version="3.2.0" />
+        <PackageReference Include="Testcontainers" Version="3.3.0" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="3.3.0" />
+        <PackageReference Include="Testcontainers.CouchDb" Version="3.3.0" />
+        <PackageReference Include="Testcontainers.MsSql" Version="3.3.0" />
+        <PackageReference Include="Testcontainers.DynamoDb" Version="3.3.0" />
+        <PackageReference Include="Testcontainers.RavenDb" Version="3.3.0" />
+        <PackageReference Include="Testcontainers.MongoDb" Version="3.3.0" />
     </ItemGroup>
     <ItemGroup>
+        <ProjectReference Include="..\..\src\Proto.Persistence.Couchbase\Proto.Persistence.Couchbase.csproj" />
+        <ProjectReference Include="..\..\src\Proto.Persistence.DynamoDB\Proto.Persistence.DynamoDB.csproj" />
         <ProjectReference Include="..\..\src\Proto.Persistence.Marten\Proto.Persistence.Marten.csproj" />
+        <ProjectReference Include="..\..\src\Proto.Persistence.MongoDB\Proto.Persistence.MongoDB.csproj" />
+        <ProjectReference Include="..\..\src\Proto.Persistence.RavenDB\Proto.Persistence.RavenDB.csproj" />
         <ProjectReference Include="..\..\src\Proto.Persistence.Sqlite\Proto.Persistence.Sqlite.csproj" />
+        <ProjectReference Include="..\..\src\Proto.Persistence.SqlServer\Proto.Persistence.SqlServer.csproj" />
         <ProjectReference Include="..\..\src\Proto.Persistence\Proto.Persistence.csproj" />
         <ProjectReference Include="..\Proto.TestFixtures\Proto.TestFixtures.csproj" />
     </ItemGroup>

--- a/tests/Proto.Persistence.Tests/Proto.Persistence.Tests.csproj
+++ b/tests/Proto.Persistence.Tests/Proto.Persistence.Tests.csproj
@@ -4,9 +4,13 @@
         <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Testcontainers" Version="3.2.0" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="3.2.0" />
     </ItemGroup>
     <ItemGroup>
+        <ProjectReference Include="..\..\src\Proto.Persistence.Marten\Proto.Persistence.Marten.csproj" />
+        <ProjectReference Include="..\..\src\Proto.Persistence.Sqlite\Proto.Persistence.Sqlite.csproj" />
         <ProjectReference Include="..\..\src\Proto.Persistence\Proto.Persistence.csproj" />
         <ProjectReference Include="..\Proto.TestFixtures\Proto.TestFixtures.csproj" />
     </ItemGroup>


### PR DESCRIPTION
## Description

Updated the Marten package version from 4.3.1 to 6.0.2 in the project file.
- Changed the access modifier of the `Event` and `Snapshot` classes from internal to public in the `Proto.Persistence.Marten` namespace.  With the internal  modifier  all marten test will fail with the following messagge:
`'Snapshot' is not accessible due to the security level `
- Replaced calls to `_store.OpenSession()` with `_store.IdentitySession()` in the `MartenProvider` class for consistency. `OpenSession()` is now deprecated.
- Added new test cases for different providers (InMemory MongoDB,RavenDB,SQL Server,SqLite) in the `ExamplePersistentActorTests` class:
    - EventsAreSavedToPersistence
    - SnapshotsAreSavedToPersistence
    - EventsCanBeDeleted
    - SnapshotsCanBeDeleted
    - GivenEventsOnly_StateIsRestoredFromEvents
    - GivenASnapshotOnly_StateIsRestoredFromTheSnapshot
    - GivenEventsThenASnapshot_StateShouldBeRestoredFromTheSnapshot
    - GivenASnapshotAndSubsequentEvents_StateShouldBeRestoredFromSnapshotAndSubsequentEvents
    - GivenMultipleSnapshots_StateIsRestoredFromMostRecentSnapshot


## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
