### PR TITLE
Fix exception summary in Persistence.WithEventSourcing

### DIFF
--- a/src/Proto.Persistence/Persistence.cs
+++ b/src/Proto.Persistence/Persistence.cs
@@ -58,7 +58,7 @@ public class Persistence
     ///     replayed.
     /// </param>
     /// <returns></returns>
-    /// <exception cref="ArgumentNullException">Thrown when evenStore of applyEvent are null</exception>
+    /// <exception cref="ArgumentNullException">Thrown when eventStore or applyEvent are null</exception>
     public static Persistence WithEventSourcing(IEventStore eventStore, string actorId, Action<Event> applyEvent)
     {
         if (eventStore is null)


### PR DESCRIPTION
## Summary
- fix exception comment for event sourcing initialization

## Testing
- `dotnet build src/Proto.Persistence/Proto.Persistence.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688dfc4aa1448328ad3b8600500aef2b