### PR TITLE
Centralized package management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,95 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.400.16" />
+    <PackageVersion Include="AWSSDK.ECS" Version="3.7.402.10" />
+    <PackageVersion Include="Azure.Identity" Version="1.12.0" />
+    <PackageVersion Include="Azure.ResourceManager.AppContainers" Version="1.3.0" />
+    <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.8.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="Consul" Version="1.7.14.4" />
+    <PackageVersion Include="CouchbaseNetClient" Version="2.7.22" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="DotNet.Testcontainers" Version="1.6.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageVersion Include="Google.Protobuf" Version="3.28.0" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.65.0" />
+    <PackageVersion Include="Grpc.Core.Api" Version="2.65.0" />
+    <PackageVersion Include="Grpc.HealthCheck" Version="2.65.0" />
+    <PackageVersion Include="Grpc.Net.Common" Version="2.65.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.66.0" />
+    <PackageVersion Include="Handlebars.Net" Version="2.0.9" />
+    <PackageVersion Include="IsExternalInit.System.Runtime.CompilerServices" Version="1.0.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2024.2.0" />
+    <PackageVersion Include="JsonPatch.Net" Version="3.1.1" />
+    <PackageVersion Include="KubernetesClient" Version="14.0.12" />
+    <PackageVersion Include="Marten" Version="7.27.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.8" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.NET.Build.Containers" Version="8.0.401" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="MinVer" Version="6.0.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.28.0" />
+    <PackageVersion Include="MudBlazor" Version="6.21.0" />
+    <PackageVersion Include="Neovolve.Logging.Xunit" Version="6.1.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="OpenTelemetry" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Jaeger" Version="1.5.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageVersion Include="prometheus-net" Version="8.2.1" />
+    <PackageVersion Include="Proto.Cluster.CodeGen" Version="1.7.0" />
+    <PackageVersion Include="protobuf-net" Version="3.2.30" />
+    <PackageVersion Include="protobuf-net.Reflection" Version="3.2.12" />
+    <PackageVersion Include="RavenDB.Client" Version="6.0.105" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.12.4" />
+    <PackageVersion Include="Serilog" Version="4.0.1" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.2" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Seq" Version="8.0.0" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.8.12" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageVersion Include="System.Interactive.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
+    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
+    <PackageVersion Include="Testcontainers" Version="3.10.0" />
+    <PackageVersion Include="Testcontainers.CouchDb" Version="3.10.0" />
+    <PackageVersion Include="Testcontainers.DynamoDb" Version="3.10.0" />
+    <PackageVersion Include="Testcontainers.MongoDb" Version="3.10.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="3.10.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="3.10.0" />
+    <PackageVersion Include="Testcontainers.RavenDb" Version="3.10.0" />
+    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
-    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.400.16" />
-    <PackageVersion Include="AWSSDK.ECS" Version="3.7.402.10" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.400.21" />
+    <PackageVersion Include="AWSSDK.ECS" Version="3.7.402.16" />
     <PackageVersion Include="Azure.Identity" Version="1.12.0" />
     <PackageVersion Include="Azure.ResourceManager.AppContainers" Version="1.3.0" />
     <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.8.0" />
@@ -15,9 +15,9 @@
     <PackageVersion Include="CouchbaseNetClient" Version="2.7.22" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="DotNet.Testcontainers" Version="1.6.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.28.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.28.1" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.65.0" />
     <PackageVersion Include="Grpc.Core.Api" Version="2.65.0" />
     <PackageVersion Include="Grpc.HealthCheck" Version="2.65.0" />
@@ -27,7 +27,7 @@
     <PackageVersion Include="IsExternalInit.System.Runtime.CompilerServices" Version="1.0.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2024.2.0" />
     <PackageVersion Include="JsonPatch.Net" Version="3.1.1" />
-    <PackageVersion Include="KubernetesClient" Version="14.0.12" />
+    <PackageVersion Include="KubernetesClient" Version="15.0.1" />
     <PackageVersion Include="Marten" Version="7.27.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.8" />
@@ -68,13 +68,16 @@
     <PackageVersion Include="protobuf-net" Version="3.2.30" />
     <PackageVersion Include="protobuf-net.Reflection" Version="3.2.12" />
     <PackageVersion Include="RavenDB.Client" Version="6.0.105" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.12.4" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.12.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
     <PackageVersion Include="Serilog" Version="4.0.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.2" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.Seq" Version="8.0.0" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.8.12" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.8.16" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.7.3" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />

