### PR TITLE
Wrapping Task.Delay with an implementation that uses TimeProvider in …

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,6 +52,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.4.0" />
     <PackageVersion Include="Microsoft.NET.Build.Containers" Version="9.0.202" />
 
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,6 +48,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.2.0" />
     <PackageVersion Include="Microsoft.NET.Build.Containers" Version="8.0.401" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,7 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageVersion Include="JsonPatch.Net" Version="3.1.1" />
     <PackageVersion Include="KubernetesClient" Version="15.0.1" />
+    <PackageVersion Include="dotnet-etcd" Version="7.2.0" />
     <PackageVersion Include="Marten" Version="7.27.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.8" />

--- a/src/Proto.Actor/Timers/Scheduler.cs
+++ b/src/Proto.Actor/Timers/Scheduler.cs
@@ -17,6 +17,9 @@ namespace Proto.Timers;
 public class Scheduler
 {
     private readonly ISenderContext _context;
+#if NET8_0_OR_GREATER
+    private readonly TimeProvider _timeProvider;
+#endif
 
     /// <summary>
     ///     Creates a new scheduler.
@@ -25,7 +28,24 @@ public class Scheduler
     public Scheduler(ISenderContext context)
     {
         _context = context;
+
+#if NET8_0_OR_GREATER
+        _timeProvider = TimeProvider.System;
+#endif
     }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    ///     Creates a new scheduler.
+    /// </summary>
+    /// <param name="context">Context to send the scheduled message through</param>
+    /// <param name="timeProvider">TimeProvider to use for scheduling (FakeTimeProvider can be used for testing)</param>
+    public Scheduler(ISenderContext context, TimeProvider timeProvider)
+    {
+        _context = context;
+        _timeProvider = timeProvider;
+    }
+#endif
 
     /// <summary>
     ///     Schedules a single message to be sent in the future.
@@ -41,7 +61,7 @@ public class Scheduler
 
         _ = SafeTask.Run(async () =>
             {
-                await Task.Delay(delay, token).ConfigureAwait(false);
+                await Delay(delay, token).ConfigureAwait(false);
 
                 _context.Send(target, message);
             }, token
@@ -75,7 +95,7 @@ public class Scheduler
 
         _ = SafeTask.Run(async () =>
             {
-                await Task.Delay(delay, token).ConfigureAwait(false);
+                await Delay(delay, token).ConfigureAwait(false);
 
                 while (!cts.IsCancellationRequested)
                 {
@@ -105,17 +125,26 @@ public class Scheduler
 
         _ = SafeTask.Run(async () =>
             {
-                await Task.Delay(delay, token).ConfigureAwait(false);
+                await Delay(delay, token).ConfigureAwait(false);
 
                 while (!cts.IsCancellationRequested)
                 {
                     _context.Request(target, message);
 
-                    await Task.Delay(interval, token).ConfigureAwait(false);
+                    await Delay(interval, token).ConfigureAwait(false);
                 }
             }, token
         );
 
         return cts;
+    }
+
+    private async Task Delay(TimeSpan delay, CancellationToken token)
+    {
+#if NET8_0_OR_GREATER
+    await Task.Delay(delay, _timeProvider, token).ConfigureAwait(false);
+#else
+        await Task.Delay(delay, token).ConfigureAwait(false);
+#endif
     }
 }

--- a/src/Proto.Actor/Timers/TimerExtensions.cs
+++ b/src/Proto.Actor/Timers/TimerExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Proto.Timers;
 
 public static class TimerExtensions
@@ -8,4 +10,14 @@ public static class TimerExtensions
     /// <param name="context"></param>
     /// <returns></returns>
     public static Scheduler Scheduler(this ISenderContext context) => new(context);
+    
+#if NET8_0_OR_GREATER
+    /// <summary>
+    ///     Gets a new scheduler that allows to schedule messages in the future
+    /// </summary>
+    /// <param name="context">Context to send the scheduled message through</param>
+    /// <param name="timeProvider">TimeProvider to use for scheduling (FakeTimeProvider can be used for testing)</param>
+    /// <returns></returns>
+    public static Scheduler Scheduler(this ISenderContext context, TimeProvider timeProvider) => new(context, timeProvider);
+#endif
 }

--- a/src/Proto.Cluster.Etcd/Proto.Cluster.Etcd.csproj
+++ b/src/Proto.Cluster.Etcd/Proto.Cluster.Etcd.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="dotnet-etcd" Version="7.2.0" />
+      <PackageReference Include="dotnet-etcd" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj
+++ b/tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj
@@ -8,7 +8,11 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj" />
-        <ProjectReference Include="..\Proto.TestFixtures\Proto.TestFixtures.csproj" />
+        <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj"/>
+        <ProjectReference Include="..\Proto.TestFixtures\Proto.TestFixtures.csproj"/>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Condition=" '$(TargetFramework)' == 'net8.0' "/>
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Condition=" '$(TargetFramework)' == 'net9.0' "/>
     </ItemGroup>
 </Project>

--- a/tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj
+++ b/tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj
@@ -11,8 +11,10 @@
         <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj"/>
         <ProjectReference Include="..\Proto.TestFixtures\Proto.TestFixtures.csproj"/>
     </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Condition=" '$(TargetFramework)' == 'net8.0' "/>
-        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Condition=" '$(TargetFramework)' == 'net9.0' "/>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+      <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     </ItemGroup>
 </Project>

--- a/tests/Proto.Actor.Tests/SchedulerTests.cs
+++ b/tests/Proto.Actor.Tests/SchedulerTests.cs
@@ -1,0 +1,37 @@
+#if NET8_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
+using Proto.Timers;
+using Xunit;
+
+namespace Proto.Tests;
+
+public class SchedulerTests
+{
+    [Fact]
+    public async Task SendOnceWorksWithTimeProvider()
+    {
+        await using var system = new ActorSystem();
+        var context = system.Root;
+        var tcs = new TaskCompletionSource();
+        var pid = context.Spawn(Props.FromFunc(context =>
+        {
+            if (context.Message is "Wakeup")
+            {
+                tcs.SetResult();
+            }
+
+            return Task.CompletedTask;
+        }));
+        var timeProvider = new FakeTimeProvider();
+        var scheduler = context.Scheduler(timeProvider);
+
+        scheduler.SendOnce(TimeSpan.FromSeconds(10), pid, "Wakeup");
+        // Give SendOnce's inner call to Task.Delay a head start, so it won't miss the call to Advance.
+        await Task.Delay(50);
+        timeProvider.Advance(TimeSpan.FromMinutes(10));
+        await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(10));
+    }
+}
+#endif


### PR DESCRIPTION
….NET 8 or higher

## Description

This PR solves issue #2148 by enabling passing a `TimeProvider` instance to be used by `Task.Delay`.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
