### PR TITLE
Persistence.cs use callback with index

### DIFF
--- a/benchmarks/GossipBenchmark/Node1/Program.cs
+++ b/benchmarks/GossipBenchmark/Node1/Program.cs
@@ -11,12 +11,9 @@ using Proto;
 using Proto.Cluster;
 using Proto.Cluster.Consul;
 using Proto.Cluster.Partition;
-using Proto.Cluster.Seed;
-using Proto.Cluster.SeedNode.Redis;
 using Proto.Context;
 using Proto.Remote;
 using Proto.Remote.GrpcNet;
-using StackExchange.Redis;
 using static Proto.CancellationTokens;
 using ProtosReflection = ClusterHelloWorld.Messages.ProtosReflection;
 

--- a/benchmarks/GossipBenchmark/Node2/Program.cs
+++ b/benchmarks/GossipBenchmark/Node2/Program.cs
@@ -11,12 +11,9 @@ using Proto;
 using Proto.Cluster;
 using Proto.Cluster.Consul;
 using Proto.Cluster.Partition;
-using Proto.Cluster.Seed;
-using Proto.Cluster.SeedNode.Redis;
 using Proto.Context;
 using Proto.Remote;
 using Proto.Remote.GrpcNet;
-using StackExchange.Redis;
 using static System.Threading.Tasks.Task;
 using ProtosReflection = ClusterHelloWorld.Messages.ProtosReflection;
 

--- a/benchmarks/GossipDecoder/Program.cs
+++ b/benchmarks/GossipDecoder/Program.cs
@@ -1,8 +1,6 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
-using System.Runtime.InteropServices.JavaScript;
 using Google.Protobuf;
-using Google.Protobuf.WellKnownTypes;
 using Proto.Cluster;
 
 Console.WriteLine("Hello, World!");

--- a/benchmarks/SkyriseMini/Client/ProtoActorExtensions.cs
+++ b/benchmarks/SkyriseMini/Client/ProtoActorExtensions.cs
@@ -1,6 +1,3 @@
-using System.IO.Compression;
-using Grpc.Net.Client;
-using Grpc.Net.Compression;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/benchmarks/SkyriseMini/Server/ProtoActorExtensions.cs
+++ b/benchmarks/SkyriseMini/Server/ProtoActorExtensions.cs
@@ -1,14 +1,10 @@
-﻿using System.IO.Compression;
-using Grpc.Net.Client;
-using Grpc.Net.Compression;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Proto;
 using Proto.Cluster;
 using Proto.Cluster.Consul;
 using Proto.Cluster.Partition;
-using Proto.Cluster.PartitionActivator;
 using Proto.DependencyInjection;
 using Proto.Remote;
 using Proto.Remote.GrpcNet;

--- a/examples/ClusterK8sGrains/Node1/Program.cs
+++ b/examples/ClusterK8sGrains/Node1/Program.cs
@@ -18,8 +18,6 @@ using Proto.Remote.GrpcNet;
 using static Proto.CancellationTokens;
 using ProtosReflection = ClusterHelloWorld.Messages.ProtosReflection;
 using System.Runtime.Loader;
-using Microsoft.Extensions.Configuration;
-using Extensions = Proto.Remote.GrpcNet.Extensions;
 
 // Hook SIGTERM to a cancel token to know when k8s is shutting us down
 // hostBuilder should be used in production

--- a/examples/ClusterK8sGrains/Node2/Program.cs
+++ b/examples/ClusterK8sGrains/Node2/Program.cs
@@ -9,7 +9,6 @@ using System.Runtime.Loader;
 using System.Threading.Tasks;
 using System.Threading;
 using ClusterHelloWorld.Messages;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Proto;
 using Proto.Cluster;

--- a/examples/Patterns/Saga/InMemoryProvider.cs
+++ b/examples/Patterns/Saga/InMemoryProvider.cs
@@ -21,13 +21,13 @@ public class InMemoryProvider : IProvider
     public Task<(object Snapshot, long Index)> GetSnapshotAsync(string actorName) =>
         Task.FromResult(((object)default(Snapshot), 0L));
 