--- a/ProtoActor.sln
+++ b/ProtoActor.sln
@@ -107,6 +107,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".meta", ".meta", "{222D5932
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
 		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Proto.Cluster.Identity.Redis", "src\Proto.Cluster.Identity.Redis\Proto.Cluster.Identity.Redis.csproj", "{B0F9003C-BA53-4948-8FB7-1F7F230F9310}"

--- a/benchmarks/AutoClusterBenchmark/AutoClusterBenchmark.csproj
+++ b/benchmarks/AutoClusterBenchmark/AutoClusterBenchmark.csproj
@@ -24,15 +24,15 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNet.Testcontainers" Version="1.6.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-        <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.5.1" />
-        <PackageReference Include="Serilog" Version="4.0.1" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="DotNet.Testcontainers" />
+        <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+        <PackageReference Include="MongoDB.Driver" />
+        <PackageReference Include="Newtonsoft.Json" />
+        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
+        <PackageReference Include="Serilog" />
+        <PackageReference Include="Serilog.Extensions.Logging" />
+        <PackageReference Include="Serilog.Sinks.Console" />
     </ItemGroup>
 
     <ItemGroup>

--- a/benchmarks/ClusterBenchmark/ClusterBenchmark.csproj
+++ b/benchmarks/ClusterBenchmark/ClusterBenchmark.csproj
@@ -19,15 +19,15 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNet.Testcontainers" Version="1.6.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-        <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.5.1" />
-        <PackageReference Include="Serilog" Version="4.0.1" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="DotNet.Testcontainers" />
+        <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+        <PackageReference Include="MongoDB.Driver" />
+        <PackageReference Include="Newtonsoft.Json" />
+        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
+        <PackageReference Include="Serilog" />
+        <PackageReference Include="Serilog.Extensions.Logging" />
+        <PackageReference Include="Serilog.Sinks.Console" />
     </ItemGroup>
 
     <ItemGroup>

--- a/benchmarks/ClusterMicroBenchmarks/ClusterMicroBenchmarks.csproj
+++ b/benchmarks/ClusterMicroBenchmarks/ClusterMicroBenchmarks.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+        <PackageReference Include="BenchmarkDotNet" />
     </ItemGroup>
     
     <ItemGroup>

--- a/benchmarks/GossipBenchmark/Messages/Messages.csproj
+++ b/benchmarks/GossipBenchmark/Messages/Messages.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <NoWarn>8981</NoWarn>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.28.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
-    <PackageReference Include="Proto.Cluster.CodeGen" Version="1.7.0" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+    <PackageReference Include="Proto.Cluster.CodeGen" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="Protos.proto" />

--- a/benchmarks/HostedService/HostedService.csproj
+++ b/benchmarks/HostedService/HostedService.csproj
@@ -5,9 +5,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" NoWarn="NU1605" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.8" NoWarn="NU1605" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" NoWarn="NU1605" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" NoWarn="NU1605" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>

--- a/benchmarks/KubernetesDiagnostics/KubernetesDiagnostics.csproj
+++ b/benchmarks/KubernetesDiagnostics/KubernetesDiagnostics.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
     
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-      <PackageReference Include="Microsoft.NET.Build.Containers" Version="8.0.401" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+      <PackageReference Include="Microsoft.NET.Build.Containers" />
     </ItemGroup>
     
     <ItemGroup>

--- a/benchmarks/MailboxBenchmark/MailboxBenchmark.csproj
+++ b/benchmarks/MailboxBenchmark/MailboxBenchmark.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
@@ -7,6 +7,6 @@
     <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotnet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotnet" />
   </ItemGroup>
 </Project>

--- a/benchmarks/ProtoActorBenchmarks/ProtoActorBenchmarks.csproj
+++ b/benchmarks/ProtoActorBenchmarks/ProtoActorBenchmarks.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
@@ -7,7 +7,7 @@
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/benchmarks/RemoteBenchmark/Messages/Messages.csproj
+++ b/benchmarks/RemoteBenchmark/Messages/Messages.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <NoWarn>8981</NoWarn>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.28.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="System.ValueTuple" />
+    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/benchmarks/RemoteBenchmark/Node1/Node1.csproj
+++ b/benchmarks/RemoteBenchmark/Node1/Node1.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ServerGarbageCollection>true</ServerGarbageCollection>
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\Messages\Messages.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' != 'net5.0'">
     <DefineConstants>NETCORE</DefineConstants>

