### PR TITLE
Make it possible to disable verification of Revision Has Traffic Enabled…

### DIFF
--- a/src/Proto.Cluster.AzureContainerApps/Options/AzureContainerAppsProviderOptions.cs
+++ b/src/Proto.Cluster.AzureContainerApps/Options/AzureContainerAppsProviderOptions.cs
@@ -32,4 +32,9 @@ public class AzureContainerAppsProviderOptions
     /// The actual TTL is determined by the <see cref="PollInterval"/> and the <see cref="MemberTimeToLive"/> by adding them together.
     /// </summary>
     public TimeSpan MemberTimeToLive { get; set; } = TimeSpan.FromMinutes(1);
+    /// <summary>
+    /// If set to true, the provider will verify that the revision that this replica is part of has 1 or more percent of the traffic.
+    /// If not it won't be added to the cluster, and if already added it will be removed.
+    /// </summary>
+    public bool IsVerifyRevisionHasTrafficEnabled { get; set; } = true;
 }


### PR DESCRIPTION
## Description

This pull request adds an option to disable the "has traffic weight" against Azure Container Apps for the Azure Container Apps provider.
When using Single Mode these checks are unnecessary.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
