### PR TITLE
Fix - Under load and during topology changes, thread saturation can occur, causing a lockup

### DIFF
--- a/ProtoActor.sln
+++ b/ProtoActor.sln
@@ -307,6 +307,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "template", "template", "{08
 		examples\ClusterK8sGrains\chart\templates\protoactor-k8s-grains-serviceaccount.yaml = examples\ClusterK8sGrains\chart\templates\protoactor-k8s-grains-serviceaccount.yaml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EndpointManagerTest", "benchmarks\EndpointManagerTest\EndpointManagerTest.csproj", "{B7258689-41D2-4284-AF93-050DD1DFEAC4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1481,6 +1483,18 @@ Global
 		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Release|x64.Build.0 = Release|Any CPU
 		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Release|x86.ActiveCfg = Release|Any CPU
 		{B196FBFE-0DAA-4533-9A56-BB5826A57923}.Release|x86.Build.0 = Release|Any CPU
+		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Debug|x64.Build.0 = Debug|Any CPU
+		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Debug|x86.Build.0 = Debug|Any CPU
+		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Release|x64.ActiveCfg = Release|Any CPU
+		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Release|x64.Build.0 = Release|Any CPU
+		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Release|x86.ActiveCfg = Release|Any CPU
+		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1616,6 +1630,7 @@ Global
 		{B196FBFE-0DAA-4533-9A56-BB5826A57923} = {ADE7A14E-FFE9-4137-AC25-E2F2A82B0A8C}
 		{CDCE3D4C-1BDD-460F-93B8-75123A258183} = {ADE7A14E-FFE9-4137-AC25-E2F2A82B0A8C}
 		{087E5441-1582-4D55-8233-014C0FB06FF0} = {CDCE3D4C-1BDD-460F-93B8-75123A258183}
+		{B7258689-41D2-4284-AF93-050DD1DFEAC4} = {0F3AB331-C042-4371-A2F0-0AFDFA13DC9F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD0D1E44-8118-4682-8793-6B20ABFA824C}

--- a/benchmarks/EndpointManagerTest/Dockerfile
+++ b/benchmarks/EndpointManagerTest/Dockerfile
@@ -1,0 +1,23 @@
+﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+USER $APP_UID
+WORKDIR /app
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["benchmarks/EndpointManagerTest/EndpointManagerTest.csproj", "benchmarks/EndpointManagerTest/"]
+COPY ["src/Proto.Actor/Proto.Actor.csproj", "src/Proto.Actor/"]
+COPY ["src/Proto.Remote/Proto.Remote.csproj", "src/Proto.Remote/"]
+RUN dotnet restore "benchmarks/EndpointManagerTest/EndpointManagerTest.csproj"
+COPY . .
+WORKDIR "/src/benchmarks/EndpointManagerTest"
+RUN dotnet build "EndpointManagerTest.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "EndpointManagerTest.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "EndpointManagerTest.dll"]

--- a/benchmarks/EndpointManagerTest/EndpointManagerTest.csproj
+++ b/benchmarks/EndpointManagerTest/EndpointManagerTest.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj" />
+		<ProjectReference Include="..\..\src\Proto.Remote\Proto.Remote.csproj" />
+	</ItemGroup>
+	
+</Project>

--- a/benchmarks/EndpointManagerTest/EndpointManagerTest.csproj
+++ b/benchmarks/EndpointManagerTest/EndpointManagerTest.csproj
@@ -5,11 +5,18 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj" />
 		<ProjectReference Include="..\..\src\Proto.Remote\Proto.Remote.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <Content Include="..\..\.dockerignore">
+	    <Link>.dockerignore</Link>
+	  </Content>
 	</ItemGroup>
 	
 </Project>