--- a/benchmarks/RemoteBenchmark/Node2/Node2.csproj
+++ b/benchmarks/RemoteBenchmark/Node2/Node2.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ServerGarbageCollection>true</ServerGarbageCollection>
@@ -12,7 +12,7 @@
     <ProjectReference Include="..\Messages\Messages.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' != 'net5.0'">
     <DefineConstants>NETCORE</DefineConstants>

--- a/benchmarks/SkyriseMini/Client/SkyriseMiniClient.csproj
+++ b/benchmarks/SkyriseMini/Client/SkyriseMiniClient.csproj
@@ -18,18 +18,18 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Grpc.Tools" Version="2.66.0">
+      <PackageReference Include="Grpc.Tools">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="OpenTelemetry" Version="1.9.0" />
-      <PackageReference Include="OpenTelemetry.Api" Version="1.9.0" />
-      <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
-      <PackageReference Include="prometheus-net" Version="8.2.1" />
-      <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
-      <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-      <PackageReference Include="Serilog.Sinks.Seq" Version="8.0.0" />
-      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+      <PackageReference Include="OpenTelemetry" />
+      <PackageReference Include="OpenTelemetry.Api" />
+      <PackageReference Include="OpenTelemetry.Exporter.Prometheus" />
+      <PackageReference Include="prometheus-net" />
+      <PackageReference Include="Serilog.AspNetCore" />
+      <PackageReference Include="Serilog.Sinks.Console" />
+      <PackageReference Include="Serilog.Sinks.Seq" />
+      <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>

--- a/benchmarks/SkyriseMini/Server/SkyriseMiniServer.csproj
+++ b/benchmarks/SkyriseMini/Server/SkyriseMiniServer.csproj
@@ -18,18 +18,18 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Grpc.Tools" Version="2.66.0">
+      <PackageReference Include="Grpc.Tools">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="OpenTelemetry" Version="1.9.0" />
-      <PackageReference Include="OpenTelemetry.Api" Version="1.9.0" />
-      <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
-      <PackageReference Include="prometheus-net" Version="8.2.1" />
-      <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
-      <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-      <PackageReference Include="Serilog.Sinks.Seq" Version="8.0.0" />
-      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+      <PackageReference Include="OpenTelemetry" />
+      <PackageReference Include="OpenTelemetry.Api" />
+      <PackageReference Include="OpenTelemetry.Exporter.Prometheus" />
+      <PackageReference Include="prometheus-net" />
+      <PackageReference Include="Serilog.AspNetCore" />
+      <PackageReference Include="Serilog.Sinks.Console" />
+      <PackageReference Include="Serilog.Sinks.Seq" />
+      <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/ActorMetrics/ActorMetrics.csproj
+++ b/examples/ActorMetrics/ActorMetrics.csproj
@@ -6,14 +6,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Grpc.Tools" Version="2.66.0">
+        <PackageReference Include="Grpc.Tools">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+        <PackageReference Include="OpenTelemetry.Exporter.Prometheus" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/AspNetGrains/Messages/Messages.csproj
+++ b/examples/AspNetGrains/Messages/Messages.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.28.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
-        <PackageReference Include="Proto.Cluster.CodeGen" Version="1.7.0" />
+        <PackageReference Include="Google.Protobuf" />
+        <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+        <PackageReference Include="Proto.Cluster.CodeGen" />
     </ItemGroup>
     <ItemGroup>
         <Protobuf Include="Protos.proto" />

--- a/examples/Chat/Messages/Chat.Messages.csproj
+++ b/examples/Chat/Messages/Chat.Messages.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
+        <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/ClusterGrainHelloWorld/Messages/Messages.csproj
+++ b/examples/ClusterGrainHelloWorld/Messages/Messages.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.28.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
-        <PackageReference Include="Proto.Cluster.CodeGen" Version="1.7.0" />
+        <PackageReference Include="Google.Protobuf" />
+        <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+        <PackageReference Include="Proto.Cluster.CodeGen" />
     </ItemGroup>
     <ItemGroup>
         <Protobuf Include="Protos.proto" />

--- a/examples/ClusterK8sGrains/Messages/Messages.csproj
+++ b/examples/ClusterK8sGrains/Messages/Messages.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
         <LangVersion>11</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.28.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
-        <PackageReference Include="Proto.Cluster.CodeGen" Version="1.7.0" />
+        <PackageReference Include="Google.Protobuf" />
+        <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+        <PackageReference Include="Proto.Cluster.CodeGen" />
     </ItemGroup>
     <ItemGroup>
         <Protobuf Include="Protos.proto" />

