### PR TITLE
Add support for an Advertised Host other than PodIP when using Kubernetes cluster provider

### DIFF
--- a/ProtoActor.sln
+++ b/ProtoActor.sln
@@ -278,6 +278,34 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Proto.Cluster.SeedNode.Mong
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GossipDecoder", "benchmarks\GossipDecoder\GossipDecoder.csproj", "{FC144547-78F5-4C0B-B886-B7BC1563893B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ClusterK8sGrains", "ClusterK8sGrains", "{ADE7A14E-FFE9-4137-AC25-E2F2A82B0A8C}"
+	ProjectSection(SolutionItems) = preProject
+		examples\ClusterK8sGrains\readme.md = examples\ClusterK8sGrains\readme.md
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Messages", "examples\ClusterK8sGrains\Messages\Messages.csproj", "{44B8EBA7-5A47-4D20-B62F-48413B676473}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Node1", "examples\ClusterK8sGrains\Node1\Node1.csproj", "{80DC28A1-D361-4A25-AC5D-8F5B6DCE276A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Node2", "examples\ClusterK8sGrains\Node2\Node2.csproj", "{B196FBFE-0DAA-4533-9A56-BB5826A57923}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "chart", "chart", "{CDCE3D4C-1BDD-460F-93B8-75123A258183}"
+	ProjectSection(SolutionItems) = preProject
+		examples\ClusterK8sGrains\chart\Chart.yaml = examples\ClusterK8sGrains\chart\Chart.yaml
+		examples\ClusterK8sGrains\chart\values.yaml = examples\ClusterK8sGrains\chart\values.yaml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "template", "template", "{087E5441-1582-4D55-8233-014C0FB06FF0}"
+	ProjectSection(SolutionItems) = preProject
+		examples\ClusterK8sGrains\chart\templates\namespace.yaml = examples\ClusterK8sGrains\chart\templates\namespace.yaml
+		examples\ClusterK8sGrains\chart\templates\node1-deployment.yaml = examples\ClusterK8sGrains\chart\templates\node1-deployment.yaml
+		examples\ClusterK8sGrains\chart\templates\node2-deployment.yaml = examples\ClusterK8sGrains\chart\templates\node2-deployment.yaml
+		examples\ClusterK8sGrains\chart\templates\protoactor-k8s-cluster-port-service.yaml = examples\ClusterK8sGrains\chart\templates\protoactor-k8s-cluster-port-service.yaml
+		examples\ClusterK8sGrains\chart\templates\protoactor-k8s-grains-role.yaml = examples\ClusterK8sGrains\chart\templates\protoactor-k8s-grains-role.yaml
+		examples\ClusterK8sGrains\chart\templates\protoactor-k8s-grains-rolebinding.yaml = examples\ClusterK8sGrains\chart\templates\protoactor-k8s-grains-rolebinding.yaml
+		examples\ClusterK8sGrains\chart\templates\protoactor-k8s-grains-serviceaccount.yaml = examples\ClusterK8sGrains\chart\templates\protoactor-k8s-grains-serviceaccount.yaml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1416,6 +1444,42 @@ Global
 		{FC144547-78F5-4C0B-B886-B7BC1563893B}.Release|x64.Build.0 = Release|Any CPU
 		{FC144547-78F5-4C0B-B886-B7BC1563893B}.Release|x86.ActiveCfg = Release|Any CPU
 		{FC144547-78F5-4C0B-B886-B7BC1563893B}.Release|x86.Build.0 = Release|Any CPU
+		{44B8EBA7-5A47-4D20-B62F-48413B676473}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44B8EBA7-5A47-4D20-B62F-48413B676473}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44B8EBA7-5A47-4D20-B62F-48413B676473}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{44B8EBA7-5A47-4D20-B62F-48413B676473}.Debug|x64.Build.0 = Debug|Any CPU
+		{44B8EBA7-5A47-4D20-B62F-48413B676473}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{44B8EBA7-5A47-4D20-B62F-48413B676473}.Debug|x86.Build.0 = Debug|Any CPU
+		{44B8EBA7-5A47-4D20-B62F-48413B676473}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44B8EBA7-5A47-4D20-B62F-48413B676473}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44B8EBA7-5A47-4D20-B62F-48413B676473}.Release|x64.ActiveCfg = Release|Any CPU
+		{44B8EBA7-5A47-4D20-B62F-48413B676473}.Release|x64.Build.0 = Release|Any CPU
+		{44B8EBA7-5A47-4D20-B62F-48413B676473}.Release|x86.ActiveCfg = Release|Any CPU
+		{44B8EBA7-5A47-4D20-B62F-48413B676473}.Release|x86.Build.0 = Release|Any CPU
+		{80DC28A1-D361-4A25-AC5D-8F5B6DCE276A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80DC28A1-D361-4A25-AC5D-8F5B6DCE276A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80DC28A1-D361-4A25-AC5D-8F5B6DCE276A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{80DC28A1-D361-4A25-AC5D-8F5B6DCE276A}.Debug|x64.Build.0 = Debug|Any CPU
+		{80DC28A1-D361-4A25-AC5D-8F5B6DCE276A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{80DC28A1-D361-4A25-AC5D-8F5B6DCE276A}.Debug|x86.Build.0 = Debug|Any CPU
+		{80DC28A1-D361-4A25-AC5D-8F5B6DCE276A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80DC28A1-D361-4A25-AC5D-8F5B6DCE276A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80DC28A1-D361-4A25-AC5D-8F5B6DCE276A}.Release|x64.ActiveCfg = Release|Any CPU
+		{80DC28A1-D361-4A25-AC5D-8F5B6DCE276A}.Release|x64.Build.0 = Release|Any CPU
+		{80DC28A1-D361-4A25-AC5D-8F5B6DCE276A}.Release|x86.ActiveCfg = Release|Any CPU
+		{80DC28A1-D361-4A25-AC5D-8F5B6DCE276A}.Release|x86.Build.0 = Release|Any CPU
+		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Debug|x64.Build.0 = Debug|Any CPU
+		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Debug|x86.Build.0 = Debug|Any CPU
+		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Release|x64.ActiveCfg = Release|Any CPU
+		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Release|x64.Build.0 = Release|Any CPU
+		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Release|x86.ActiveCfg = Release|Any CPU
+		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1545,6 +1609,12 @@ Global
 		{5FECD1A8-A873-4927-81C3-E5C5A37D80C5} = {0F3AB331-C042-4371-A2F0-0AFDFA13DC9F}
 		{6611DA4A-6471-45CE-A288-45BC7BF00B52} = {3D12F5E5-9774-4D7E-8A5B-B1F64544925B}
 		{FC144547-78F5-4C0B-B886-B7BC1563893B} = {0F3AB331-C042-4371-A2F0-0AFDFA13DC9F}
+		{ADE7A14E-FFE9-4137-AC25-E2F2A82B0A8C} = {59DCCC96-DDAF-469F-9E8E-9BC733285082}
+		{44B8EBA7-5A47-4D20-B62F-48413B676473} = {ADE7A14E-FFE9-4137-AC25-E2F2A82B0A8C}
+		{80DC28A1-D361-4A25-AC5D-8F5B6DCE276A} = {ADE7A14E-FFE9-4137-AC25-E2F2A82B0A8C}
+		{B196FBFE-0DAA-4533-9A56-BB5826A57923} = {ADE7A14E-FFE9-4137-AC25-E2F2A82B0A8C}
+		{CDCE3D4C-1BDD-460F-93B8-75123A258183} = {ADE7A14E-FFE9-4137-AC25-E2F2A82B0A8C}
+		{087E5441-1582-4D55-8233-014C0FB06FF0} = {CDCE3D4C-1BDD-460F-93B8-75123A258183}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD0D1E44-8118-4682-8793-6B20ABFA824C}

--- a/examples/ClusterK8sGrains/Clusterk8sGrains.sln
+++ b/examples/ClusterK8sGrains/Clusterk8sGrains.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Messages", "Messages\Messages.csproj", "{A5E3B3E1-5517-4E08-9E50-50EF17215AB5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Node2", "Node2\Node2.csproj", "{95685292-A5C9-48DA-871A-EB00A78A39A5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Node1", "Node1\Node1.csproj", "{B8D93ECE-0203-41C2-B845-7BBDDBA222DE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A5E3B3E1-5517-4E08-9E50-50EF17215AB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5E3B3E1-5517-4E08-9E50-50EF17215AB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5E3B3E1-5517-4E08-9E50-50EF17215AB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5E3B3E1-5517-4E08-9E50-50EF17215AB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95685292-A5C9-48DA-871A-EB00A78A39A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95685292-A5C9-48DA-871A-EB00A78A39A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95685292-A5C9-48DA-871A-EB00A78A39A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95685292-A5C9-48DA-871A-EB00A78A39A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8D93ECE-0203-41C2-B845-7BBDDBA222DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8D93ECE-0203-41C2-B845-7BBDDBA222DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8D93ECE-0203-41C2-B845-7BBDDBA222DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8D93ECE-0203-41C2-B845-7BBDDBA222DE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/examples/ClusterK8sGrains/Messages/Messages.csproj
+++ b/examples/ClusterK8sGrains/Messages/Messages.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <LangVersion>11</LangVersion>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Google.Protobuf" Version="3.22.0" />
+        <PackageReference Include="Grpc.Tools" Version="2.51.0" PrivateAssets="All" />
+        <PackageReference Include="Proto.Cluster.CodeGen" Version="1.0.0-rc3.17" />
+    </ItemGroup>
+    <ItemGroup>
+        <Protobuf Include="Protos.proto" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProtoGrain Include="Protos.proto" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\Proto.Cluster\Proto.Cluster.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/examples/ClusterK8sGrains/Messages/Protos.proto
+++ b/examples/ClusterK8sGrains/Messages/Protos.proto
@@ -1,0 +1,12 @@
+﻿syntax = "proto3";
+package HelloHelloWorld;
+option csharp_namespace = "ClusterHelloWorld.Messages";
+
+message HelloRequest {}
+message HelloResponse {
+    string Message=1;
+}
+
+service HelloGrain {
+	rpc SayHello(HelloRequest) returns (HelloResponse) {}
+}

--- a/examples/ClusterK8sGrains/Node1/Dockerfile
+++ b/examples/ClusterK8sGrains/Node1/Dockerfile
@@ -1,0 +1,27 @@
+﻿FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+WORKDIR /app
+
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["examples/ClusterK8sGrains/Node1/Node1.csproj", "examples/ClusterK8sGrains/Node1/"]
+COPY ["examples/ClusterK8sGrains/Node2/Node2.csproj", "examples/ClusterK8sGrains/Node2/"]
+COPY ["src/Proto.Cluster.Kubernetes/Proto.Cluster.Kubernetes.csproj", "src/Proto.Cluster.Kubernetes/"]
+COPY ["src/Proto.Cluster/Proto.Cluster.csproj", "src/Proto.Cluster/"]
+COPY ["src/Proto.Remote/Proto.Remote.csproj", "src/Proto.Remote/"]
+COPY ["src/Proto.Actor/Proto.Actor.csproj", "src/Proto.Actor/"]
+COPY ["examples/ClusterK8sGrains/Messages/Messages.csproj", "examples/ClusterK8sGrains/Messages/"]
+RUN dotnet restore "examples/ClusterK8sGrains/Node1/Node1.csproj"
+RUN dotnet restore "examples/ClusterK8sGrains/Node2/Node2.csproj"
+COPY . .
+WORKDIR "/src/examples/ClusterK8sGrains/Node1"
+RUN dotnet build "Node1.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "Node1.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false --no-restore
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "Node1.dll"]

--- a/examples/ClusterK8sGrains/Node1/Node1.csproj
+++ b/examples/ClusterK8sGrains/Node1/Node1.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <ServerGarbageCollection>true</ServerGarbageCollection>
+        <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+        <LangVersion>10</LangVersion>
+        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <Company>proto.actor example</Company>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\Proto.Cluster.Kubernetes\Proto.Cluster.Kubernetes.csproj" />
+        <ProjectReference Include="..\..\..\src\Proto.Cluster\Proto.Cluster.csproj"/>
+        <ProjectReference Include="..\..\..\src\Proto.Remote\Proto.Remote.csproj"/>
+        <ProjectReference Include="..\Messages\Messages.csproj"/>
+    </ItemGroup>
+    <ItemGroup>
+      <Content Include="..\..\..\.dockerignore">
+        <Link>.dockerignore</Link>
+      </Content>
+    </ItemGroup>
+</Project>

--- a/examples/ClusterK8sGrains/Node1/Program.cs
+++ b/examples/ClusterK8sGrains/Node1/Program.cs
@@ -1,0 +1,96 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Program.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2022 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ClusterHelloWorld.Messages;
+using Microsoft.Extensions.Logging;
+using Proto;
+using Proto.Cluster;
+using Proto.Cluster.Kubernetes;
+using Proto.Cluster.PartitionActivator;
+using Proto.Remote;
+using Proto.Remote.GrpcNet;
+using static Proto.CancellationTokens;
+using ProtosReflection = ClusterHelloWorld.Messages.ProtosReflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.Configuration;
+using Extensions = Proto.Remote.GrpcNet.Extensions;
+
+// Hook SIGTERM to a cancel token to know when k8s is shutting us down
+// hostBuilder should be used in production
+var cts = new CancellationTokenSource();
+AssemblyLoadContext.Default.Unloading += ctx => cts.Cancel();
+
+var config = new ConfigurationBuilder().AddEnvironmentVariables().Build();
+
+Log.SetLoggerFactory(
+    LoggerFactory.Create(l => l.AddConsole(options =>
+        {
+            //options.FormatterName = "json"; // Use the JSON formatter
+        }).SetMinimumLevel(LogLevel.Debug)
+        .AddFilter("Proto.Cluster.Gossip", LogLevel.Information)
+        .AddFilter("Proto.Context.ActorContext", LogLevel.Information)));
+
+// Required to allow unencrypted GrpcNet connections
+AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+
+var serviceName = config["ProtoActor:ServiceName"];
+var podIp = config["ProtoActor:PodIP"];
+var advertisedHost = config["ProtoActor:AdvertisedHost"];
+if (!string.IsNullOrEmpty(serviceName) && !string.IsNullOrEmpty(podIp))
+{
+    podIp = podIp.Replace('.', '-');
+    advertisedHost = $"{podIp}.{serviceName}";
+}
+
+var system = new ActorSystem()
+    .WithRemote(GrpcNetRemoteConfig
+        .BindToAllInterfaces(advertisedHost: advertisedHost, port: 4020)
+        .WithProtoMessages(ProtosReflection.Descriptor))
+    .WithCluster(ClusterConfig
+        .Setup("MyCluster",
+            new KubernetesProvider(),
+            new PartitionActivatorLookup())
+    );
+
+system.EventStream.Subscribe<ClusterTopology>(
+    e => { Console.WriteLine($"{DateTime.Now:O} My members {e.TopologyHash}"); }
+);
+
+await system
+    .Cluster()
+    .StartMemberAsync();
+
+Console.WriteLine("Started");
+
+try
+{
+    var helloGrain = system.Cluster().GetHelloGrain("MyGrain");
+
+    var res = await helloGrain.SayHello(new HelloRequest(), FromSeconds(15));
+    Console.WriteLine(res?.Message ?? "RES IS NULL");
+
+    res = await helloGrain.SayHello(new HelloRequest(), FromSeconds(5));
+    Console.WriteLine(res?.Message ?? "RES IS NULL");
+}
+catch (Exception e)
+{
+    Log.CreateLogger("Program").LogError(e, "Error sending messages");
+}
+
+Console.WriteLine("Press CTRL-C to exit");
+Console.CancelKeyPress += (_, e) =>
+{
+    e.Cancel = true; // prevent the process from terminating.
+    cts.Cancel();
+};
+
+await Task.Delay(Timeout.Infinite, cts.Token);
+
+Console.WriteLine("Shutting Down...");
+await system.Cluster().ShutdownAsync();

--- a/examples/ClusterK8sGrains/Node2/Dockerfile
+++ b/examples/ClusterK8sGrains/Node2/Dockerfile
@@ -1,0 +1,27 @@
+﻿FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+WORKDIR /app
+
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["examples/ClusterK8sGrains/Node1/Node1.csproj", "examples/ClusterK8sGrains/Node1/"]
+COPY ["examples/ClusterK8sGrains/Node2/Node2.csproj", "examples/ClusterK8sGrains/Node2/"]
+COPY ["src/Proto.Cluster.Kubernetes/Proto.Cluster.Kubernetes.csproj", "src/Proto.Cluster.Kubernetes/"]
+COPY ["src/Proto.Cluster/Proto.Cluster.csproj", "src/Proto.Cluster/"]
+COPY ["src/Proto.Remote/Proto.Remote.csproj", "src/Proto.Remote/"]
+COPY ["src/Proto.Actor/Proto.Actor.csproj", "src/Proto.Actor/"]
+COPY ["examples/ClusterK8sGrains/Messages/Messages.csproj", "examples/ClusterK8sGrains/Messages/"]
+RUN dotnet restore "examples/ClusterK8sGrains/Node1/Node1.csproj"
+RUN dotnet restore "examples/ClusterK8sGrains/Node2/Node2.csproj"
+COPY . .
+WORKDIR "/src/examples/ClusterK8sGrains/Node2"
+RUN dotnet build "Node2.csproj" -c $BUILD_CONFIGURATION -o /app/build 
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "Node2.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false --no-restore
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "Node2.dll"]

--- a/examples/ClusterK8sGrains/Node2/Node2.csproj
+++ b/examples/ClusterK8sGrains/Node2/Node2.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <ServerGarbageCollection>true</ServerGarbageCollection>
+        <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+        <LangVersion>11</LangVersion>
+        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <Company>proto.actor example</Company>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\Proto.Cluster.Kubernetes\Proto.Cluster.Kubernetes.csproj" />
+        <ProjectReference Include="..\..\..\src\Proto.Cluster\Proto.Cluster.csproj"/>
+        <ProjectReference Include="..\..\..\src\Proto.Remote\Proto.Remote.csproj"/>
+        <ProjectReference Include="..\Messages\Messages.csproj"/>
+    </ItemGroup>
+    <ItemGroup>
+      <Content Include="..\..\..\.dockerignore">
+        <Link>.dockerignore</Link>
+      </Content>
+    </ItemGroup>
+</Project>

--- a/examples/ClusterK8sGrains/Node2/Program.cs
+++ b/examples/ClusterK8sGrains/Node2/Program.cs
@@ -1,0 +1,99 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Program.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2022 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Runtime.Loader;
+using System.Threading.Tasks;
+using System.Threading;
+using ClusterHelloWorld.Messages;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Proto;
+using Proto.Cluster;
+using Proto.Cluster.Kubernetes;
+using Proto.Cluster.PartitionActivator;
+using Proto.Remote;
+using Proto.Remote.GrpcNet;
+using static System.Threading.Tasks.Task;
+using ProtosReflection = ClusterHelloWorld.Messages.ProtosReflection;
+
+// Hook SIGTERM to a cancel token to know when k8s is shutting us down
+// hostBuilder should be used in production
+var cts = new CancellationTokenSource();
+AssemblyLoadContext.Default.Unloading += ctx => cts.Cancel();
+
+var config = new ConfigurationBuilder().AddEnvironmentVariables().Build();
+
+Log.SetLoggerFactory(
+    LoggerFactory.Create(l => l.AddConsole(options =>
+        {
+            //options.FormatterName = "json"; // Use the JSON formatter
+        }).SetMinimumLevel(LogLevel.Debug)
+        .AddFilter("Proto.Cluster.Gossip", LogLevel.Information)
+        .AddFilter("Proto.Context.ActorContext", LogLevel.Information)));
+
+// Required to allow unencrypted GrpcNet connections
+AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+
+var serviceName = config["ProtoActor:ServiceName"];
+var podIp = config["ProtoActor:PodIP"];
+var advertisedHost = config["ProtoActor:AdvertisedHost"];
+if (!string.IsNullOrEmpty(serviceName) && !string.IsNullOrEmpty(podIp))
+{
+    podIp = podIp.Replace('.', '-');
+    advertisedHost = $"{podIp}.{serviceName}";
+}
+
+var system = new ActorSystem(new ActorSystemConfig().WithDeveloperSupervisionLogging(true))
+    .WithRemote(GrpcNetRemoteConfig
+        .BindToAllInterfaces(advertisedHost: advertisedHost, port: 4020)
+        .WithProtoMessages(ProtosReflection.Descriptor))
+    .WithCluster(ClusterConfig
+        .Setup("MyCluster", new KubernetesProvider(), new PartitionActivatorLookup())
+        .WithClusterKind(
+            HelloGrainActor.GetClusterKind((ctx, identity) => new HelloGrain(ctx, identity.Identity)))
+    );
+
+system.EventStream.Subscribe<ClusterTopology>(
+    e => { Console.WriteLine($"{DateTime.Now:O} My members {e.TopologyHash}"); }
+);
+
+await system
+    .Cluster()
+    .StartMemberAsync();
+
+Console.WriteLine("Started...");
+
+Console.CancelKeyPress += (_, e) =>
+{
+    e.Cancel = true; // prevent the process from terminating.
+    cts.Cancel();
+};
+
+await Delay(Timeout.Infinite, cts.Token);
+Console.WriteLine("Shutting Down...");
+
+public class HelloGrain : HelloGrainBase
+{
+    private readonly string _identity;
+
+    public HelloGrain(IContext ctx, string identity) : base(ctx)
+    {
+        _identity = identity;
+    }
+
+    public override Task<HelloResponse> SayHello(HelloRequest request)
+    {
+        Console.WriteLine("Got request!!");
+
+        var res = new HelloResponse
+        {
+            Message = $"Hello from typed grain {_identity} | {DateTime.UtcNow:O}"
+        };
+
+        return FromResult(res);
+    }
+}

--- a/examples/ClusterK8sGrains/chart/.helmignore
+++ b/examples/ClusterK8sGrains/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/examples/ClusterK8sGrains/chart/Chart.yaml
+++ b/examples/ClusterK8sGrains/chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: protoactor-example-k8s-grains
+description: A hello world Proto.Actor Grains cluster in k8s
+type: application
+version: 0.1.0

--- a/examples/ClusterK8sGrains/chart/templates/namespace.yaml
+++ b/examples/ClusterK8sGrains/chart/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}

--- a/examples/ClusterK8sGrains/chart/templates/node1-deployment.yaml
+++ b/examples/ClusterK8sGrains/chart/templates/node1-deployment.yaml
@@ -1,0 +1,37 @@
+# protoactor-widget-actor-deployment.yaml
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: protoactor-k8s-grains-node1
+  namespace: {{ .Values.namespace }}
+spec:
+  serviceName: {{ .Values.protoActorCluster.subdomain }}
+  replicas: 1
+  selector:
+    matchLabels:
+      app: protoactor-k8s-grains-node1
+  template:
+    metadata:
+      labels:
+        app: protoactor-k8s-grains-node1
+        protoActorMember: "true"
+    spec:
+      serviceAccountName: protoactor-k8s-grains-serviceaccount
+      containers:
+      - name: protoactor-k8s-grains-node1
+        image: {{ .Values.node1.image }}
+        ports:
+         - containerPort: 4020
+           name: protoactor
+        env:
+          - name: ProtoActor__PodIP
+            valueFrom:
+              fieldRef:
+                # Deployment workload need to use the IP of the pod
+                # StatefulSet workloads need to use the Pod Name.
+                fieldPath: metadata.name
+          - name: ProtoActor__ServiceName
+            value: "{{ .Values.protoActorCluster.subdomain }}.{{ .Values.namespace }}.svc.{{ .Values.protoActorCluster.dnsZone}}"
+          - name: "ProtoActor__ClusterName"
+            value: {{ .Values.protoActorCluster.name }}

--- a/examples/ClusterK8sGrains/chart/templates/node1-deployment.yaml
+++ b/examples/ClusterK8sGrains/chart/templates/node1-deployment.yaml
@@ -24,14 +24,3 @@ spec:
         ports:
          - containerPort: 4020
            name: protoactor
-        env:
-          - name: ProtoActor__PodIP
-            valueFrom:
-              fieldRef:
-                # Deployment workload need to use the IP of the pod
-                # StatefulSet workloads need to use the Pod Name.
-                fieldPath: metadata.name
-          - name: ProtoActor__ServiceName
-            value: "{{ .Values.protoActorCluster.subdomain }}.{{ .Values.namespace }}.svc.{{ .Values.protoActorCluster.dnsZone}}"
-          - name: "ProtoActor__ClusterName"
-            value: {{ .Values.protoActorCluster.name }}

--- a/examples/ClusterK8sGrains/chart/templates/node2-deployment.yaml
+++ b/examples/ClusterK8sGrains/chart/templates/node2-deployment.yaml
@@ -23,14 +23,3 @@ spec:
         ports:
          - containerPort: 4020
            name: protoactor
-        env:
-          - name: ProtoActor__PodIP
-            valueFrom:
-              fieldRef:
-                # Deployment workload need to use the IP of the pod
-                # StatefulSet workloads need to use the Pod Name.
-                fieldPath: status.podIP
-          - name: ProtoActor__ServiceName
-            value: "{{ .Values.protoActorCluster.subdomain }}.{{ .Values.namespace }}.svc.{{ .Values.protoActorCluster.dnsZone}}"
-          - name: "ProtoActor__ClusterName"
-            value: {{ .Values.protoActorCluster.name }}

--- a/examples/ClusterK8sGrains/chart/templates/node2-deployment.yaml
+++ b/examples/ClusterK8sGrains/chart/templates/node2-deployment.yaml
@@ -1,0 +1,36 @@
+# protoactor-widget-actor-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: protoactor-k8s-grains-node2
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: protoactor-k8s-grains-node2
+  template:
+    metadata:
+      labels:
+        app: protoactor-k8s-grains-node2
+        protoActorMember: "true"
+    spec:
+      serviceAccountName: protoactor-k8s-grains-serviceaccount
+      subdomain: {{ .Values.protoActorCluster.subdomain }}
+      containers:
+      - name: protoactor-k8s-grains-node2
+        image: {{ .Values.node2.image }}
+        ports:
+         - containerPort: 4020
+           name: protoactor
+        env:
+          - name: ProtoActor__PodIP
+            valueFrom:
+              fieldRef:
+                # Deployment workload need to use the IP of the pod
+                # StatefulSet workloads need to use the Pod Name.
+                fieldPath: status.podIP
+          - name: ProtoActor__ServiceName
+            value: "{{ .Values.protoActorCluster.subdomain }}.{{ .Values.namespace }}.svc.{{ .Values.protoActorCluster.dnsZone}}"
+          - name: "ProtoActor__ClusterName"
+            value: {{ .Values.protoActorCluster.name }}

--- a/examples/ClusterK8sGrains/chart/templates/protoactor-k8s-cluster-port-service.yaml
+++ b/examples/ClusterK8sGrains/chart/templates/protoactor-k8s-cluster-port-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.protoActorCluster.subdomain }}
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    protoActorMember: "true"
+  ports:
+    - name: protoactor-k8s-cluster-port-service
+      protocol: TCP
+      port: 4020
+      targetPort: 4020
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None

