### PR TITLE
Fixed cluster client mode bug

### DIFF
--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -200,7 +200,7 @@ public class Cluster : IActorSystemExtension<Cluster>
         await Remote.StartAsync().ConfigureAwait(false);
 
         Logger.LogInformation("Starting");
-        MemberList = new MemberList(this);
+        MemberList = new MemberList(this, client);
         _ = MemberList.Started.ContinueWith(_ => _joinedClusterTcs.TrySetResult(true));
         ClusterContext = Config.ClusterContextProducer(this);
 

--- a/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
@@ -209,7 +209,7 @@ public class PartitionIdentityTests
                                 {
                                     _output.WriteLine($"[{DateTimeOffset.Now:O}] Starting cluster member");
 
-                                    _ = clusterFixture.SpawnNode()
+                                    _ = clusterFixture.SpawnMember()
                                         .ContinueWith(
                                             t =>
                                             {

--- a/tests/Proto.Cluster.Tests/ClusterTests.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTests.cs
@@ -63,6 +63,7 @@ public abstract class ClusterTests : ClusterTestBase
 
             try
             {
+                await clientNode.JoinedCluster.WaitAsync(timeout);
                 clientNode.JoinedCluster.IsCompletedSuccessfully.Should().BeTrue();
                 
                 var timer = Stopwatch.StartNew();

--- a/tests/Proto.Cluster.Tests/GossipTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTests.cs
@@ -82,7 +82,7 @@ public class GossipTests
 
         afterSettingMatchingState.value.Should().Be(initialTopologyHash);
 
-        await clusterFixture.SpawnNode();
+        await clusterFixture.SpawnMember();
         await Task.Delay(2000); // Allow topology state to propagate
 
         var afterChangingTopology =

--- a/tests/Proto.Cluster.Tests/RetryOnDeadLetterTests.cs
+++ b/tests/Proto.Cluster.Tests/RetryOnDeadLetterTests.cs
@@ -24,7 +24,7 @@ public class RetryOnDeadLetterTests
         await member.RequestAsync<Pong>(identity, EchoActor.Kind, new Ping(), CancellationTokens.FromSeconds(1));
 
         // pretend we have an invalid PID in the cache
-        var otherMember = await fixture.SpawnNode();
+        var otherMember = await fixture.SpawnMember();
         if (member.PidCache.TryGet(ClusterIdentity.Create(identity, EchoActor.Kind), out var pid))
         {
             var newPid = PID.FromAddress(otherMember.System.Address, pid.Id);


### PR DESCRIPTION
## Description

Fixed issue with client cluster logic where it would not see itself as started unless listed by the cluster provider. Changed member list to accept any cluster topology updates when in client mode and set started.

Added tests for client mode requests.

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