--- a/examples/ClusterPubSub/ClusterPubSub.csproj
+++ b/examples/ClusterPubSub/ClusterPubSub.csproj
@@ -10,13 +10,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.28.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.66.0">
+        <PackageReference Include="Google.Protobuf" />
+        <PackageReference Include="Grpc.Tools">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-        <PackageReference Include="Proto.Cluster.CodeGen" Version="1.7.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+        <PackageReference Include="Proto.Cluster.CodeGen" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/ClusterPubSubBatchingProducer/ClusterPubSubBatchingProducer.csproj
+++ b/examples/ClusterPubSubBatchingProducer/ClusterPubSubBatchingProducer.csproj
@@ -12,12 +12,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.28.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.66.0">
+        <PackageReference Include="Google.Protobuf" />
+        <PackageReference Include="Grpc.Tools">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/DeadLetterThrottling/DeadLetterThrottling.csproj
+++ b/examples/DeadLetterThrottling/DeadLetterThrottling.csproj
@@ -6,11 +6,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj"/>
+        <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     </ItemGroup>
 
 </Project>

--- a/examples/DependencyInjection/DependencyInjection.csproj
+++ b/examples/DependencyInjection/DependencyInjection.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/EventStreamTopicsCluster/EventStreamTopicsCluster.csproj
+++ b/examples/EventStreamTopicsCluster/EventStreamTopicsCluster.csproj
@@ -13,12 +13,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Grpc.Tools" Version="2.66.0">
+        <PackageReference Include="Grpc.Tools">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/KafkaVirtualActorIngress/KafkaVirtualActorIngress.csproj
+++ b/examples/KafkaVirtualActorIngress/KafkaVirtualActorIngress.csproj
@@ -15,12 +15,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.28.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.66.0">
+        <PackageReference Include="Google.Protobuf" />
+        <PackageReference Include="Grpc.Tools">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="StackExchange.Redis" Version="2.6.66" />
+        <PackageReference Include="StackExchange.Redis" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/Persistence/Messages/Messages.csproj
+++ b/examples/Persistence/Messages/Messages.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.28.0" />
-        <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
+        <PackageReference Include="Google.Protobuf" />
+        <PackageReference Include="System.ValueTuple" />
+        <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>
         <Protobuf Include="Protos.proto" GrpcServices="Server,Client" />

--- a/examples/RemoteActivate/Messages/Messages.csproj
+++ b/examples/RemoteActivate/Messages/Messages.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
@@ -10,8 +10,8 @@
     <None Include="Protos.proto" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/RemoteActivate/Node2/Node2.csproj
+++ b/examples/RemoteActivate/Node2/Node2.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -7,8 +7,8 @@
     <Content Include="runtimeconfig.template.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.7.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/Supervision/Supervision.csproj
+++ b/examples/Supervision/Supervision.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj"/>
+        <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,16 +17,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" PrivateAssets="All"/>
-        <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-        <PackageReference Include="Roslynator.Analyzers" Version="4.12.4">
+        <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
+        <PackageReference Include="MinVer" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+        <PackageReference Include="Roslynator.Analyzers">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="..\..\logo.png" Pack="true" PackagePath="\"/>
+        <None Include="..\..\logo.png" Pack="true" PackagePath="\" />
     </ItemGroup>
 </Project>

--- a/src/Proto.Actor/Proto.Actor.csproj
+++ b/src/Proto.Actor/Proto.Actor.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <NoWarn>8981</NoWarn>
         <RootNamespace>Proto</RootNamespace>
@@ -9,15 +9,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.28.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
-        <PackageReference Include="IsExternalInit.System.Runtime.CompilerServices" Version="1.0.0" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-        <PackageReference Include="System.Text.Json" Version="8.0.4" />
-        <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
+        <PackageReference Include="Google.Protobuf" />
+        <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+        <PackageReference Include="IsExternalInit.System.Runtime.CompilerServices" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="System.Collections.Immutable" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+        <PackageReference Include="System.Text.Json" />
+        <PackageReference Include="System.Threading.Channels" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Proto.Analyzers/Proto.Analyzers.csproj
+++ b/src/Proto.Analyzers/Proto.Analyzers.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Proto.Cluster.AmazonECS/Proto.Cluster.AmazonECS.csproj
+++ b/src/Proto.Cluster.AmazonECS/Proto.Cluster.AmazonECS.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.ECS" Version="3.7.402.10" />
-        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.8" />
+        <PackageReference Include="AWSSDK.ECS" />
+        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Proto.Cluster.AzureContainerApps/Proto.Cluster.AzureContainerApps.csproj
+++ b/src/Proto.Cluster.AzureContainerApps/Proto.Cluster.AzureContainerApps.csproj
@@ -4,10 +4,10 @@
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.12.0" />
-        <PackageReference Include="Azure.ResourceManager.AppContainers" Version="1.3.0" />
-        <PackageReference Include="Azure.ResourceManager.Resources" Version="1.8.0" />
-        <PackageReference Include="StackExchange.Redis" Version="2.8.12" />
+        <PackageReference Include="Azure.Identity" />
+        <PackageReference Include="Azure.ResourceManager.AppContainers" />
+        <PackageReference Include="Azure.ResourceManager.Resources" />
+        <PackageReference Include="StackExchange.Redis" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Proto.Cluster\Proto.Cluster.csproj" />

