### PR TITLE
introduce actor to publish events in eventstream

### DIFF
--- a/src/Proto.Actor/ActorSystem.cs
+++ b/src/Proto.Actor/ActorSystem.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Proto.Diagnostics;
 using Proto.Extensions;
 using Proto.Future;
+using Proto.Mailbox;
 using Proto.Metrics;
 using Proto.Utils;
 
@@ -49,8 +50,9 @@ public sealed class ActorSystem : IAsyncDisposable
         DeadLetter = dl.Configure();
         ProcessRegistry.TryAdd("$deadletter", DeadLetter);
         Guardians = new Guardians(this);
-        EventStream = new EventStream(this);
         Metrics = new ProtoMetrics(config.MetricsEnabled);
+        EventStream = new EventStream(this);
+        ActorDispatcher = new ActorDispatcher(this);
         var eventStream = new EventStreamProcess(this).Configure();
         ProcessRegistry.TryAdd("$eventstream", eventStream);
         Extensions = new ActorSystemExtensions(this);
@@ -88,6 +90,11 @@ public sealed class ActorSystem : IAsyncDisposable
     ///     Manages all processes in the actor system (actors, futures, event stream, etc.).
     /// </summary>
     public ProcessRegistry ProcessRegistry { get; }
+    
+    /// <summary>
+    ///    Dispatcher used to schedule messages via an actor.
+    /// </summary>
+    public IDispatcher ActorDispatcher { get; }
 
     /// <summary>
     ///     Root context of the actor system. Use it to spawn actors or send messages from outside of an actor context.

--- a/src/Proto.Actor/ActorSystem.cs
+++ b/src/Proto.Actor/ActorSystem.cs
@@ -52,7 +52,6 @@ public sealed class ActorSystem : IAsyncDisposable
         Guardians = new Guardians(this);
         Metrics = new ProtoMetrics(config.MetricsEnabled);
         EventStream = new EventStream(this);
-        ActorDispatcher = new ActorDispatcher(this);
         var eventStream = new EventStreamProcess(this).Configure();
         ProcessRegistry.TryAdd("$eventstream", eventStream);
         Extensions = new ActorSystemExtensions(this);
@@ -90,11 +89,6 @@ public sealed class ActorSystem : IAsyncDisposable
     ///     Manages all processes in the actor system (actors, futures, event stream, etc.).
     /// </summary>
     public ProcessRegistry ProcessRegistry { get; }
-    
-    /// <summary>
-    ///    Dispatcher used to schedule messages via an actor.
-    /// </summary>
-    public IDispatcher ActorDispatcher { get; }
 
     /// <summary>
     ///     Root context of the actor system. Use it to spawn actors or send messages from outside of an actor context.

--- a/src/Proto.Actor/EventStream/DeadLetter.cs
+++ b/src/Proto.Actor/EventStream/DeadLetter.cs
@@ -16,8 +16,8 @@ namespace Proto;
 
 /// <summary>
 ///     A wrapper for a message that could not be delivered to the original recipient. Such message is wrapped in
-///     a <see cref="DeadLetterEvent{T}" /> by the <see cref="DeadLetterProcess" /> and forwarded
-///     to the <see cref="EventStream{T}" />
+///     a <see cref="DeadLetterEvent" /> by the <see cref="DeadLetterProcess" /> and forwarded
+///     to the <see cref="EventStream" />
 /// </summary>
 [PublicAPI]
 public class DeadLetterEvent

--- a/src/Proto.Actor/EventStream/EventStream.cs
+++ b/src/Proto.Actor/EventStream/EventStream.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -72,6 +73,11 @@ public class EventStream : EventStream<object>
 
     public override void Publish(object msg)
     {
+        if (_pid == null)
+        {
+            SpinWait.SpinUntil(() => _pid != null);
+        }
+
         foreach (var sub in Subscriptions.Values)
         {
             var action = () =>

--- a/tests/Proto.Actor.Tests/EventStreamTests.cs
+++ b/tests/Proto.Actor.Tests/EventStreamTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Proto.Mailbox;
 using Xunit;
@@ -17,6 +18,9 @@ public class EventStreamTests
 
         eventStream.Subscribe<string>(theString => received = theString);
         eventStream.Publish("hello");
+        
+        await Task.Delay(1000);
+        
         Assert.Equal("hello", received);
     }
 
@@ -32,6 +36,9 @@ public class EventStreamTests
         eventStream.Publish("hello");
         eventStream.Publish(1);
         eventStream.Publish(true);
+
+        await Task.Delay(1000);
+        
         Assert.Equal(3, receivedEvents.Count);
     }
 
@@ -46,6 +53,9 @@ public class EventStreamTests
         eventStream.Publish("first message");
         subscription.Unsubscribe();
         eventStream.Publish("second message");
+        
+        await Task.Delay(1000);
+        
         Assert.Single(receivedEvents);
     }
 
@@ -59,6 +69,9 @@ public class EventStreamTests
         var eventsReceived = new List<object>();
         eventStream.Subscribe<int>(@event => eventsReceived.Add(@event));
         eventStream.Publish("not an int");
+        
+        await Task.Delay(1000);
+        
         Assert.Empty(eventsReceived);
     }
 
@@ -79,5 +92,6 @@ public class EventStreamTests
         );
 
         eventStream.Publish("hello");
+        await Task.Delay(1000);
     }
 }


### PR DESCRIPTION
This introduces a new system actor to publish events to the event-stream.
Before, all events have been published synchronously by default. 

It just seems reasonable that publishing is always doing async, but still "in order".

I´m thinking the support for dispatchers in the eventstream should probably be removed, as they are intended for actors only and sort of creeped into the eventstream to fix this specific issue, in the wrong way.
