### PR TITLE
Expose some internal properties as public

### DIFF
--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -137,11 +137,11 @@ public class Cluster : IActorSystemExtension<Cluster>
     /// </summary>
     public MemberList MemberList { get; private set; } = null!;
 
-    internal IIdentityLookup IdentityLookup { get; set; } = null!;
+    public IIdentityLookup IdentityLookup { get; set; } = null!;
+
+    public PidCache PidCache { get; }
 
     internal IClusterProvider Provider { get; set; } = null!;
-
-    internal PidCache PidCache { get; }
 
     private void SubscribeToTopologyEvents() =>
         System.EventStream.Subscribe<ClusterTopology>(e =>

--- a/src/Proto.Cluster/Messages/Messages.cs
+++ b/src/Proto.Cluster/Messages/Messages.cs
@@ -15,7 +15,7 @@ namespace Proto.Cluster;
 
 public sealed partial class ClusterIdentity : ICustomDiagnosticMessage
 {
-    internal PID? CachedPid { get; set; }
+    public PID? CachedPid { get; set; }
 
     public string ToDiagnosticString() => $"{Kind}/{Identity}";
 

--- a/src/Proto.Cluster/PidCache.cs
+++ b/src/Proto.Cluster/PidCache.cs
@@ -14,7 +14,7 @@ using Proto.Remote;
 
 namespace Proto.Cluster;
 
-internal class PidCache
+public class PidCache
 {
     private readonly ICollection<KeyValuePair<ClusterIdentity, PID>> _cacheCollection;
     private readonly ConcurrentDictionary<ClusterIdentity, PID> _cacheDict;


### PR DESCRIPTION
## Description
In order to write a proper alternative to the DefaultClusterContext, we need these properties to be public. I believe they should be considering that the API does allow end users to swap the IClusterContext with the `WithClusterContextProducer` method on `ClusterConfig`

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