--- a/src/Proto.Cluster.CodeGen/Proto.Cluster.CodeGen.csproj
+++ b/src/Proto.Cluster.CodeGen/Proto.Cluster.CodeGen.csproj
@@ -21,18 +21,18 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Content Include="build\*" PackagePath="build\"/>
-        <Content Include="buildMultiTargeting\*" PackagePath="buildMultiTargeting\"/>
+        <Content Include="build\*" PackagePath="build\" />
+        <Content Include="buildMultiTargeting\*" PackagePath="buildMultiTargeting\" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Handlebars.Net" Version="2.0.9"/>
-        <PackageReference Include="protobuf-net" Version="3.2.30" />
-        <PackageReference Include="protobuf-net.Reflection" Version="3.2.12" />
-        <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4"/>
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4"/>
+        <PackageReference Include="Handlebars.Net" />
+        <PackageReference Include="protobuf-net" />
+        <PackageReference Include="protobuf-net.Reflection" />
+        <PackageReference Include="Microsoft.Build.Framework" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" />
         <!-- Marks all packages as 'local only' so they don't end up in the nuspec. -->
-        <PackageReference Update="@(PackageReference)" PrivateAssets="All"/>
+        <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
     </ItemGroup>
 
 

--- a/src/Proto.Cluster.Consul/Proto.Cluster.Consul.csproj
+++ b/src/Proto.Cluster.Consul/Proto.Cluster.Consul.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <LangVersion>10</LangVersion>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Consul" Version="1.7.14.4" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+        <PackageReference Include="Consul" />
+        <PackageReference Include="Microsoft.Extensions.Options" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Proto.Cluster\Proto.Cluster.csproj" />

--- a/src/Proto.Cluster.Dashboard/Proto.Cluster.Dashboard.csproj
+++ b/src/Proto.Cluster.Dashboard/Proto.Cluster.Dashboard.csproj
@@ -8,8 +8,8 @@
         <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Update="MinVer" Version="3.0.0" />
-        <PackageReference Include="MudBlazor" Version="6.21.0" />
+        
+        <PackageReference Include="MudBlazor" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Proto.Cluster.Identity.MongoDb/Proto.Cluster.Identity.MongoDb.csproj
+++ b/src/Proto.Cluster.Identity.MongoDb/Proto.Cluster.Identity.MongoDb.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
+        <PackageReference Include="MongoDB.Driver" />
 
     </ItemGroup>
 

--- a/src/Proto.Cluster.Identity.Redis/Proto.Cluster.Identity.Redis.csproj
+++ b/src/Proto.Cluster.Identity.Redis/Proto.Cluster.Identity.Redis.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="StackExchange.Redis" Version="2.6.66" />
+        <PackageReference Include="StackExchange.Redis" />
     </ItemGroup>
 
 </Project>

--- a/src/Proto.Cluster.Kubernetes/Proto.Cluster.Kubernetes.csproj
+++ b/src/Proto.Cluster.Kubernetes/Proto.Cluster.Kubernetes.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="JsonPatch.Net" Version="3.1.1" />
-        <PackageReference Include="KubernetesClient" Version="14.0.12" />
+        <PackageReference Include="JsonPatch.Net" />
+        <PackageReference Include="KubernetesClient" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Proto.Cluster.SeedNode.MongoDb/Proto.Cluster.SeedNode.MongoDb.csproj
+++ b/src/Proto.Cluster.SeedNode.MongoDb/Proto.Cluster.SeedNode.MongoDb.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
+        <PackageReference Include="MongoDB.Driver" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Proto.Cluster.SeedNode.Redis/Proto.Cluster.SeedNode.Redis.csproj
+++ b/src/Proto.Cluster.SeedNode.Redis/Proto.Cluster.SeedNode.Redis.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="StackExchange.Redis" Version="2.6.111" />
+      <PackageReference Include="StackExchange.Redis" />
     </ItemGroup>
 
 </Project>