-    public Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+    public Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object, long> callback)
     {
         if (Events.TryGetValue(actorName, out var events))
         {
             foreach (var e in events.Where(e => e.Key >= indexStart && e.Key <= indexEnd))
             {
-                callback(e.Value);
+                callback(e.Value, e.Key);
             }
         }
 

--- a/examples/Proto.Cluster.Dashboard.Host/Program.cs
+++ b/examples/Proto.Cluster.Dashboard.Host/Program.cs
@@ -1,12 +1,7 @@
-using Google.Protobuf.WellKnownTypes;
 using MudBlazor.Services;
-using Proto;
 using Proto.Cluster;
 using Proto.Cluster.Dashboard;
-using Proto.Cluster.Partition;
-using Proto.Cluster.Seed;
 using Proto.Remote;
-using Proto.Remote.GrpcNet;
 using Proto.Remote.HealthChecks;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/examples/remotechannels/Client/Program.cs
+++ b/examples/remotechannels/Client/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using Common;
 using Proto;
 using Proto.Remote;

--- a/src/Proto.Actor/Configuration/ActorSystemConfig.cs
+++ b/src/Proto.Actor/Configuration/ActorSystemConfig.cs
@@ -5,13 +5,9 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using Proto.Context;
-using Proto.Extensions;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 // ReSharper disable once CheckNamespace

--- a/src/Proto.Actor/Extensions/IActorSystemExtension.cs
+++ b/src/Proto.Actor/Extensions/IActorSystemExtension.cs
@@ -4,9 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System;
 using System.Threading;
-using System.Threading.Tasks;
 using Proto.Diagnostics;
 
 namespace Proto.Extensions;

--- a/src/Proto.Actor/Process/Process.cs
+++ b/src/Proto.Actor/Process/Process.cs
@@ -6,8 +6,6 @@
 
 // ReSharper disable once CheckNamespace
 
-using System;
-using System.Threading.Tasks;
 using Proto.Mailbox;
 
 namespace Proto;

--- a/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
+++ b/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;

--- a/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Proto.Cluster/Seed/FixedServerSeedNodeDiscovery.cs
+++ b/src/Proto.Cluster/Seed/FixedServerSeedNodeDiscovery.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Proto.Cluster.SingleNode;
 
 namespace Proto.Cluster.Seed;
 

--- a/src/Proto.Cluster/Seed/SeedNodeClusterProviderOptions.cs
+++ b/src/Proto.Cluster/Seed/SeedNodeClusterProviderOptions.cs
@@ -4,8 +4,6 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System.Collections.Immutable;
-
 namespace Proto.Cluster.Seed;
 
 public record SeedNodeClusterProviderOptions(ISeedNodeDiscovery Discovery);

--- a/src/Proto.Cluster/ServiceCollectionExtensions.cs
+++ b/src/Proto.Cluster/ServiceCollectionExtensions.cs
@@ -3,10 +3,8 @@ using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Proto.Cluster;
 using Proto.Cluster.Identity;
 using Proto.Cluster.Partition;
-using Proto.Cluster.Seed;
 using Proto.DependencyInjection;
 using Proto.Remote.GrpcNet;
 

--- a/src/Proto.OpenTelemetry/OpenTelemetryRootContextDecorator.cs
+++ b/src/Proto.OpenTelemetry/OpenTelemetryRootContextDecorator.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Proto.Persistence.Couchbase/CouchbaseProvider.cs
+++ b/src/Proto.Persistence.Couchbase/CouchbaseProvider.cs
@@ -21,7 +21,7 @@ public class CouchbaseProvider : IProvider
         _bucket = bucket;
     }
 
