### PR TITLE
OTel ActorContextDecorator should support all ReenterAfter overloads

### DIFF
--- a/src/Proto.Actor/Context/ActorContextDecorator.cs
+++ b/src/Proto.Actor/Context/ActorContextDecorator.cs
@@ -65,11 +65,11 @@ public abstract class ActorContextDecorator : IContext
 
     public virtual void ReenterAfter(Task target, Action action) => _context.ReenterAfter(target, action);
 
-    public void ReenterAfter(Task target, Action<Task> action) => _context.ReenterAfter(target, action);
+    public virtual void ReenterAfter(Task target, Action<Task> action) => _context.ReenterAfter(target, action);
 
-    public void ReenterAfter<T>(Task<T> target, Action<Task<T>> action) => _context.ReenterAfter(target, action);
+    public virtual void ReenterAfter<T>(Task<T> target, Action<Task<T>> action) => _context.ReenterAfter(target, action);
 
-    public void ReenterAfter(Task target, Func<Task, Task> action) => _context.ReenterAfter(target, action);
+    public virtual void ReenterAfter(Task target, Func<Task, Task> action) => _context.ReenterAfter(target, action);
 
     public CapturedContext Capture() => _context.Capture();
 


### PR DESCRIPTION
## Description

Currently only 2 of the 5 overloads for ReenterAfter is supported by the OpenTelemetryActorContextDecorator. This causes telemetry to be lost when using the unsupported variants.

We encountered problems with our system where we had to manually re-set the Baggage, because we called one of the unsupported ReenterAfter overloads. With this fix it should mean we don't have to do this anymore.

I have added tests that cover each of the overloads (expectedly 3 out of 5 failed before the fix).

Suggestions for naming and improvements to the tests are welcome, I just made the simplest tests i could think of to test the problem.

However since I am making changes to the ActorContextDecorator base class, it may have implications for all other decorators. It might be necessary to take a look and see if those need updating to make sure they implement the missing overloads too.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