--- a/src/Proto.Cluster.TestProvider/Proto.Cluster.TestProvider.csproj
+++ b/src/Proto.Cluster.TestProvider/Proto.Cluster.TestProvider.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <RootNamespace>Proto.Cluster.Consul</RootNamespace>
         <LangVersion>10</LangVersion>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Options" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Proto.Cluster\Proto.Cluster.csproj" />

--- a/src/Proto.Cluster/Proto.Cluster.csproj
+++ b/src/Proto.Cluster/Proto.Cluster.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <NoWarn>8981</NoWarn>
         <IsPackable>true</IsPackable>
@@ -7,7 +7,7 @@
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
+        <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Proto.Remote\Proto.Remote.csproj" />

--- a/src/Proto.OpenTelemetry/Proto.OpenTelemetry.csproj
+++ b/src/Proto.OpenTelemetry/Proto.OpenTelemetry.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry" Version="1.9.0" />
-        <PackageReference Include="OpenTelemetry.Api" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry" />
+        <PackageReference Include="OpenTelemetry.Api" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Proto.Actor\Proto.Actor.csproj" />

--- a/src/Proto.Persistence.Couchbase/Proto.Persistence.Couchbase.csproj
+++ b/src/Proto.Persistence.Couchbase/Proto.Persistence.Couchbase.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="CouchbaseNetClient" Version="2.7.22" />
+        <PackageReference Include="CouchbaseNetClient" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Proto.Persistence\Proto.Persistence.csproj" />

--- a/src/Proto.Persistence.DynamoDB/Proto.Persistence.DynamoDB.csproj
+++ b/src/Proto.Persistence.DynamoDB/Proto.Persistence.DynamoDB.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.400.16" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Proto.Persistence\Proto.Persistence.csproj" />

--- a/src/Proto.Persistence.Marten/Proto.Persistence.Marten.csproj
+++ b/src/Proto.Persistence.Marten/Proto.Persistence.Marten.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Marten" Version="7.27.0" />
+        <PackageReference Include="Marten" />
 
     </ItemGroup>
     <ItemGroup>

--- a/src/Proto.Persistence.MongoDB/Proto.Persistence.MongoDB.csproj
+++ b/src/Proto.Persistence.MongoDB/Proto.Persistence.MongoDB.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
+        <PackageReference Include="MongoDB.Driver" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Proto.Persistence\Proto.Persistence.csproj" />

--- a/src/Proto.Persistence.RavenDB/Proto.Persistence.RavenDB.csproj
+++ b/src/Proto.Persistence.RavenDB/Proto.Persistence.RavenDB.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="RavenDB.Client" Version="6.0.105" />
+        <PackageReference Include="RavenDB.Client" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Proto.Persistence\Proto.Persistence.csproj" />

--- a/src/Proto.Persistence.SqlServer/Proto.Persistence.SqlServer.csproj
+++ b/src/Proto.Persistence.SqlServer/Proto.Persistence.SqlServer.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+        <PackageReference Include="Newtonsoft.Json" />
+        <PackageReference Include="Microsoft.Data.SqlClient" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Proto.Persistence\Proto.Persistence.csproj" />

--- a/src/Proto.Persistence.Sqlite/Proto.Persistence.Sqlite.csproj
+++ b/src/Proto.Persistence.Sqlite/Proto.Persistence.Sqlite.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.8" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Microsoft.Data.Sqlite" />
+        <PackageReference Include="Newtonsoft.Json" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Proto.Persistence\Proto.Persistence.csproj" />

--- a/src/Proto.Remote/Proto.Remote.csproj
+++ b/src/Proto.Remote/Proto.Remote.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <NoWarn>8981</NoWarn>
         <IsPackable>true</IsPackable>