-    public Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+    public Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object, long> callback)
     {
         var query = GenerateGetEventsQuery(actorName, indexStart, indexEnd);
 
@@ -105,7 +105,7 @@ public class CouchbaseProvider : IProvider
         $"AND b.eventIndex <= {indexEnd} " +
         "ORDER BY b.eventIndex ASC";
 
-    private async Task<long> ExecuteGetEventsQueryAsync(string query, Action<object> callback)
+    private async Task<long> ExecuteGetEventsQueryAsync(string query, Action<object, long> callback)
     {
         var req = QueryRequest.Create(query);
 
@@ -119,7 +119,7 @@ public class CouchbaseProvider : IProvider
 
         foreach (var @event in events)
         {
-            callback(@event.Data);
+            callback(@event.Data, @event.EventIndex);
         }
 
         return events.LastOrDefault()?.EventIndex ?? -1;

--- a/src/Proto.Persistence.Marten/MartenProvider.cs
+++ b/src/Proto.Persistence.Marten/MartenProvider.cs
@@ -14,7 +14,7 @@ public class MartenProvider : IProvider
         _store = store;
     }
 
-    public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+    public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object, long> callback)
     {
         var session = _store.IdentitySession();
         await using var _ = session.ConfigureAwait(false);
@@ -27,7 +27,7 @@ public class MartenProvider : IProvider
 
         foreach (var @event in events)
         {
-            callback(@event.Data);
+            callback(@event.Data, @event.Index);
         }
 
         return events.LastOrDefault()?.Index ?? -1;

--- a/src/Proto.Persistence.MongoDB/MongoDBProvider.cs
+++ b/src/Proto.Persistence.MongoDB/MongoDBProvider.cs
@@ -25,7 +25,7 @@ public class MongoDBProvider : IProvider
 
     private IMongoCollection<Snapshot> SnapshotCollection => _mongoDB.GetCollection<Snapshot>("snapshots");
 
-    public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+    public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object, long> callback)
     {
         var sort = Builders<Event>.Sort.Ascending("EventIndex");
 
@@ -36,7 +36,7 @@ public class MongoDBProvider : IProvider
 
         foreach (var @event in events)
         {
-            callback(@event.Data);
+            callback(@event.Data, @event.EventIndex);
         }
 
         return events.Any() ? events.Last().EventIndex : -1;

--- a/src/Proto.Persistence.RavenDB/RavenDBProvider.cs
+++ b/src/Proto.Persistence.RavenDB/RavenDBProvider.cs
@@ -18,7 +18,7 @@ public class RavenDBProvider : IProvider
         SetupIndexes();
     }
 
-    public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+    public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object, long> callback)
     {
         using var session = _store.OpenAsyncSession();
 
@@ -30,7 +30,7 @@ public class RavenDBProvider : IProvider
 
         foreach (var @event in events)
         {
-            callback(@event.Data);
+            callback(@event.Data, @event.Index);
         }
 
         return events.LastOrDefault()?.Index ?? -1;

--- a/src/Proto.Persistence.SqlServer/SqlServerProvider.cs
+++ b/src/Proto.Persistence.SqlServer/SqlServerProvider.cs
@@ -82,7 +82,7 @@ public class SqlServerProvider : IProvider
             CreateParameter("SnapshotIndex", BigInt, inclusiveToIndex)
         );
 
-    public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+    public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object, long> callback)
     {
         await using var connection = new SqlConnection(_connectionString);
 
@@ -107,7 +107,7 @@ public class SqlServerProvider : IProvider
         {
             lastIndex = (long)eventReader["EventIndex"];
 
-            callback(JsonConvert.DeserializeObject<object>(eventReader["EventData"].ToString(), AutoTypeSettings));
+            callback(JsonConvert.DeserializeObject<object>(eventReader["EventData"].ToString(), AutoTypeSettings), lastIndex);
         }
 
         return lastIndex;

--- a/src/Proto.Persistence.Sqlite/SqliteProvider.cs
+++ b/src/Proto.Persistence.Sqlite/SqliteProvider.cs
@@ -72,7 +72,7 @@ public class SqliteProvider : IProvider
         await deleteCommand.ExecuteNonQueryAsync().ConfigureAwait(false);
     }
 
