### PR TITLE
Priority remote

### DIFF
--- a/src/Proto.Cluster/Gossip/Messages.cs
+++ b/src/Proto.Cluster/Gossip/Messages.cs
@@ -1,0 +1,14 @@
+using Proto.Remote;
+
+namespace Proto.Cluster.Gossip;
+
+public partial class GossipRequest : IRemotePriorityMessage
+{
+    
+}
+
+public partial class GossipResponse : IRemotePriorityMessage
+{
+    
+}
+

--- a/src/Proto.Cluster/Messages/Messages.cs
+++ b/src/Proto.Cluster/Messages/Messages.cs
@@ -139,3 +139,8 @@ public partial class Member
         return hash;
     }
 }
+
+public partial class MemberHeartbeat : IRemotePriorityMessage
+{
+    
+}

--- a/src/Proto.Remote/IRemotePriorityMessage.cs
+++ b/src/Proto.Remote/IRemotePriorityMessage.cs
@@ -1,0 +1,6 @@
+namespace Proto.Remote;
+
+public interface IRemotePriorityMessage
+{
+    
+}


### PR DESCRIPTION
Introduces priority messages for Proto.Remote

Messages can be marked as `IRemotePriorityMessage` to give it higher priority on the remote writer pipeline