### PR TITLE
Fix spelling of 'occurred' in cluster logs

### DIFF
--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -319,7 +319,7 @@ internal class IdentityStorageWorker : IActor
             if (!_cluster.System.Shutdown.IsCancellationRequested && _shouldThrottle().IsOpen() &&
                 _memberList.ContainsMemberId(activator.Id))
             {
-                _logger.LogError(e, "[SpawnActivationAsync] Error occured requesting remote PID {@Request}", req);
+                _logger.LogError(e, "[SpawnActivationAsync] Error occurred requesting remote PID {@Request}", req);
             }
         }
 

--- a/src/Proto.Cluster/Partition/PartitionIdentityLookup.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityLookup.cs
@@ -166,7 +166,7 @@ public class PartitionIdentityLookup : IIdentityLookup
             e.CheckFailFast();
 
             Logger.LogError(e,
-                "[PartitionIdentity] Error occured requesting remote PID {@Request}, identity Owner {Owner}", req,
+                "[PartitionIdentity] Error occurred requesting remote PID {@Request}, identity Owner {Owner}", req,
                 identityOwner);
 
             return null;

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorLookup.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorLookup.cs
@@ -93,7 +93,7 @@ public class PartitionActivatorLookup : IIdentityLookup
             e.CheckFailFast();
 
             Logger.LogError(e,
-                "[PartitionActivator] Error occured requesting remote PID {@Request}, identity Owner {Owner}", req,
+                "[PartitionActivator] Error occurred requesting remote PID {@Request}, identity Owner {Owner}", req,
                 owner);
 
             return null;

--- a/src/Proto.Cluster/SingleNode/SingleNodeLookup.cs
+++ b/src/Proto.Cluster/SingleNode/SingleNodeLookup.cs
@@ -69,7 +69,7 @@ public class SingleNodeLookup : IIdentityLookup
         catch (Exception e) when (e is not IdentityIsBlockedException)
         {
             e.CheckFailFast();
-            Logger.LogError(e, "[SingleNode] Error occured requesting remote PID {@Request}", req);
+            Logger.LogError(e, "[SingleNode] Error occurred requesting remote PID {@Request}", req);
 
             return null;
         }


### PR DESCRIPTION
## Summary
- fix typo "Error occured" to "Error occurred" in `SingleNodeLookup`
- normalize error log spelling in identity and partition lookup components

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_688dfc2fa0cc832889819033f9ed75d8