-    public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+    public async Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object, long> callback)
     {
         using var connection = new SqliteConnection(ConnectionString);
 
@@ -92,9 +92,10 @@ public class SqliteProvider : IProvider
 
         while (await reader.ReadAsync().ConfigureAwait(false))
         {
-            indexes.Add(Convert.ToInt64(reader["EventIndex"]));
+            var index = Convert.ToInt64(reader["EventIndex"]);
+            indexes.Add(index);
 
-            callback(JsonConvert.DeserializeObject<object>(reader["EventData"].ToString(), AutoTypeSettings));
+            callback(JsonConvert.DeserializeObject<object>(reader["EventData"].ToString(), AutoTypeSettings), index);
         }
 
         return indexes.Any() ? indexes.LastOrDefault() : -1;

--- a/src/Proto.Persistence/IProvider.cs
+++ b/src/Proto.Persistence/IProvider.cs
@@ -55,7 +55,7 @@ public interface IEventStore
     /// <param name="indexEnd">Index of the last event to get (inclusive)</param>
     /// <param name="callback">A callback which should be called for each read event, in the order the events are stored</param>
     /// <returns>Index of the last read event or -1 if none</returns>
-    Task<long> GetEventsAsync(string actorId, long indexStart, long indexEnd, Action<object> callback);
+    Task<long> GetEventsAsync(string actorId, long indexStart, long indexEnd, Action<object, long> callback);
 
     /// <summary>
     ///     Writes an event to event stream of particular actor

--- a/src/Proto.Persistence/Persistence.cs
+++ b/src/Proto.Persistence/Persistence.cs
@@ -230,10 +230,10 @@ public class Persistence
             _actorId,
             fromEventIndex,
             long.MaxValue,
-            @event =>
+            (@event, index) =>
             {
-                Index++;
-                _applyEvent?.Invoke(new RecoverEvent(@event, Index));
+                Index = index;
+                _applyEvent?.Invoke(new RecoverEvent(@event, index));
             }
         ).ConfigureAwait(false);
     }
@@ -260,10 +260,10 @@ public class Persistence
             _actorId,
             fromIndex,
             toIndex,
-            @event =>
+            (@event, index) =>
             {
-                _applyEvent?.Invoke(new ReplayEvent(@event, Index));
-                Index++;
+                _applyEvent?.Invoke(new ReplayEvent(@event, index));
+                Index=index;
             }
         ).ConfigureAwait(false);
     }
@@ -339,7 +339,7 @@ public class Persistence
     private class NoEventStore : IEventStore
     {
         public Task<long>
-            GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback) =>
+            GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object, long> callback) =>
             Task.FromResult(-1L);
 
         public Task<long> PersistEventAsync(string actorName, long index, object @event) => Task.FromResult(0L);

--- a/tests/Proto.Analyzers.Tests/AnalyzerTest.cs
+++ b/tests/Proto.Analyzers.Tests/AnalyzerTest.cs
@@ -2,7 +2,6 @@
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.CSharp.Testing.XUnit;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace Proto.Analyzers.Tests;
 

--- a/tests/Proto.Analyzers.Tests/CodeFixProviderTests.cs
+++ b/tests/Proto.Analyzers.Tests/CodeFixProviderTests.cs
@@ -2,7 +2,6 @@
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace Proto.Analyzers.Tests;
 

--- a/tests/Proto.Cluster.Tests/OrderedDeliveryTests.cs
+++ b/tests/Proto.Cluster.Tests/OrderedDeliveryTests.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using ClusterTest.Messages;
 using FluentAssertions;
-using Proto.Utils;
 using Xunit;
 
 namespace Proto.Cluster.Tests;

--- a/tests/Proto.Persistence.Tests/InMemoryProvider.cs
+++ b/tests/Proto.Persistence.Tests/InMemoryProvider.cs
@@ -31,7 +31,7 @@ public class InMemoryProvider : IProvider
         return Task.FromResult((snapshot.Value, snapshot.Key));
     }
 
-    public Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object> callback)
+    public Task<long> GetEventsAsync(string actorName, long indexStart, long indexEnd, Action<object, long> callback)
     {
         var lastIndex = 0L;
 
@@ -40,7 +40,7 @@ public class InMemoryProvider : IProvider
             foreach (var e in events.Where(e => e.Key >= indexStart && e.Key <= indexEnd))
             {
                 lastIndex = e.Key;
-                callback(e.Value);
+                callback(e.Value, e.Key);
             }
         }
 

--- a/tests/Proto.Persistence.Tests/PersistenceWithSnapshotStrategiesTests.cs
+++ b/tests/Proto.Persistence.Tests/PersistenceWithSnapshotStrategiesTests.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Marten;
-using Proto.Persistence.Marten;
 using Proto.Persistence.SnapshotStrategies;
 using Xunit;
 


### PR DESCRIPTION
At times certain persistence options don't allow you to delete an event and a common way to deal with this is to read the stream in memory, delete the stream, remove the desired event, and persist the stream. Some storages such as SQL or EventStoreDB will continue the index count from where it left resulting quite often in version conflicts. Rewriting this to use an Index in the callback can fix this bug/issue/inconvenience

## Description

<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
