### PR TITLE
Blocked member duration configurable. IsBlocked takes this duration into account. When member leaves, remove everywhere.

### DIFF
--- a/src/Proto.Actor/Configuration/ActorSystemConfig.cs
+++ b/src/Proto.Actor/Configuration/ActorSystemConfig.cs
@@ -129,6 +129,11 @@ public record ActorSystemConfig
     public LogLevel DiagnosticsLogLevel { get; set; } = LogLevel.Information;
 
     /// <summary>
+    ///     Once a member is blocked, it will remain blocked for this duration. Defaults to 1 hour.
+    /// </summary>
+    public TimeSpan BlockedMemberDuration { get; init; } = TimeSpan.FromHours(1);
+
+    /// <summary>
     ///     Creates a new default ActorSystemConfig
     /// </summary>
     /// <returns>The new ActorSystemConfig</returns>
@@ -238,6 +243,12 @@ public record ActorSystemConfig
     /// <returns></returns>
     public ActorSystemConfig WithDiagnosticsLogLevel(LogLevel diagnosticsLogLevel) =>
         this with { DiagnosticsLogLevel = diagnosticsLogLevel };
+
+    /// <summary>
+    ///     Once a member is blocked, it will remain blocked for this duration. Defaults to 1 hour.
+    /// </summary>
+    public ActorSystemConfig WithBlockedMemberDuration(TimeSpan blockedMemberDuration) =>
+        this with { BlockedMemberDuration = blockedMemberDuration };
 
 
     /// <summary>

--- a/src/Proto.Cluster/Member/MemberList.cs
+++ b/src/Proto.Cluster/Member/MemberList.cs
@@ -274,6 +274,8 @@ public record MemberList
                 {
                     _indexByAddress = _indexByAddress.Remove(memberThatLeft.Address);
                 }
+
+                _metaMembers = _metaMembers.Remove(memberThatLeft.Id);
             }
             //Log?
         }

--- a/src/Proto.Remote/BlockList.cs
+++ b/src/Proto.Remote/BlockList.cs
@@ -15,7 +15,8 @@ public record MemberBlocked(string MemberId, string Reason);
 
 /// <summary>
 ///     <see cref="BlockList" /> contains all members that have been blocked from communication, e.g. due to
-///     unresponsiveness.
+///     unresponsiveness. Entries on this list expire after <see cref="ActorSystemConfig.BlockedMemberDuration"/>,
+///     defaults to 1 hour.
 /// </summary>
 public class BlockList
 {
@@ -30,10 +31,11 @@ public class BlockList
     }
 
     /// <summary>
-    ///     List of all blocked members ids (their <see cref="ActorSystem.Id" />). Entries on this list expire within an hour.
+    ///     List of all blocked members ids (their <see cref="ActorSystem.Id" />). Entries on this list expire after
+    ///     <see cref="ActorSystemConfig.BlockedMemberDuration"/>, defaults to 1 hour.
     /// </summary>
     public ImmutableHashSet<string> BlockedMembers => _blockedMembers
-        .Where(kvp => kvp.Value > DateTime.UtcNow.AddHours(-1))
+        .Where(kvp => kvp.Value > DateTime.UtcNow.Add(-_system.Config.BlockedMemberDuration))
         .Select(kvp => kvp.Key)
         .ToImmutableHashSet();
 
@@ -57,9 +59,10 @@ public class BlockList
     }
 
     /// <summary>
-    ///     Checks if the specified member is blocked
+    ///     Checks if the specified member is blocked. A blocked member will remain blocked for
+    ///     <see cref="ActorSystemConfig.BlockedMemberDuration"/>, defaults to 1 hour.
     /// </summary>
     /// <param name="memberId">Member id - same as member's <see cref="ActorSystem.Id" /></param>
     /// <returns></returns>
-    public bool IsBlocked(string memberId) => _blockedMembers.ContainsKey(memberId);
+    public bool IsBlocked(string memberId) => BlockedMembers.Contains(memberId);
 }


### PR DESCRIPTION
## Description

<!-- If your pull request solves an issue, please reference it here -->
Can now use ActorSystemConfig.WithBlockedMemberDuration() to configure how long a member will remain in block list after blocked. The default is 1 hour, which is the same value as before. 

Changed behavior of BlockList.IsBlocked() - before, a blocked member would be considered blocked forever. Now it uses the same logic as BlockList.BlockedMembers, which I think would be expected.

Lastly, when a member leaves it was removed from all the places it was added when it originally joined, except the _metaMembers dictionary. Now it will be removed from here as well. Before this change, a member could never successfully rejoin.

Background:
We had an issue with our cluster provider implementation which momentarily provided invalid data - which is being fixed separately. Nonetheless, once it recovered, any wrongfully removed members were never able to be successfully re-added. This resulted in a bad state where the cluster provider was providing a list of members but they were never added back to the member list, which of course caused a number of issues. Now, members have the ability to rejoin, and they can be configured to be blocked for less than an hour.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