--- a/examples/ClusterK8sGrains/chart/templates/protoactor-k8s-grains-role.yaml
+++ b/examples/ClusterK8sGrains/chart/templates/protoactor-k8s-grains-role.yaml
@@ -1,0 +1,16 @@
+# protoactor-widget-actor-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: protoactor-k8s-grains-role
+  namespace: {{ .Values.namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - patch

--- a/examples/ClusterK8sGrains/chart/templates/protoactor-k8s-grains-rolebinding.yaml
+++ b/examples/ClusterK8sGrains/chart/templates/protoactor-k8s-grains-rolebinding.yaml
@@ -1,0 +1,14 @@
+# protoactor-widget-actor-rolebinding.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: protoactor-k8s-grains-rolebinding
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: protoactor-k8s-grains-role
+subjects:
+  - kind: ServiceAccount
+    name: protoactor-k8s-grains-serviceaccount

--- a/examples/ClusterK8sGrains/chart/templates/protoactor-k8s-grains-serviceaccount.yaml
+++ b/examples/ClusterK8sGrains/chart/templates/protoactor-k8s-grains-serviceaccount.yaml
@@ -1,0 +1,7 @@
+# protoactor-widget-actor-serviceaccount.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: protoactor-k8s-grains-serviceaccount
+  namespace: {{ .Values.namespace }}

--- a/examples/ClusterK8sGrains/chart/values.yaml
+++ b/examples/ClusterK8sGrains/chart/values.yaml
@@ -4,7 +4,6 @@ namespace: protoactor-example-k8s-grains
 protoActorCluster:
   subdomain: protoactor-cluster
   name: protoactor-example-cluster
-  dnsZone: cluster.local
 
 node1:
   image: localhost:5000/protoactor.example.k8s.grains.node1:latest

--- a/examples/ClusterK8sGrains/chart/values.yaml
+++ b/examples/ClusterK8sGrains/chart/values.yaml
@@ -1,0 +1,14 @@
+# values.yaml
+namespace: protoactor-example-k8s-grains
+  
+protoActorCluster:
+  subdomain: protoactor-cluster
+  name: protoactor-example-cluster
+  dnsZone: cluster.local
+
+node1:
+  image: localhost:5000/protoactor.example.k8s.grains.node1:latest
+  
+node2:
+  image: localhost:5000/protoactor.example.k8s.grains.node2:latest
+

--- a/examples/ClusterK8sGrains/readme.md
+++ b/examples/ClusterK8sGrains/readme.md
@@ -1,0 +1,37 @@
+Example of a Proto.Actor cluster running in k8s with the kuberneties service locator.
+Is also using k8s DNS name, to support the use of TLS between the cluster members. 
+
+# Setup
+Was build and testing using k3s and Rancher Desktop and registry for local development.
+
+## Local registry (optional)
+If you don't already have container repository, you can setup a local registry for loading and testing this example.
+```shell
+docker volume create registry_data
+docker run -d -p 5000:5000 --name registry --restart=always -v registry_data:/var/lib/registry registry:2
+```
+
+## Build and push images
+
+Run from the root of the repository to build and push the images to the local registry.
+```shell
+docker build -t protoactor.example.k8s.grains.node1:latest -f .\examples\ClusterK8sGrains\Node1\Dockerfile .
+docker tag protoactor.example.k8s.grains.node1:latest localhost:5000/protoactor.example.k8s.grains.node1:latest
+docker push localhost:5000/protoactor.example.k8s.grains.node1:latest
+
+docker build -t protoactor.example.k8s.grains.node2:latest -f .\examples\ClusterK8sGrains\Node2\Dockerfile .
+docker tag protoactor.example.k8s.grains.node2:latest localhost:5000/protoactor.example.k8s.grains.node2:latest
+docker push localhost:5000/protoactor.example.k8s.grains.node2:latest
+```
+
+## Deploy to k8s
+
+From the ClusterK8sGrains folder run the following commands to deploy the application to k8s.
+```shell
+helm install protoactor-example-k8s-grains .\examples\ClusterK8sGrains\chart
+```
+
+To remove the application from k8s run the following command.
+```shell
+helm uninstall protoactor-example-k8s-grains
+```

--- a/src/Proto.Cluster.Kubernetes/KubernetesClusterMonitor.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesClusterMonitor.cs
@@ -302,7 +302,7 @@ internal class KubernetesClusterMonitor : IActor
         }
         
         var memberStatuses = _clusterPods.Values
-            .Select(x => x.GetMemberStatus())
+            .Select(x => x.GetMemberStatus(_config))
             .Where(x => x is not null)
             .Where(x => x.IsRunning && (x.IsReady || x.Member.Id == _cluster.System.Id))
             .Select(x => x.Member)

--- a/src/Proto.Cluster.Kubernetes/KubernetesExtensions.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesExtensions.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -66,7 +67,7 @@ internal static class KubernetesExtensions
 
         if (pod.Status?.ContainerStatuses is null)
             return null;
-        
+
         if (pod.Metadata?.Labels is null)
             return null;
 
@@ -76,9 +77,9 @@ internal static class KubernetesExtensions
             .Where(l => l.Key.StartsWith(AnnotationKinds))
             .SelectMany(l => l.Value.Split(';'))
             .ToArray();
-        
+
         var host = pod.Status.PodIP ?? "";
-        if(pod.Metadata.Labels.TryGetValue(LabelHost, out var hostOverride))
+        if (pod.Metadata.Labels.TryGetValue(LabelHost, out var hostOverride))
             host = hostOverride;
         else if (pod.Metadata.Labels.TryGetValue(LabelHostPrefix, out var hostPrefix))
         {
@@ -92,7 +93,7 @@ internal static class KubernetesExtensions
 
             host = hostPrefix + dnsPostfix;
         }
-        
+
         var port = Convert.ToInt32(pod.Metadata.Labels[LabelPort]);
         var mid = pod.Metadata.Labels[LabelMemberId];
         var alive = pod.Status.ContainerStatuses.All(x => x.Ready);
@@ -111,23 +112,70 @@ internal static class KubernetesExtensions
     ///     Get the namespace of the current pod
     /// </summary>
     /// <returns>The pod namespace</returns>
+    /// <exception cref="InvalidOperationException">Failed to get the Kubernetes namespace, not running in a k8s cluster</exception>
     internal static string GetKubeNamespace()
     {
-        if (cachedNamespace is null)
+        if (TryGetKubeNamespace(out var kubeNamespace))
         {
-            var namespaceFile = Path.Combine(
-                $"{Path.DirectorySeparatorChar}var",
-                "run",
-                "secrets",
-                "kubernetes.io",
-                "serviceaccount",
-                "namespace"
-            );
-
-            cachedNamespace = File.ReadAllText(namespaceFile);
+            return kubeNamespace;
         }
 
-        return cachedNamespace;
+        throw new InvalidOperationException("The application doesn't seem to be running in Kubernetes");
+    }
+
+    internal static bool TryGetKubeNamespace(out string kubeNamespace)
+    {
+        if (cachedNamespace is not null)
+        {
+            if (cachedNamespace.Length == 0)
+            {
+                // We have already tried to get the namespace, and it was not found.
+                kubeNamespace = null;
+                return false;
+            }
+            
+            kubeNamespace = cachedNamespace;
+            return true;
+        }
+
+        var namespaceFile = Path.Combine(
+            $"{Path.DirectorySeparatorChar}var",
+            "run",
+            "secrets",
+            "kubernetes.io",
+            "serviceaccount",
+            "namespace"
+        );
+
+        if (!File.Exists(namespaceFile))
+        {
+            // Note setting it to empty, so we don't try again.
+            kubeNamespace = null;
+            return false;
+        }
+        
+        // k8s has a limit of 63 characters for namespace names 
+        // Limit to reading 63 characters, in case a larger files is there, we will just ignore it.
+        using var reader = new StreamReader(namespaceFile, Encoding.UTF8);
+        var buffer = new char[65];
+        var read = reader.Read(buffer, 0, 64);
+        if (read == 0 || read > 63)
+        {
+            cachedNamespace = string.Empty;
+            kubeNamespace = null;
+            return false;
+        }
+        
+        kubeNamespace = cachedNamespace = new string(buffer, 0, read).Trim();
+        if (string.IsNullOrWhiteSpace(kubeNamespace))
+        {
+            // Set it to something, so we know we read it, and we don't try again.
+            cachedNamespace = string.Empty;
+            kubeNamespace = null;
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Proto.Cluster.Kubernetes/KubernetesHelper.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesHelper.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using k8s;
+using k8s.Models;
+
+namespace Proto.Cluster.Kubernetes;
+
+public static class KubernetesHelper
+{
+    /// <summary>
+    /// Checks if the Kubernetes namespace file exists. 
+    /// </summary>
+    [PublicAPI]
+    public static bool HasKubeNamespace() => KubernetesExtensions.TryGetKubeNamespace(out _);
+    
+    /// <summary>
+    /// Attempts to get the FQDN for the Pod by querying the Kubernetes API.
+    /// </summary>
+    /// <exception cref="ApplicationException">Unable to detected k8s or if Subdomain is missing from Pod Definition.</exception>
+    [PublicAPI]
+    public static async ValueTask<string> GetPodFqdn(this KubernetesProvider kubernetesProvider)
+    {
+        return await GetPodFqdn(kubernetesProvider.Config);
+    }
+
+    /// <summary>
+    /// Attempts to get the FQDN for the Pod by querying the Kubernetes API.
+    /// </summary>
+    /// <exception cref="ApplicationException">Unable to detected k8s or if Subdomain is missing from Pod Definition.</exception>
+    [PublicAPI]
+    public static async ValueTask<string> GetPodFqdn(this KubernetesProviderConfig config)
+    {
+        var kubeNamespace = KubernetesExtensions.GetKubeNamespace();
+
+        var k8SClient = config.ClientFactory();
+        var pod = await k8SClient.CoreV1.ReadNamespacedPodAsync(Environment.MachineName, kubeNamespace)
+            .ConfigureAwait(false);
+
+        if (string.IsNullOrEmpty(pod.Spec.Subdomain))
+        {
+            throw new ApplicationException("Failed to get the FQDN for the Pod, the spec.subdomain or spec.serviceName is not set");
+        }
+
+        // Look up our workload kind, and then determine if we are a pod with a stable name and so can use our host name
+        // of if we are a workload like a Deployment, and need to use our IP address for the FQDN.
+
+        var ownerReferences = pod.Metadata.OwnerReferences;
+        var isStableHostnameWorkload = ownerReferences.Any(
+            // Add other workload kinds with stable hostnames as needed
+            owner => owner.Kind is "StatefulSet" or "DaemonSet" 
+        );
+
+        var host = isStableHostnameWorkload ? pod.Metadata.Name : pod.Status.PodIP.Replace('.', '-');
+        var hostFqdn = $"{host}.{pod.Spec.Subdomain}.{pod.Namespace()}.svc.{config.ClusterDomain}";
+        return hostFqdn;
+    }
+}

--- a/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
@@ -39,6 +39,8 @@ public class KubernetesProvider : IClusterProvider
     private string _podName;
     private int _port;
 
+    internal KubernetesProviderConfig Config => _config;
+    
     public async Task<DiagnosticsEntry[]> GetDiagnostics()
     {
         try
@@ -67,7 +69,7 @@ public class KubernetesProvider : IClusterProvider
 
     public KubernetesProvider(KubernetesProviderConfig config)
     {
-        if (KubernetesExtensions.GetKubeNamespace() is null)
+        if (!KubernetesExtensions.TryGetKubeNamespace(out _))
         {
             throw new InvalidOperationException("The application doesn't seem to be running in Kubernetes");
         }

--- a/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
@@ -159,30 +159,6 @@ public class KubernetesProvider : IClusterProvider
 
         AppendHostToPodLabels(pod, labels);
 
-        // Check ownerReferences to determine if it's a StatefulSet or Deployment
-        var ownerReferences = pod.Metadata.OwnerReferences;
-        var workloadType = ""; // StatefulSet or Deployment
-        var workloadName = "";
-
-        foreach (var ownerRef in ownerReferences)
-        {
-            if (ownerRef.Kind == "StatefulSet")
-            {
-                workloadType = "StatefulSet";
-                workloadName = ownerRef.Name;
-                break;
-            }
-            else if (ownerRef.Kind == "Deployment")
-            {
-                workloadType = "Deployment";
-                break;
-            }
-        }
-
-        Logger.LogInformation(
-            "[Cluster][KubernetesProvider] Using Kubernetes workload type: {WorkloadType}, {WorkloadName}",
-            workloadType, workloadName ?? "N/A");
-
         foreach (var existing in pod.Metadata.Labels)
         {
             labels.TryAdd(existing.Key, existing.Value);

--- a/src/Proto.Cluster.Kubernetes/KubernetesProviderConfig.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProviderConfig.cs
@@ -48,7 +48,7 @@ public record KubernetesProviderConfig
 
     internal LogLevel DebugLogLevel => DeveloperLogging ? LogLevel.Information : LogLevel.Debug;
 
-    private static IKubernetes DefaultFactory() => new k8s.Kubernetes(KubernetesClientConfiguration.InClusterConfig());
+    internal static IKubernetes DefaultFactory() => new k8s.Kubernetes(KubernetesClientConfiguration.InClusterConfig());
     
     /// <summary>
     /// The k8s Cluster Domain (TLD), defaults to "cluster.local"

--- a/src/Proto.Cluster.Kubernetes/KubernetesProviderConfig.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProviderConfig.cs
@@ -35,6 +35,11 @@ public record KubernetesProviderConfig
     ///     Enables more detailed logging
     /// </summary>
     private bool DeveloperLogging { get; }
+    
+    /// <summary>
+    /// The k8s Cluster Domain (TLD), defaults to "cluster.local"
+    /// </summary>
+    public string ClusterDomain { get; init; } = "cluster.local";
 
     /// <summary>
     ///     Override the default implementation to configure the kubernetes client
@@ -44,4 +49,10 @@ public record KubernetesProviderConfig
     internal LogLevel DebugLogLevel => DeveloperLogging ? LogLevel.Information : LogLevel.Debug;
 
     private static IKubernetes DefaultFactory() => new k8s.Kubernetes(KubernetesClientConfiguration.InClusterConfig());
+    
+    /// <summary>
+    /// The k8s Cluster Domain (TLD), defaults to "cluster.local"
+    /// </summary>
+    public KubernetesProviderConfig WithClusterDomain(string clusterDomain = "cluster.local")
+        => this with { ClusterDomain = clusterDomain };
 }

--- a/src/Proto.Cluster.Kubernetes/ProtoLabels.cs
+++ b/src/Proto.Cluster.Kubernetes/ProtoLabels.cs
@@ -13,4 +13,6 @@ public static class ProtoLabels
     public const string LabelCluster = ProtoClusterPrefix + "cluster";
     public const string LabelMemberId = ProtoClusterPrefix + "member-id";
     public const string AnnotationKinds = ProtoClusterPrefix + "kinds";
+    public const string LabelHost = ProtoClusterPrefix + "host";
+    public const string LabelHostPrefix = ProtoClusterPrefix + "host-prefix";
 }


### PR DESCRIPTION
## Description

This PR introduces an enhancement to the Kubernetes cluster provider to allow an advertised host to be added as a Pod label, when not using the PodIP. This feature for scenarios where the fully qualified domain name (FQDN) is needed, for example, when using TLS to secure the communications within the cluster. This change include logic to detected the pod subdomain, namespace, and cluster domain, to attempt to keep the hostname stored in the label under k8s's max length of 63 chars for Pod Label values.

When workloads of type Deployment are joining the Proto.Actor cluster, it is recommended to create a headless services definition, and to also add a spec.subdomain to the Pod definition that matches the name of the assigned headless service. See `examples/ClusterK8sGrains` for a working example.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