--- a/benchmarks/EndpointManagerTest/Program.cs
+++ b/benchmarks/EndpointManagerTest/Program.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.Extensions.Logging;
+using Proto;
+using Proto.Remote;
+using Proto.Remote.GrpcNet;
+
+namespace EndpointManagerTest;
+
+class Program
+{
+	private static async Task Main()
+	{
+		Log.SetLoggerFactory(
+			LoggerFactory.Create(
+				c =>
+					c.SetMinimumLevel(LogLevel.Debug)
+						.AddFilter("Microsoft", LogLevel.None)
+						.AddFilter("Grpc", LogLevel.None)
+						.AddFilter("Proto.Context.ActorContext", LogLevel.Information)
+						.AddFilter("Proto.Remote.ServerConnector", LogLevel.Error)
+						.AddSimpleConsole(o => o.SingleLine = true)
+			)
+		);
+		
+		var logger = Log.CreateLogger("Main");
+		
+		var sys1 = new ActorSystem().WithRemote(GrpcNetRemoteConfig.BindTo("localhost", 12000).WithRemoteKind("noop", Props.FromProducer(() => new NoopActor())));
+		await sys1.Remote().StartAsync();
+		
+		var sys2 = new ActorSystem().WithRemote(GrpcNetRemoteConfig.BindTo("localhost", 12001).WithRemoteKind("noop", Props.FromProducer(() => new NoopActor())));
+		await sys2.Remote().StartAsync();
+		
+		var echoActorOn2 = (await sys1.Remote().SpawnAsync("localhost:12001", "noop", TimeSpan.FromSeconds(1))).Pid;
+		_ = Task.Factory.StartNew(async () =>
+		{
+			while (true)
+			{
+				_ = sys1.Root.RequestAsync<Touched>(echoActorOn2, new Touch());
+			}
+		});
+		
+		var echoActorOn1 = (await sys2.Remote().SpawnAsync("localhost:12000", "noop", TimeSpan.FromSeconds(1))).Pid;
+		_ = Task.Factory.StartNew(async () =>
+		{
+			while (true)
+			{
+				_ = sys2.Root.RequestAsync<Touched>(echoActorOn1, new Touch());
+			}
+		});
+		
+		await Task.Delay(3000);
+		
+		sys1.EventStream.Publish(new EndpointTerminatedEvent(false, "localhost:12001", null));
+		
+		var port = 12002;
+		for (var i = 12002; i < 12012; i++)
+		{
+			//logger.LogInformation("Touching {i}", i);
+			_ = sys1.Root.RequestAsync<Touched>(new PID($"localhost:{i}", "$1"), new Touch());
+		}
+		
+		while (true)
+		{
+			//logger.LogInformation("End");
+			await Task.Delay(1000);
+		}
+	}
+}
+
+public class NoopActor : IActor
+{	
+	public async Task ReceiveAsync(IContext context)
+	{
+	}
+}

--- a/benchmarks/EndpointManagerTest/Program.cs
+++ b/benchmarks/EndpointManagerTest/Program.cs
@@ -1,10 +1,27 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Diagnostics;
+using Microsoft.Extensions.Logging;
 using Proto;
 using Proto.Remote;
 using Proto.Remote.GrpcNet;
 
 namespace EndpointManagerTest;
 
