### PR TITLE
refactor: replace sleep with async wait in supervision test

### DIFF
--- a/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
@@ -306,8 +306,13 @@ public class SupervisionTestsOneForOne
         context.Spawn(grandParentProps);
 
         parentMailboxStats.Reset.Wait(1000);
-        Thread.Sleep(1000); //parentMailboxStats.Received could still be modified without a wait here
-        Assert.Contains(parentMailboxStats.Received, msg => msg is Restart);
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(1);
+        while (!parentMailboxStats.Received.ToArray().Any(msg => msg is Restart) && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.Contains(parentMailboxStats.Received.ToArray(), msg => msg is Restart);
     }
 
     private class ParentActor : IActor


### PR DESCRIPTION
## Summary
- replace `Thread.Sleep` in `OneForOneStrategy_Should_RestartParentOnEscalateFailure` with an async wait loop for `Restart`

## Testing
- `dotnet test tests/Proto.Actor.Tests -c Release --no-build` *(fails: dotnet command not found)*
- `apt-get update` *(fails: repository access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688dfc629c208328a53b984940217972