### PR TITLE
Hardened cluster-request deduplication

### DIFF
--- a/src/Proto.Actor/Deduplication/DeduplicationContext.cs
+++ b/src/Proto.Actor/Deduplication/DeduplicationContext.cs
@@ -72,6 +72,8 @@ internal class DeDuplicator<T> where T : IEquatable<T>
             if (IsDuplicate(key!, cutoff))
             {
                 _logger.LogInformation("Request de-duplicated");
+                // Update timestamp to keep a sliding window of TTL
+                _processed[key!]= now;
 
                 return;
             }

--- a/src/Proto.Cluster/ClusterConfig.cs
+++ b/src/Proto.Cluster/ClusterConfig.cs
@@ -43,7 +43,7 @@ public record ClusterConfig
         GossipFanout = 3;
         GossipMaxSend = 50;
         HeartbeatExpiration = TimeSpan.Zero;
-        ClusterRequestDeDuplicationWindow = TimeSpan.FromSeconds(30);
+        ClusterRequestDeDuplicationWindow = TimeSpan.FromMinutes(1);
         IdentityLookup = identityLookup;
         MemberStrategyBuilder = (_, _) => new SimpleMemberStrategy();
         RemotePidCacheTimeToLive = TimeSpan.FromMinutes(15);


### PR DESCRIPTION
## Description

To reduce issues from long or reentrant requests, this PR ensures that retries for a message that has already been handled will not be reprocessed. The previous behavior tagged when the first message was handled, but did not update on subsequent attempts. Default deduplication window has also been bumped from 30s to 1 minute.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