+// This program tests lockup issues with the EndpointManager.
+// TL:DR; This is to demonstrate the issue with the locking and blocking waits in EndpointManager, and to confirm the fix.
+//
+// This recreates a scenario we were seeing in our production environments. 
+// What we saw was 30 cluster clients were sending many messages to 2 of the cluster members, who were sending messages to eachother depending
+// on actor placement. If something happens and the 2 members had to reboot, they would end up locking up, not being able to do anything.
+// This scenario has been recreated more simply here, where you have 2 members sending many messages back and forth, a disconnect comes through
+// from a member that recently restarted, and new connections are being opened to other members. Putting all these together, we end up in a situation
+// where many threads get stuck at a lock in EndpointManager, while the one thread inside of the lock is waiting for a ServerConnector to stop.
+// NOTE: that this can be a bit flakey as we are trying to reproduce a complete thread lockup. So there is a dockerfile to run it in a more consistent
+// environment. Using `--cpus="1"` with docker will make it even more consistent, but sometimes it takes a few tries to repro. 
+// You will know you reproduced it when you stop seeing "This should log every second." every second. you may also see the built in
+// "ThreadPool is running hot" log, but the absence of that log is ambiguous, since if it's locked up it won't finish to log how long it took!
+// The other indicator is that all the new connections made at the end should be logging terminations and reconnects and quickly give up (since they don't exist),
+// but of course that won't be happening when you're locked up. Also seeing any "terminating" messages without a corresponding "terminated" message
+// also indicates that you're locked up.
 class Program
 {
 	private static async Task Main()
@@ -16,12 +33,30 @@ class Program
 						.AddFilter("Microsoft", LogLevel.None)
 						.AddFilter("Grpc", LogLevel.None)
 						.AddFilter("Proto.Context.ActorContext", LogLevel.Information)
+						.AddFilter("Proto.Diagnostics.DiagnosticsStore", LogLevel.Warning)
 						.AddFilter("Proto.Remote.ServerConnector", LogLevel.Error)
 						.AddSimpleConsole(o => o.SingleLine = true)
 			)
 		);
 		
 		var logger = Log.CreateLogger("Main");
+		
+		_ = Task.Factory.StartNew(async () =>
+		{
+			while (true)
+			{
+				try
+				{
+					await Task.Factory.StartNew(async () => { await Task.Yield(); });
+				}
+				catch (Exception)
+				{
+				}
+
+				logger.LogInformation("This should log every second [pending: {pendingWorkItems}].", ThreadPool.PendingWorkItemCount);
+				await Task.Delay(1000);
+			}
+		});
 		
 		var sys1 = new ActorSystem().WithRemote(GrpcNetRemoteConfig.BindTo("localhost", 12000).WithRemoteKind("noop", Props.FromProducer(() => new NoopActor())));
 		await sys1.Remote().StartAsync();
@@ -34,7 +69,11 @@ class Program
 		{
 			while (true)
 			{
-				_ = sys1.Root.RequestAsync<Touched>(echoActorOn2, new Touch());
+				for (var i = 0; i < 200; i++)
+				{
+					_ = sys1.Root.RequestAsync<Touched>(echoActorOn2, new Touch());
+				}
+				await Task.Yield();
 			}
 		});
 		
@@ -43,7 +82,11 @@ class Program
 		{
 			while (true)
 			{
-				_ = sys2.Root.RequestAsync<Touched>(echoActorOn1, new Touch());
+				for (var i = 0; i < 200; i++)
+				{
+					_ = sys2.Root.RequestAsync<Touched>(echoActorOn1, new Touch());
+				}
+				await Task.Yield();
 			}
 		});
 		
@@ -52,7 +95,7 @@ class Program
 		sys1.EventStream.Publish(new EndpointTerminatedEvent(false, "localhost:12001", null));
 		
 		var port = 12002;
