### PR TITLE
remove value task

### DIFF
--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -397,7 +397,7 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
                 Unwatch uw                      => HandleUnwatch(uw),
                 Failure f                       => HandleFailureAsync(f),
                 Restart                         => HandleRestartAsync(),
-                SuspendMailbox or ResumeMailbox => default,
+                SuspendMailbox or ResumeMailbox => Task.CompletedTask,
                 Continuation cont               => HandleContinuation(cont),
                 ProcessDiagnosticsRequest pdr   => HandleProcessDiagnosticsRequest(pdr),
                 ReceiveTimeout _                => HandleReceiveTimeout(),

--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -504,7 +504,7 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
 
         processDiagnosticsRequest.Result.SetResult(diagnosticsString);
 
-        return default;
+        return Task.CompletedTask;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -555,7 +555,7 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
                 _extras?.ResetReceiveTimeoutTimer(ReceiveTimeout);
             }
 
-            return default;
+            return Task.CompletedTask;
         }
 
         return Await(this, t, influenceReceiveTimeout);
@@ -725,7 +725,7 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
     {
         _extras?.Unwatch(uw.Watcher);
 
-        return default;
+        return Task.CompletedTask;
     }
 
     private Task HandleWatch(Watch w)
@@ -739,7 +739,7 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
             EnsureExtras().Watch(w.Watcher);
         }
 
-        return default;
+        return Task.CompletedTask;
     }
 
     private Task HandleFailureAsync(Failure msg)
@@ -790,7 +790,7 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
         if (_state >= ContextState.Stopping)
         {
             //already stopping or stopped
-            return default;
+            return Task.CompletedTask;
         }
 
         _state = ContextState.Stopping;
@@ -814,7 +814,7 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
         }
     }
 
-    private ValueTask StopAllChildren()
+    private Task StopAllChildren()
     {
         if (_extras != null)
         {
@@ -829,11 +829,11 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
 
     //intermediate stopping stage, waiting for children to stop
     //this is directly triggered by StopAllChildren, or by Terminated messages from stopping children
-    private ValueTask TryRestartOrStopAsync()
+    private Task TryRestartOrStopAsync()
     {
         if (_extras?.Children.Count > 0)
         {
-            return default;
+            return Task.CompletedTask;
         }
 
         CancelReceiveTimeout();
@@ -843,12 +843,12 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
         {
             ContextState.Restarting => RestartAsync(),
             ContextState.Stopping   => FinalizeStopAsync(),
-            _                       => default
+            _                       => Task.CompletedTask
         };
     }
 
     //Last and final termination step
-    private async ValueTask FinalizeStopAsync()
+    private async Task FinalizeStopAsync()
     {
         System.ProcessRegistry.Remove(Self);
         //This is intentional
@@ -867,7 +867,7 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
         _state = ContextState.Stopped;
     }
 
-    private async ValueTask RestartAsync()
+    private async Task RestartAsync()
     {
         await DisposeActorIfDisposable().ConfigureAwait(false);
         Actor = IncarnateActor();

--- a/src/Proto.Actor/Mailbox/Dispatcher.cs
+++ b/src/Proto.Actor/Mailbox/Dispatcher.cs
@@ -14,9 +14,9 @@ public interface IMessageInvoker
 {
     CancellationTokenSource? CancellationTokenSource { get; }
 
-    ValueTask InvokeSystemMessageAsync(SystemMessage msg);
+    Task InvokeSystemMessageAsync(SystemMessage msg);
 
-    ValueTask InvokeUserMessageAsync(object msg);
+    Task InvokeUserMessageAsync(object msg);
 
     void EscalateFailure(Exception reason, object? message);
 }
@@ -123,9 +123,9 @@ internal class NoopInvoker : IMessageInvoker
 
     public CancellationTokenSource CancellationTokenSource => throw new NotImplementedException();
 
-    public ValueTask InvokeSystemMessageAsync(SystemMessage msg) => throw new NotImplementedException();
+    public Task InvokeSystemMessageAsync(SystemMessage msg) => throw new NotImplementedException();
 
-    public ValueTask InvokeUserMessageAsync(object msg) => throw new NotImplementedException();
+    public Task InvokeUserMessageAsync(object msg) => throw new NotImplementedException();
 
     public void EscalateFailure(Exception reason, object? message) => throw new NotImplementedException();
 }

--- a/tests/Proto.TestFixtures/TestMailboxHandler.cs
+++ b/tests/Proto.TestFixtures/TestMailboxHandler.cs
@@ -32,10 +32,10 @@ public class TestMailboxHandler : IMessageInvoker, IDispatcher
     }
 
     // ReSharper disable once SuspiciousTypeConversion.Global
-    public async ValueTask InvokeSystemMessageAsync(SystemMessage msg) =>
+    public async Task InvokeSystemMessageAsync(SystemMessage msg) =>
         await ((TestMessageWithTaskCompletionSource)msg).TaskCompletionSource.Task;
 
-    public async ValueTask InvokeUserMessageAsync(object msg) =>
+    public async Task InvokeUserMessageAsync(object msg) =>
         await ((TestMessageWithTaskCompletionSource)msg).TaskCompletionSource.Task;
 
     public void EscalateFailure(Exception reason, object message)


### PR DESCRIPTION
Needless magic, ReceiveAsync is Task and the task is already allocated at that point.
It doesn't get less allocated because we switch to valuetask internally