### PR TITLE
Change container metadata to use CONTAINER_APP_REPLICA_NAME

### DIFF
--- a/src/Proto.Cluster.AzureContainerApps/Services/EnvironmentContainerAppMetadataAccessor.cs
+++ b/src/Proto.Cluster.AzureContainerApps/Services/EnvironmentContainerAppMetadataAccessor.cs
@@ -21,7 +21,7 @@ public class EnvironmentContainerAppMetadataAccessor : IContainerAppMetadataAcce
     {
         var containerAppName = Environment.GetEnvironmentVariable("CONTAINER_APP_NAME") ?? throw new Exception("No app name provided");
         var revisionName = Environment.GetEnvironmentVariable("CONTAINER_APP_REVISION") ?? throw new Exception("No app revision provided");
-        var replicaName = Environment.GetEnvironmentVariable("HOSTNAME") ?? throw new Exception("No replica name provided");
+        var replicaName = Environment.GetEnvironmentVariable("CONTAINER_APP_REPLICA_NAME") ?? throw new Exception("No replica name provided");
 
         return new(new ContainerAppMetadata(containerAppName, revisionName, replicaName));
     }


### PR DESCRIPTION
Replace environment variable HOSTNAME with CONTAINER_APP_REPLICA_NAME.

## Description

In new ACA Environment with workload profiles, using the Consumption profile, HOSTNAME does not appear to exist as an environment variable anymore - thus the application cannot start. However, the env variable CONTAINER_APP_REPLICA_NAME exists in both classic ACA Environment (Consumption) and in new workload profiles (Dedicated + Consumption). So this change should be backwards compatible as well.

Also, it makes more sense in this context and uses the same standard as the other Container App metadata env variables that are fetched.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
