### PR TITLE
Support adding additional error handling to generated actors

### DIFF
--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -62,7 +62,7 @@ namespace {{CsNamespace}}
             }
             catch (Exception x)
             {
-                onError(x.ToString());
+                OnError(x);
             }
         }
         {{/each}}
@@ -70,6 +70,11 @@ namespace {{CsNamespace}}
         {{#each Methods}}
         public abstract Task{{#if UseReturn}}<{{OutputName}}>{{/if}} {{Name}}({{SingleParameterDefinition}});
         {{/each}}
+
+        public virtual void OnError(Exception ex)
+        { 
+            Context!.Respond(new global::Proto.Cluster.GrainErrorResponse { Err = ex.ToString() });
+        }
     }
 
     public class {{Name}}Client

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
@@ -42,7 +42,7 @@ namespace Acme.OtherSystem.Foo
             }
             catch (Exception x)
             {
-                onError(x.ToString());
+                OnError(x);
             }
         }
         public virtual async Task SendCommand(Acme.Mysystem.Bar.SomeCommand request, Action respond, Action<string> onError)
@@ -54,7 +54,7 @@ namespace Acme.OtherSystem.Foo
             }
             catch (Exception x)
             {
-                onError(x.ToString());
+                OnError(x);
             }
         }
         public virtual async Task RequestResponse(Acme.Mysystem.Bar.Query request, Action<Acme.Mysystem.Bar.Response> respond, Action<string> onError)
@@ -66,7 +66,7 @@ namespace Acme.OtherSystem.Foo
             }
             catch (Exception x)
             {
-                onError(x.ToString());
+                OnError(x);
             }
         }
         public virtual async Task NoParameterOrReturn(Action respond, Action<string> onError)
@@ -78,7 +78,7 @@ namespace Acme.OtherSystem.Foo
             }
             catch (Exception x)
             {
-                onError(x.ToString());
+                OnError(x);
             }
         }
     
@@ -86,6 +86,11 @@ namespace Acme.OtherSystem.Foo
         public abstract Task SendCommand(Acme.Mysystem.Bar.SomeCommand request);
         public abstract Task<Acme.Mysystem.Bar.Response> RequestResponse(Acme.Mysystem.Bar.Query request);
         public abstract Task NoParameterOrReturn();
+
+        public virtual void OnError(Exception ex)
+        { 
+            Context!.Respond(new global::Proto.Cluster.GrainErrorResponse { Err = ex.ToString() });
+        }
     }
 
     public class TestGrainClient

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutputPackageless.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutputPackageless.cs
@@ -42,7 +42,7 @@ namespace Acme.OtherSystem.Foo
             }
             catch (Exception x)
             {
-                onError(x.ToString());
+                OnError(x);
             }
         }
         public virtual async Task SendCommand(Acme.Mysystem.Bar.SomeCommand request, Action respond, Action<string> onError)
@@ -54,7 +54,7 @@ namespace Acme.OtherSystem.Foo
             }
             catch (Exception x)
             {
-                onError(x.ToString());
+                OnError(x);
             }
         }
         public virtual async Task RequestResponse(Acme.Mysystem.Bar.Query request, Action<Acme.Mysystem.Bar.Response> respond, Action<string> onError)
@@ -66,7 +66,7 @@ namespace Acme.OtherSystem.Foo
             }
             catch (Exception x)
             {
-                onError(x.ToString());
+                OnError(x);
             }
         }
         public virtual async Task NoParameterOrReturn(Action respond, Action<string> onError)
@@ -78,7 +78,7 @@ namespace Acme.OtherSystem.Foo
             }
             catch (Exception x)
             {
-                onError(x.ToString());
+                OnError(x);
             }
         }
     
@@ -86,6 +86,11 @@ namespace Acme.OtherSystem.Foo
         public abstract Task SendCommand(Acme.Mysystem.Bar.SomeCommand request);
         public abstract Task<Acme.Mysystem.Bar.Response> RequestResponse(Acme.Mysystem.Bar.Query request);
         public abstract Task NoParameterOrReturn();
+
+        public virtual void OnError(Exception ex)
+        { 
+            Context!.Respond(new global::Proto.Cluster.GrainErrorResponse { Err = ex.ToString() });
+        }
     }
 
     public class TestGrainClient

--- a/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
@@ -83,6 +83,9 @@ public class PartitionIdentityTests
         timer.Restart();
         await fixture.DisposeAsync();
         _output.WriteLine($"Stopped cluster in {timer.Elapsed}");
+        
+        // delay to reduce flakiness
+        await Task.Delay(2000);
 
         var actorStates = fixture.Repository.Contents.ToList();
 


### PR DESCRIPTION
## Description

<!-- If your pull request solves an issue, please reference it here -->

Currently, if you want to log whenever a generated actor throws an error while handling a message, you have to override the long form of every message handler. This adds an `OnError` virtual method so that you can easily add logging or any other behavior in one place.

This change maintains exact behavior from before, as the default implementation of `OnError` does the same thing that the passed in `onError` callback always does. Even though the `onError` parameter is now technically redundant, it is retained to keep behavior of existing overrides unchanged.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