@@ -8,12 +8,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Grpc.AspNetCore" Version="2.65.0" />
-        <PackageReference Include="Grpc.Core.Api" Version="2.65.0" />
-        <PackageReference Include="Grpc.HealthCheck" Version="2.65.0" />
-        <PackageReference Include="Grpc.Net.Common" Version="2.65.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
-        <PackageReference Include="System.Text.Json" Version="8.0.4" />
+        <PackageReference Include="Grpc.AspNetCore" />
+        <PackageReference Include="Grpc.Core.Api" />
+        <PackageReference Include="Grpc.HealthCheck" />
+        <PackageReference Include="Grpc.Net.Common" />
+        <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+        <PackageReference Include="System.Text.Json" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Proto.Actor\Proto.Actor.csproj" />

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -8,16 +8,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1"/>
-        <PackageReference Include="FluentAssertions" Version="6.12.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
+        <PackageReference Include="AutoFixture.Xunit2" />
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio" />
+        <PackageReference Include="GitHubActionsTestLogger">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Roslynator.Analyzers" Version="4.12.4">
+        <PackageReference Include="Roslynator.Analyzers">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/tests/Proto.Analyzers.Tests/Proto.Analyzers.Tests.csproj
+++ b/tests/Proto.Analyzers.Tests/Proto.Analyzers.Tests.csproj
@@ -8,10 +8,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" />
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/Proto.Cluster.CodeGen.Tests/Proto.Cluster.CodeGen.Tests.csproj
+++ b/tests/Proto.Cluster.CodeGen.Tests/Proto.Cluster.CodeGen.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Handlebars.Net" Version="2.0.9" />
-        <PackageReference Include="protobuf-net.Reflection" Version="3.2.12" />
+        <PackageReference Include="Handlebars.Net" />
+        <PackageReference Include="protobuf-net.Reflection" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Proto.Cluster.Identity.Tests/Proto.Cluster.Identity.Tests.csproj
+++ b/tests/Proto.Cluster.Identity.Tests/Proto.Cluster.Identity.Tests.csproj
@@ -13,7 +13,7 @@
         <ProjectReference Include="..\Proto.TestFixtures\Proto.TestFixtures.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Neovolve.Logging.Xunit" Version="6.1.0" />
+        <PackageReference Include="Neovolve.Logging.Xunit" />
     </ItemGroup>
     <ItemGroup>
         <None Update="*.json" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />

--- a/tests/Proto.Cluster.MongoIdentity.Tests/Proto.Cluster.MongoIdentity.Tests.csproj
+++ b/tests/Proto.Cluster.MongoIdentity.Tests/Proto.Cluster.MongoIdentity.Tests.csproj
@@ -14,7 +14,7 @@
         <ProjectReference Include="..\Proto.TestFixtures\Proto.TestFixtures.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Neovolve.Logging.Xunit" Version="6.1.0" />
+        <PackageReference Include="Neovolve.Logging.Xunit" />
     </ItemGroup>
     <ItemGroup>
         <None Update="*.json" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />

--- a/tests/Proto.Cluster.PartitionIdentity.Tests/Proto.Cluster.PartitionIdentity.Tests.csproj
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/Proto.Cluster.PartitionIdentity.Tests.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
 
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj
+++ b/tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj
@@ -13,12 +13,12 @@
         <ProjectReference Include="..\..\src\Proto.Remote\Proto.Remote.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
-        <PackageReference Include="IsExternalInit.System.Runtime.CompilerServices" Version="1.0.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.5.1" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+        <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+        <PackageReference Include="IsExternalInit.System.Runtime.CompilerServices" />
+        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
 
-        <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
+        <PackageReference Include="System.Interactive.Async" />
     </ItemGroup>
     <ItemGroup>
         <Protobuf Include="*.proto" />

--- a/tests/Proto.OpenTelemetry.Tests/Proto.OpenTelemetry.Tests.csproj
+++ b/tests/Proto.OpenTelemetry.Tests/Proto.OpenTelemetry.Tests.csproj
@@ -9,13 +9,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Grpc.Tools" Version="2.66.0">
+        <PackageReference Include="Grpc.Tools">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="OpenTelemetry" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry" />
         
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/Proto.Persistence.Tests/ContainersFixture.cs
+++ b/tests/Proto.Persistence.Tests/ContainersFixture.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading.Tasks;
+using Testcontainers.MongoDb;
+using Testcontainers.MsSql;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Proto.Persistence.Tests;
+
+public class ContainersFixture : IAsyncLifetime
+{
+    private const int InitialState = 1;
+
+    private readonly PostgreSqlContainer _postgreSqlContainer = new PostgreSqlBuilder()
+        .WithDatabase("IntegrationTests")
+        .WithUsername("postgres")
+        .WithPassword("root")
+        .WithCommand(new[] { "-c", "log_statement=all" })
+        .Build();
+
+    readonly MsSqlContainer _msSqlContainer = new MsSqlBuilder()
+        .Build();
+
+    readonly MongoDbContainer _mongoDbContainer = new MongoDbBuilder()
+        .Build();
+
+    public PostgreSqlContainer Postgres => _postgreSqlContainer;
+
+    public MsSqlContainer MsSql => _msSqlContainer;
+
+    public MongoDbContainer MongoDb => _mongoDbContainer;
+
+    public Task InitializeAsync() =>
+        Task.WhenAll(
+            _postgreSqlContainer.StartAsync(),
+            _msSqlContainer.StartAsync(),
+            _mongoDbContainer.StartAsync()
+        );
+
+    public Task DisposeAsync() =>
+        Task.WhenAll(
+            _postgreSqlContainer.StopAsync(),
+            _msSqlContainer.StopAsync(),
+            _mongoDbContainer.StopAsync()
+        );
+}

