### PR TITLE
using await on types implementing IAsyncDisposable

### DIFF
--- a/src/Proto.Persistence.SqlServer/SqlServerProvider.cs
+++ b/src/Proto.Persistence.SqlServer/SqlServerProvider.cs
@@ -67,15 +67,15 @@ public class SqlServerProvider : IProvider
             $@"INSERT INTO [{_tableSchema}].[{_tableSnapshots}] (Id, ActorName, SnapshotIndex, SnapshotData) VALUES (@Id, @ActorName, @SnapshotIndex, @SnapshotData)";
     }
 
-    public Task DeleteEventsAsync(string actorName, long inclusiveToIndex) =>
-        ExecuteNonQueryAsync(
+    public async Task DeleteEventsAsync(string actorName, long inclusiveToIndex) =>
+        await ExecuteNonQueryAsync(
             _sqlDeleteEvents,
             CreateParameter("ActorName", NVarChar, actorName),
             CreateParameter("EventIndex", BigInt, inclusiveToIndex)
         );
 
-    public Task DeleteSnapshotsAsync(string actorName, long inclusiveToIndex) =>
-        ExecuteNonQueryAsync(
+    public async Task DeleteSnapshotsAsync(string actorName, long inclusiveToIndex) =>
+        await ExecuteNonQueryAsync(
             _sqlDeleteSnapshots,
             CreateParameter("ActorName", NVarChar, actorName),
             CreateParameter("SnapshotIndex", BigInt, inclusiveToIndex)
@@ -117,9 +117,9 @@ public class SqlServerProvider : IProvider
         long snapshotIndex = 0;
         object snapshotData = null;
 
-        using var connection = new SqlConnection(_connectionString);
+        await using var connection = new SqlConnection(_connectionString);
 
-        using var command = new SqlCommand(_sqlReadSnapshot, connection);
+        await using var command = new SqlCommand(_sqlReadSnapshot, connection);
 
         await connection.OpenAsync().ConfigureAwait(false);
 
@@ -151,14 +151,14 @@ public class SqlServerProvider : IProvider
             CreateParameter("EventData", NVarChar, JsonConvert.SerializeObject(item.EventData, AllTypeSettings))
         ).ConfigureAwait(false);
 
-        return index++;
+        return index + 1;
     }
 
-    public Task PersistSnapshotAsync(string actorName, long index, object snapshot)
+    public async Task PersistSnapshotAsync(string actorName, long index, object snapshot)
     {
         var item = new Snapshot(actorName, index, snapshot);
 
-        return ExecuteNonQueryAsync(
+        await ExecuteNonQueryAsync(
             _sqlSaveSnapshot,
             CreateParameter("Id", NVarChar, item.Id),
             CreateParameter("ActorName", NVarChar, item.ActorName),
@@ -231,13 +231,13 @@ public class SqlServerProvider : IProvider
 
     private async Task ExecuteNonQueryAsync(string sql, params SqlParameter[] parameters)
     {
-        using var connection = new SqlConnection(_connectionString);
+        await using var connection = new SqlConnection(_connectionString);
 
-        using var command = new SqlCommand(sql, connection);
+        await using var command = new SqlCommand(sql, connection);
 
         await connection.OpenAsync().ConfigureAwait(false);
 
-        using var tx = connection.BeginTransaction();
+        await using var tx = connection.BeginTransaction();
 
         command.Transaction = tx;
 


### PR DESCRIPTION
## Description

Using `await using` on types implementing `IAsyncDisposable`.
Also, awaiting on `ExecuteNonQueryAsync` where it's used, in order to get a clearer callstack when exceptions are thrown.
In addition, returning `index + 1` in `PersistEventAsync` instead of `index++` which also needlessly modifies `index`.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Simple performance and debuggability improvements

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [X] No new tests are necessary