### PR TITLE
Added support for propagating OpenTelemetry baggage

### DIFF
--- a/src/Proto.OpenTelemetry/OpenTelemetryDecorators.cs
+++ b/src/Proto.OpenTelemetry/OpenTelemetryDecorators.cs
@@ -313,7 +313,8 @@ internal static class OpenTelemetryMethodsDecorators
 
         var propagationContext = envelope.Header.ExtractPropagationContext();
 
-        if (propagationContext.Baggage.Count > 0)
+        bool hasBaggage = propagationContext.Baggage.Count > 0 || Baggage.Current.Count > 0;
+        if (hasBaggage)
         {
             Baggage.Current = propagationContext.Baggage;
         }

--- a/tests/Proto.OpenTelemetry.Tests/OpenTelemetryTracingTests.cs
+++ b/tests/Proto.OpenTelemetry.Tests/OpenTelemetryTracingTests.cs
@@ -188,9 +188,10 @@ public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
                     await next(context, target, updatedEnvelope);
                 });
                 var future = new FutureProcess(middleContext.System);
+                Baggage.Current = TestBaggage;
                 middleContext.Request(target, new TraceMe(SendAs.Request), future.Pid);
                 var response = (MessageEnvelope)await future.Task;
-                response.Message.Should().Be(new TraceResponse());
+                response.Message.Should().Be(new TraceResponse(TestBaggage));
             }
         );
     

--- a/tests/Proto.OpenTelemetry.Tests/OpenTelemetryTracingTests.cs
+++ b/tests/Proto.OpenTelemetry.Tests/OpenTelemetryTracingTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
+using OpenTelemetry;
 using OpenTelemetry.Trace;
 using Proto.Future;
 using Xunit;
@@ -12,6 +13,11 @@ namespace Proto.OpenTelemetry.Tests;
 
 public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
 {
+    private static readonly Baggage TestBaggage = Baggage.Create(new Dictionary<string, string?>
+    {
+        {"baggageKey", "baggageValue"}
+    });
+    
     private static readonly Props ProxyTraceActorProps = Props.FromProducer(() => new TraceTestActor()).WithTracing();
 
     private static readonly Props InnerTraceActorProps = Props.FromFunc(context =>
@@ -22,7 +28,7 @@ public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
 
                     if (context.Sender is not null)
                     {
-                        context.Respond(new TraceResponse());
+                        context.Respond(GetTraceResponse() );
                     }
                 }
 
@@ -31,6 +37,13 @@ public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
         )
         .WithTracing();
 
+    static TraceResponse GetTraceResponse()
+    {
+        return Baggage.Current.Count > 0
+            ? new TraceResponse(Baggage.Current)
+            : new TraceResponse();
+    }
+    
     private static readonly ActivitySource TestSource = new("Proto.Actor.Tests");
 
     private readonly ActivityFixture _fixture;
@@ -122,6 +135,67 @@ public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
         inner.Should().NotBeNull();
     }
 
+    
+    [Fact]
+    public async Task TracesPropagateCorrectlyWithBaggageForRequestAsync() =>
+        await VerifyTrace(async (rootContext, target) =>
+            {
+                Baggage.Current = TestBaggage;
+                var response = await rootContext.RequestAsync<TraceResponse>(target, new TraceMe(SendAs.RequestAsync));
+                response.Should().BeEquivalentTo(new TraceResponse(TestBaggage));
+            }
+        );
+
+    [Fact]
+    public async Task TracesPropagateCorrectlyWithBaggageForRequest() =>
+        await VerifyTrace(async (rootContext, target) =>
+            {
+                Baggage.Current = TestBaggage;
+                rootContext.Request(target, new TraceMe(SendAs.Request));
+                await Task.Delay(100);
+            }
+        );
+
+    [Fact]
+    public async Task TracesPropagateCorrectlyWithBaggageForRequestWithForward() =>
+        await VerifyTrace(async (rootContext, target) =>
+            {
+                Baggage.Current = TestBaggage;
+                var response = await rootContext.RequestAsync<TraceResponse>(target, new TraceMe(SendAs.Forward));
+                response.Should().BeEquivalentTo(new TraceResponse(TestBaggage));
+            }
+        );
+
+    [Fact]
+    public async Task TracesPropagateCorrectlyWithBaggageForRequestWithSender() =>
+        await VerifyTrace(async (rootContext, target) =>
+            {
+                Baggage.Current = TestBaggage;
+                var future = new FutureProcess(rootContext.System);
+                rootContext.Request(target, new TraceMe(SendAs.Request), future.Pid);
+                var response = (MessageEnvelope)await future.Task;
+                response.Message.Should().Be(new TraceResponse(TestBaggage));
+            }
+        );
+
+    [Fact]
+    public async Task TracesPropagateCorrectlyWithBaggageForRequestWithSenderWithAdditionalMiddleware() =>
+        await VerifyTrace(async (tracedRoot, target) =>
+            {
+                var middleContext = tracedRoot.WithSenderMiddleware(next => async (context, _, envelope) =>
+                {
+                    var updatedEnvelope = envelope.WithHeader("test", "value");
+                    await next(context, target, updatedEnvelope);
+                });
+                var future = new FutureProcess(middleContext.System);
+                middleContext.Request(target, new TraceMe(SendAs.Request), future.Pid);
+                var response = (MessageEnvelope)await future.Task;
+                response.Message.Should().Be(new TraceResponse());
+            }
+        );
+    
+    // End
+    
     private async Task VerifyTrace(Func<IRootContext, PID, Task> action)
     {
         var tracedRoot = new ActorSystem().Root.WithTracing();
@@ -175,7 +249,7 @@ public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
 
     private record TraceMe(SendAs Method);
 
-    private record TraceResponse;
+    private record TraceResponse(Baggage? Baggage = null);
 
     public class TraceTestActor : IActor
     {


### PR DESCRIPTION
## Description

Adds support for propagating Baggage via OTEL, by populating Baggage.Current if received in PropagationContext.  Added tests to cover baggage propagation

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [X] I have added tests that prove my fix is effective or that my feature works