-		for (var i = 12002; i < 12012; i++)
+		for (var i = 12002; i < 12032; i++)
 		{
 			//logger.LogInformation("Touching {i}", i);
 			_ = sys1.Root.RequestAsync<Touched>(new PID($"localhost:{i}", "$1"), new Touch());

--- a/src/Proto.Remote/Endpoints/EndpointManager.cs
+++ b/src/Proto.Remote/Endpoints/EndpointManager.cs
@@ -56,7 +56,7 @@ public sealed class EndpointManager : IDiagnosticsProvider
     public void Stop()
     {
         lock (_synLock)
-        {
+        {            
             if (CancellationToken.IsCancellationRequested)
             {
                 return;
@@ -67,27 +67,28 @@ public sealed class EndpointManager : IDiagnosticsProvider
             _system.EventStream.Unsubscribe(_endpointTerminatedEvnSub);
 
             _cancellationTokenSource.Cancel();
-
-            foreach (var endpoint in _serverEndpoints.Values)
-            {
-                endpoint.DisposeAsync().GetAwaiter().GetResult();
-            }
-
-            foreach (var endpoint in _clientEndpoints.Values)
-            {
-                endpoint.DisposeAsync().GetAwaiter().GetResult();
-            }
-
-            _serverEndpoints.Clear();
-            _clientEndpoints.Clear();
-
-            StopActivator();
-
-            Logger.LogDebug("[{SystemAddress}] Stopped", _system.Address);
         }
+        
+        // release the lock while we dispose, other threads will see the cancellation token and return blocked endpoint.
+        foreach (var endpoint in _serverEndpoints.Values)
+        {
+            endpoint.DisposeAsync().GetAwaiter().GetResult();
+        }
+
+        foreach (var endpoint in _clientEndpoints.Values)
+        {
+            endpoint.DisposeAsync().GetAwaiter().GetResult();
+        }
+
+        _serverEndpoints.Clear();
+        _clientEndpoints.Clear();
+
+        StopActivator();
+
+        Logger.LogDebug("[{SystemAddress}] Stopped", _system.Address);
     }
 
-    private void OnEndpointTerminated(EndpointTerminatedEvent evt)
+    private async Task OnEndpointTerminated(EndpointTerminatedEvent evt)
     {
         if (Logger.IsEnabled(LogLevel.Debug))
         {
@@ -95,41 +96,43 @@ public sealed class EndpointManager : IDiagnosticsProvider
                 evt.Address ?? evt.ActorSystemId);
         }
 
+        Action? unblock = null;
+        IEndpoint? endpoint = null;
         lock (_synLock)
         {
-            if (evt.Address is not null && _serverEndpoints.TryRemove(evt.Address, out var endpoint))
+            if (_cancellationTokenSource.IsCancellationRequested)
             {
-                endpoint.DisposeAsync().GetAwaiter().GetResult();
-
-                if (evt.ShouldBlock && _remoteConfig.WaitAfterEndpointTerminationTimeSpan.HasValue &&
-                    _blockedAddresses.TryAdd(evt.Address, DateTime.UtcNow))
-                {
-                    _ = SafeTask.Run(async () =>
-                    {
-                        await Task.Delay(_remoteConfig.WaitAfterEndpointTerminationTimeSpan.Value)
-                            .ConfigureAwait(false);
-
-                        _blockedAddresses.TryRemove(evt.Address, out _);
-                    });
-                }
+                return;
+            }
+            
+            if (evt.Address is not null && _serverEndpoints.TryRemove(evt.Address, out endpoint))
+            {
+                _blockedAddresses.TryAdd(evt.Address, DateTime.UtcNow);
+                unblock = () => _blockedAddresses.TryRemove(evt.Address, out _);
             }
 
             if (evt.ActorSystemId is not null && _clientEndpoints.TryRemove(evt.ActorSystemId, out endpoint))
             {
-                endpoint.DisposeAsync().GetAwaiter().GetResult();
-
-                if (evt.ShouldBlock && _remoteConfig.WaitAfterEndpointTerminationTimeSpan.HasValue &&
-                    _blockedClientSystemIds.TryAdd(evt.ActorSystemId, DateTime.UtcNow))
+                _blockedClientSystemIds.TryAdd(evt.ActorSystemId, DateTime.UtcNow);
+                unblock = () => _blockedClientSystemIds.TryRemove(evt.ActorSystemId, out _);
+            }
+        }
+        
+        if (endpoint != null)
+        {
+            // leave the lock to dispose the endpoint, so that requests can't build up behind the lock
+            // the address will always be blocked while we dispose, at a minimum
+            await endpoint.DisposeAsync().ConfigureAwait(false);
+            if (evt.ShouldBlock && _remoteConfig.WaitAfterEndpointTerminationTimeSpan.HasValue)
+            {
+                await Task.Delay(_remoteConfig.WaitAfterEndpointTerminationTimeSpan.Value, CancellationToken).ConfigureAwait(false);
+                if (_cancellationTokenSource.IsCancellationRequested)
                 {
-                    _ = SafeTask.Run(async () =>
-                    {
-                        await Task.Delay(_remoteConfig.WaitAfterEndpointTerminationTimeSpan.Value)
-                            .ConfigureAwait(false);
-
-                        _blockedClientSystemIds.TryRemove(evt.ActorSystemId, out _);
-                    });
+                    return;
                 }
             }
+
+            unblock?.Invoke();
         }
 
         Logger.LogDebug("[{SystemAddress}] Endpoint {Address} terminated", _system.Address,
@@ -157,11 +160,16 @@ public sealed class EndpointManager : IDiagnosticsProvider
 
         lock (_synLock)
         {
+            if (_cancellationTokenSource.IsCancellationRequested || _blockedAddresses.ContainsKey(address))
+            {
+                return _blockedEndpoint;
+            }
+            
             if (_serverEndpoints.TryGetValue(address, out endpoint))
             {
                 return endpoint;
             }
-
+            
             if (_system.Address.StartsWith(ActorSystem.Client, StringComparison.Ordinal))
             {
                 if (Logger.IsEnabled(LogLevel.Debug))
@@ -212,6 +220,11 @@ public sealed class EndpointManager : IDiagnosticsProvider
 
         lock (_synLock)
         {
+            if (_cancellationTokenSource.IsCancellationRequested || _blockedClientSystemIds.ContainsKey(systemId))
+            {
+                return _blockedEndpoint;
+            }
+            
             if (_clientEndpoints.TryGetValue(systemId, out endpoint))
             {
                 return endpoint;

--- a/src/Proto.Remote/Endpoints/EndpointManager.cs
+++ b/src/Proto.Remote/Endpoints/EndpointManager.cs
@@ -72,12 +72,12 @@ public sealed class EndpointManager : IDiagnosticsProvider
         // release the lock while we dispose, other threads will see the cancellation token and return blocked endpoint.
         foreach (var endpoint in _serverEndpoints.Values)
         {
-            await endpoint.DisposeAsync();
+            await endpoint.DisposeAsync().ConfigureAwait(false);
         }
 
         foreach (var endpoint in _clientEndpoints.Values)
         {
-            await endpoint.DisposeAsync();
+            await endpoint.DisposeAsync().ConfigureAwait(false);
         }
 
         _serverEndpoints.Clear();

--- a/src/Proto.Remote/Endpoints/EndpointManager.cs
+++ b/src/Proto.Remote/Endpoints/EndpointManager.cs
@@ -53,7 +53,7 @@ public sealed class EndpointManager : IDiagnosticsProvider
 
     public void Start() => SpawnActivator();
 
-    public void Stop()
+    public async Task StopAsync()
     {
         lock (_synLock)
         {            
@@ -72,12 +72,12 @@ public sealed class EndpointManager : IDiagnosticsProvider
         // release the lock while we dispose, other threads will see the cancellation token and return blocked endpoint.
         foreach (var endpoint in _serverEndpoints.Values)
         {
-            endpoint.DisposeAsync().GetAwaiter().GetResult();
+            await endpoint.DisposeAsync();
         }
 
         foreach (var endpoint in _clientEndpoints.Values)
         {
-            endpoint.DisposeAsync().GetAwaiter().GetResult();
+            await endpoint.DisposeAsync();
         }
 
         _serverEndpoints.Clear();

--- a/src/Proto.Remote/Endpoints/EndpointReader.cs
+++ b/src/Proto.Remote/Endpoints/EndpointReader.cs
@@ -42,6 +42,8 @@ public sealed class EndpointReader : Remoting.RemotingBase
             throw new RpcException(Status.DefaultCancelled, "Suspended");
         }
 
+        var cancellationTokenSource = new CancellationTokenSource();
+
         async void Disconnect()
         {
             try
@@ -59,6 +61,13 @@ public sealed class EndpointReader : Remoting.RemotingBase
 
                 Logger.LogWarning("[EndpointReader][{SystemAddress}] Failed to write disconnect message to the stream",
                     _system.Address);
+            }
+            finally
+            {
+                // When we disconnect, cancel the token, so the reader and writer both stop, and this method returns,
+                // so that the stream actually closes. Without this, when kestrel begins shutdown, it's possible the 
+                // connection will stay open until the kestrel shutdown timeout is reached.
+                cancellationTokenSource.Cancel();
             }
         }
 
@@ -80,8 +89,6 @@ public sealed class EndpointReader : Remoting.RemotingBase
             }
 
             var connectRequest = requestStream.Current.ConnectRequest;
-
-            var cancellationTokenSource = new CancellationTokenSource();
 
             switch (connectRequest.ConnectionTypeCase)
             {
@@ -205,7 +212,7 @@ public sealed class EndpointReader : Remoting.RemotingBase
     {
         try
         {
-            while (await requestStream.MoveNext(CancellationToken.None).ConfigureAwait(false))
+            while (await requestStream.MoveNext(cancellationTokenSource.Token).ConfigureAwait(false))
             {
                 var currentMessage = requestStream.Current;
 

--- a/src/Proto.Remote/GrpcNet/GrpcNetClientRemote.cs
+++ b/src/Proto.Remote/GrpcNet/GrpcNetClientRemote.cs
@@ -42,13 +42,13 @@ public class GrpcNetClientRemote : IRemote
     public BlockList BlockList { get; }
     public bool Started { get; private set; }
 
-    public Task ShutdownAsync(bool graceful = true)
+    public async Task ShutdownAsync(bool graceful = true)
     {
         lock (_lock)
         {
             if (!Started)
             {
-                return Task.CompletedTask;
+                return;
             }
 
             Started = false;
@@ -58,7 +58,7 @@ public class GrpcNetClientRemote : IRemote
         {
             if (graceful)
             {
-                _endpointManager.Stop();
+                await _endpointManager.StopAsync();
             }
 
             _logger.LogInformation(
@@ -73,8 +73,6 @@ public class GrpcNetClientRemote : IRemote
                 System.Id, ex.Message
             );
         }
-
-        return Task.CompletedTask;
     }
 
     public Task StartAsync()

--- a/src/Proto.Remote/GrpcNet/GrpcNetRemote.cs
+++ b/src/Proto.Remote/GrpcNet/GrpcNetRemote.cs
@@ -157,7 +157,7 @@ public class GrpcNetRemote : IRemote
             {
                 if (graceful)
                 {
-                    _endpointManager.Stop();
+                    await _endpointManager.StopAsync();
 
                     if (_host is not null)
                     {

--- a/src/Proto.Remote/GrpcNet/HostedGrpcNetRemote.cs
+++ b/src/Proto.Remote/GrpcNet/HostedGrpcNetRemote.cs
@@ -66,37 +66,35 @@ public class HostedGrpcNetRemote : IRemote
         }
     }
 
-    public Task ShutdownAsync(bool graceful = true)
+    public async Task ShutdownAsync(bool graceful = true)
     {
         lock (_lock)
         {
             if (!Started)
             {
-                return Task.CompletedTask;
-            }
-
-            try
-            {
-                _endpointManager.Stop();
-
-                _logger.LogInformation(
-                    "Proto.Actor server stopped on {Address}. Graceful: {Graceful}",
-                    System.Address, graceful
-                );
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(
-                    ex, "Proto.Actor server stopped on {Address} with error: {MessagePayload}",
-                    System.Address, ex.Message
-                );
-
-                throw;
+                return;
             }
 
             Started = false;
+        }
 
-            return Task.CompletedTask;
+        try
+        {
+            await _endpointManager.StopAsync();
+
+            _logger.LogInformation(
+                "Proto.Actor server stopped on {Address}. Graceful: {Graceful}",
+                System.Address, graceful
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex, "Proto.Actor server stopped on {Address} with error: {MessagePayload}",
+                System.Address, ex.Message
+            );
+
+            throw;
         }
     }
 }

--- a/tests/Proto.Actor.Tests/DisposableActorTests.cs
+++ b/tests/Proto.Actor.Tests/DisposableActorTests.cs
@@ -54,7 +54,7 @@ public class DisposableActorTests
 
         var parent = context.Spawn(props);
         context.Send(parent, "crash");
-        childMailboxStats.Reset.Wait(1000);
+        childMailboxStats.Reset.Wait(2000);
         Assert.True(disposeCalled);
     }
 

--- a/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
@@ -79,7 +79,7 @@ public class SupervisionTestsOneForOne
 
         context.Send(parent, "hello");
 
-        childMailboxStats.Reset.Wait(1000);
+        childMailboxStats.Reset.Wait(2000);
         Assert.Contains(childMailboxStats.Posted, msg => msg is Restart);
         Assert.Contains(childMailboxStats.Received, msg => msg is Restart);
     }

--- a/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
@@ -147,7 +147,7 @@ public class SupervisionTestsOneForOne
         context.Send(parent, "3rd restart");
         context.Send(parent, "4th restart");
 
-        childMailboxStats.Reset.Wait(1000);
+        childMailboxStats.Reset.Wait(2000);
         Assert.Contains(Stop.Instance, childMailboxStats.Posted);
         Assert.Contains(Stop.Instance, childMailboxStats.Received);
     }


### PR DESCRIPTION
## Description

<!-- If your pull request solves an issue, please reference it here -->

### Background:
This is an issue that has caused us some pain in our production environments, rendering our proto.actor cluster inoperable until we took action to reduce load on the system. In our environment have have pods coming on and offline all the time, sometimes under heavy load, and this exploited an issue in the `EndpointManager`, where requests for new endpoints wait behind a lock while another thread disposes an endpoint.

### The change:
This PR modifies `EndpointManager` so that it disposes endpoints outside of the lock, while any concurrent requests to that endpoint return a blocked endpoint, instead of waiting behind a lock. This way, while an endpoint cleans up, new endpoints can still be added, and multiple endpoints can be disposed at the same time.

This change makes `EndpointManager` more robust by minimizing the time spent inside the lock, preventing potential thread saturation and lockup during topology changes. Since we don't want to send requests to a disposing endpoint, those requests get a blocking endpoint instead. After the dispose is complete, the same conditions apply as before for blocking and unblocking the endpoint, namely the `ShouldBlock` flag on the event, and the `WaitAfterEndpointTerminationTimeSpan` config.

### Testing:
I've added a project called `EndpointManagerTest` which reproduces the issue intermittently. After applying the change, the issue no longer occurs. Due to the nature of this issue, results can vary significantly between different environments or CPUs. So a dockerfile has been provided as well so it can be run more consistently, when run with a limit of 1 CPU. Of course results will still vary for different machines. Without the fix, the issue only occurs intermittently (in my case it would occur maybe half the time), due to race conditions that must occur, and which work ends up getting allocated by the threadpool.

### Details:
In our production environment, we had a scenario where many proto.actor client pods would start up and start sending messages to actors on a couple proto.actor member pods. The actors would typically handle them easily so the load was not as issue. But all these clients would have to be added when sending responses for partition identity or placement messages. If this occurred while some endpoint was being terminated, it could result in thread saturation and lockup. A thread would enter the `EndpointManager` lock to dispose an endpoint, while many messages are trying to be sent to new endpoints, which all wait behind the lock. These are all blocking waits, so they all hold the thread that was allocated to them, so other work can't use them. The threadpool of course allocates new threads according to it's algorithm, but if they keep getting allocated to tasks that will end up waiting behind a lock, then no work will be done, potentially for quite some time. Once the endpoint dispose work is finally given a thread and can complete, then everything can start flowing again, but that doesn't always happen when there are so many threads in blocking waits and so much competition for the new threads as they are added. In our production environment, we had another connected resource that would disconnect since its health checks could not complete under the lockup, which would ultimately cause a restart of the pod. Then it would enter an endless cycle of locking up and restarting. 



## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
