### PR TITLE
After an actor is stopped, block continuations from running

### DIFF
--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -621,7 +621,7 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
         // Don't execute the continuation if the actor instance changed.
         // Without this, Continuation's Action closure would execute with
         // an older Actor instance.
-        if (cont.Actor != Actor && cont is not { Actor: null })
+        if (_state == ContextState.Stopped || System.Shutdown.IsCancellationRequested || (cont.Actor != Actor && cont is not { Actor: null }))
         {
                 Logger.DroppingContinuation(Self, MessageEnvelope.UnwrapMessage(cont.Message));
 

--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -596,7 +596,7 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
                 // ignored
             }
 
-            if (!ctx.System.Shutdown.IsCancellationRequested)
+            if (!ctx.CancellationToken.IsCancellationRequested && !ctx.System.Shutdown.IsCancellationRequested)
             {
                 ctx.Self.SendSystemMessage(ctx.System, cont);
             }


### PR DESCRIPTION
## Description

If there are any pending continuations after an actor is stopped, a Continuation system message will still be sent when its wait completes, and the Continuation will still run even though the actor is in a fully stopped state. This can result in some unexpected behavior including data corruption, since the actor could be running elsewhere at the same time (e.g. if it was moved to another node).

This PR adds checks before sending and handling a Continuation so this can no longer happen. A test was added to confirm the issue and the fix.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