--- a/tests/Proto.Persistence.Tests/Proto.Persistence.Tests.csproj
+++ b/tests/Proto.Persistence.Tests/Proto.Persistence.Tests.csproj
@@ -1,17 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <LangVersion>10</LangVersion>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Testcontainers" Version="3.10.0" />
-        <PackageReference Include="Testcontainers.PostgreSql" Version="3.10.0" />
-        <PackageReference Include="Testcontainers.CouchDb" Version="3.10.0" />
-        <PackageReference Include="Testcontainers.MsSql" Version="3.10.0" />
-        <PackageReference Include="Testcontainers.DynamoDb" Version="3.10.0" />
-        <PackageReference Include="Testcontainers.RavenDb" Version="3.10.0" />
-        <PackageReference Include="Testcontainers.MongoDb" Version="3.10.0" />
+        <PackageReference Include="Newtonsoft.Json" />
+        <PackageReference Include="Testcontainers" />
+        <PackageReference Include="Testcontainers.PostgreSql" />
+        <PackageReference Include="Testcontainers.CouchDb" />
+        <PackageReference Include="Testcontainers.MsSql" />
+        <PackageReference Include="Testcontainers.DynamoDb" />
+        <PackageReference Include="Testcontainers.RavenDb" />
+        <PackageReference Include="Testcontainers.MongoDb" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\Proto.Persistence.Couchbase\Proto.Persistence.Couchbase.csproj" />

--- a/tests/Proto.Remote.Tests.Messages/Proto.Remote.Tests.Messages.csproj
+++ b/tests/Proto.Remote.Tests.Messages/Proto.Remote.Tests.Messages.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <NoWarn>8981</NoWarn>
         <IsTestProject>false</IsTestProject>
@@ -6,7 +6,7 @@
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
+        <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Remove="AutoFixture.Xunit2" />

--- a/tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj
+++ b/tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <LangVersion>10</LangVersion>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Neovolve.Logging.Xunit" Version="6.1.0" />
+        <PackageReference Include="Neovolve.Logging.Xunit" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\Proto.Remote\Proto.Remote.csproj" />

--- a/tests/Proto.TestFixtures/Proto.TestFixtures.csproj
+++ b/tests/Proto.TestFixtures/Proto.TestFixtures.csproj
@@ -1,21 +1,21 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <IsTestProject>false</IsTestProject>
         <LangVersion>10</LangVersion>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Remove="AutoFixture.Xunit2"/>
-        <PackageReference Remove="FluentAssertions"/>
-        <PackageReference Remove="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Remove="xunit"/>
-        <PackageReference Remove="xunit.runner.visualstudio"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>
+        <PackageReference Remove="AutoFixture.Xunit2" />
+        <PackageReference Remove="FluentAssertions" />
+        <PackageReference Remove="Microsoft.NET.Test.Sdk" />
+        <PackageReference Remove="xunit" />
+        <PackageReference Remove="xunit.runner.visualstudio" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj"/>
+        <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj" />
     </ItemGroup>
 </Project>

--- a/tests/Proto.TestKit.Tests/Proto.TestKit.Tests.csproj
+++ b/tests/Proto.TestKit.Tests/Proto.TestKit.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>9</LangVersion>
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup>
 
-    <PackageReference Update="FluentAssertions" Version="6.1.0" />
+    
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

This migrates the repository to centralized package management, avoiding the overhead of needing to change versions in every csproj when bumping versions.

I also rewrote the persistence tests to use fixtures, since the existing tests were needlessly slow ( instantiating all providers per run of each test ). 90 mins -> 1 min on my machine. One broken test (CanUseSeparateStores), but that was not adressed.

Out of date dependencies were updated.