### PR TITLE
Ecs provider fix

### DIFF
--- a/src/Proto.Cluster.AmazonECS/AmazonEcsProvider.cs
+++ b/src/Proto.Cluster.AmazonECS/AmazonEcsProvider.cs
@@ -140,7 +140,7 @@ public class AmazonEcsProvider : IClusterProvider
                         Logger.LogError(x, "Failed to get members from ECS");
                     }
 
-                    await Task.Delay(_config.PollIntervalSeconds).ConfigureAwait(false);
+                    await Task.Delay(TimeSpan.FromSeconds(_config.PollIntervalSeconds)).ConfigureAwait(false);
                 }
             }
         );

--- a/src/Proto.Cluster.AmazonECS/EcsUtils.cs
+++ b/src/Proto.Cluster.AmazonECS/EcsUtils.cs
@@ -37,6 +37,7 @@ public static class EcsUtils
         var describedTasks = await c.DescribeTasksAsync(new DescribeTasksRequest
             {
                 Include = { "TAGS" },
+                Cluster = ecsClusterName,
                 Tasks = instanceArns
             }
         ).ConfigureAwait(false);


### PR DESCRIPTION
## Description

<!-- If your pull request solves an issue, please reference it here -->
Fixes #2055
- The ECS 'describe tasks' SDK call now specifies the cluster explicitly.
- ECS monitoring poll interval is now correctly converted into seconds.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
