### PR TITLE
Add GrainException to support better error handling from generated grains

### DIFF
--- a/benchmarks/GossipBenchmark/Messages/Messages.csproj
+++ b/benchmarks/GossipBenchmark/Messages/Messages.csproj
@@ -18,5 +18,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Cluster\Proto.Cluster.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Remove="Actors.proto" />
+  </ItemGroup>
 
 </Project>

--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -73,6 +73,12 @@ namespace {{CsNamespace}}
 
         public virtual void OnError(Exception ex)
         { 
+            if (ex is global::Proto.Cluster.GrainException ge)
+            {
+                Context!.Respond(new global::Proto.Cluster.GrainErrorResponse { Err = ge.Message ?? ge.ToString(), Code = ge.Code ?? string.Empty });
+                return;
+            }
+
             Context!.Respond(new global::Proto.Cluster.GrainErrorResponse { Err = ex.ToString() });
         }
     }
@@ -102,7 +108,7 @@ namespace {{CsNamespace}}
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => {{#if UseReturn}}({{OutputName}}?)grainResponse.ResponseMessage{{else}}global::Proto.Nothing.Instance{{/if}},
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -123,7 +129,7 @@ namespace {{CsNamespace}}
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => {{#if UseReturn}}({{OutputName}}?)grainResponse.ResponseMessage{{else}}global::Proto.Nothing.Instance{{/if}},
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response

--- a/src/Proto.Cluster/Grain/GrainException.cs
+++ b/src/Proto.Cluster/Grain/GrainException.cs
@@ -3,6 +3,15 @@ using System;
 namespace Proto.Cluster;
 
 #pragma warning disable RCS1194
+/// <summary>
+/// Throwing a <see cref="GrainException"/> from inside a generated grain implementation
+/// will rethrow this same exception on the client, with the same message and code.
+/// The code property can then be used to detect what kind of error occurred to handle it accordingly.
+/// </summary>
+/// <remarks>
+/// Currently, any other exception thrown from a generated grain will result in a generic Exception
+/// being thrown with the entire exception object serialized into the message property.
+/// </remarks>
 public class GrainException : Exception
 {
 	public GrainException(string message, string? code = null) : base(message)

--- a/src/Proto.Cluster/Grain/GrainException.cs
+++ b/src/Proto.Cluster/Grain/GrainException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Proto.Cluster;
+
+#pragma warning disable RCS1194
+public class GrainException : Exception
+{
+	public GrainException(string message, string? code = null) : base(message)
+	{
+		Code = code;
+	}
+
+	public string? Code { get; }
+}

--- a/src/Proto.Cluster/GrainContracts.proto
+++ b/src/Proto.Cluster/GrainContracts.proto
@@ -15,4 +15,5 @@ message GrainResponse {
 
 message GrainErrorResponse {
   string err = 1;
+  string code = 2;
 }

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutput.cs
@@ -89,6 +89,12 @@ namespace Acme.OtherSystem.Foo
 
         public virtual void OnError(Exception ex)
         { 
+            if (ex is global::Proto.Cluster.GrainException ge)
+            {
+                Context!.Respond(new global::Proto.Cluster.GrainErrorResponse { Err = ge.Message ?? ge.ToString(), Code = ge.Code ?? string.Empty });
+                return;
+            }
+
             Context!.Respond(new global::Proto.Cluster.GrainErrorResponse { Err = ex.ToString() });
         }
     }
@@ -117,7 +123,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.GetCurrentStateResponse?)grainResponse.ResponseMessage,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -138,7 +144,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.GetCurrentStateResponse?)grainResponse.ResponseMessage,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -158,7 +164,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => global::Proto.Nothing.Instance,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -179,7 +185,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => global::Proto.Nothing.Instance,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -199,7 +205,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.Response?)grainResponse.ResponseMessage,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -220,7 +226,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.Response?)grainResponse.ResponseMessage,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -240,7 +246,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => global::Proto.Nothing.Instance,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -261,7 +267,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => global::Proto.Nothing.Instance,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response

--- a/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutputPackageless.cs
+++ b/tests/Proto.Cluster.CodeGen.Tests/ExpectedOutputPackageless.cs
@@ -89,6 +89,12 @@ namespace Acme.OtherSystem.Foo
 
         public virtual void OnError(Exception ex)
         { 
+            if (ex is global::Proto.Cluster.GrainException ge)
+            {
+                Context!.Respond(new global::Proto.Cluster.GrainErrorResponse { Err = ge.Message ?? ge.ToString(), Code = ge.Code ?? string.Empty });
+                return;
+            }
+
             Context!.Respond(new global::Proto.Cluster.GrainErrorResponse { Err = ex.ToString() });
         }
     }
@@ -117,7 +123,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.GetCurrentStateResponse?)grainResponse.ResponseMessage,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -138,7 +144,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.GetCurrentStateResponse?)grainResponse.ResponseMessage,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -158,7 +164,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => global::Proto.Nothing.Instance,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -179,7 +185,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => global::Proto.Nothing.Instance,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -199,7 +205,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.Response?)grainResponse.ResponseMessage,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -220,7 +226,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => (Acme.Mysystem.Bar.Response?)grainResponse.ResponseMessage,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -240,7 +246,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => global::Proto.Nothing.Instance,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response
@@ -261,7 +267,7 @@ namespace Acme.OtherSystem.Foo
                 // enveloped response
                 global::Proto.Cluster.GrainResponseMessage grainResponse => global::Proto.Nothing.Instance,
                 // error response
-                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new Exception(grainErrorResponse.Err),
+                global::Proto.Cluster.GrainErrorResponse grainErrorResponse => throw new global::Proto.Cluster.GrainException(grainErrorResponse.Err, grainErrorResponse.Code),
                 // timeout (when enabled by ClusterConfig.LegacyRequestTimeoutBehavior), othwerwise TimeoutException is thrown
                 null => null,
                 // unsupported response


### PR DESCRIPTION
Add GrainException which enables throwing a GrainException back on the grain client with a specific message and code from inside a grain message handler. This enables application code to easily provide different error handling behavior based on the code.

For example, if i want to throw an error inside of a grain handler due to bad user input. Right now it just throws a plain exception on the client. With GrainException and especially the new Code property, we can pass something to indicate that the error was due to user input, and not some other unknown error in the code.

This change is fully backwards compatible with existing generated grains and usage.

## Description

<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
