### PR TITLE
fix spelling mistakes in identity tests

### DIFF
--- a/src/Proto.Cluster/Identity/IdentityActivatorProxy.cs
+++ b/src/Proto.Cluster/Identity/IdentityActivatorProxy.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="IdentityProxyWorker.cs" company="Asynkron AB">
+// <copyright file="IdentityActivatorProxy.cs" company="Asynkron AB">
 //      Copyright (C) 2015-2024 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------

--- a/src/Proto.Cluster/Identity/IdentityIsBlockedException.cs
+++ b/src/Proto.Cluster/Identity/IdentityIsBlockedException.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file = "IdentityBlockedException.cs" company = "Asynkron AB">
+// <copyright file = "IdentityIsBlockedException.cs" company = "Asynkron AB">
 //      Copyright (C) 2015-2024 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------

--- a/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
+++ b/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-//   <copyright file="Activator.cs" company="Asynkron AB">
+//   <copyright file="IdentityStoragePlacementActor.cs" company="Asynkron AB">
 //       Copyright (C) 2015-2024 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------

--- a/tests/Proto.Cluster.Identity.Tests/FailureInjectionStorage.cs
+++ b/tests/Proto.Cluster.Identity.Tests/FailureInjectionStorage.cs
@@ -53,7 +53,7 @@ public sealed class FailureInjectionStorage : IIdentityStorage
             RemoveLock(spawnLock, ct);
 
             throw Mayhem.Next() % 2 == 0
-                ? new Exception("Activation fail")
+                ? new Exception("Activation failed")
                 : new LockNotFoundException("fake lock");
         }
 

--- a/tests/Proto.Cluster.Identity.Tests/IdentityStorageTests.cs
+++ b/tests/Proto.Cluster.Identity.Tests/IdentityStorageTests.cs
@@ -57,9 +57,9 @@ public abstract class IdentityStorageTests : IDisposable
             .Select(i => _storage.TryAcquireLock(identity, timeout))
         );
 
-        var successFullLock = locks.Where(it => it != null).ToList();
-        successFullLock.Should().HaveCount(1);
-        successFullLock.Single()!.ClusterIdentity.Should().BeEquivalentTo(identity);
+        var successfulLocks = locks.Where(it => it != null).ToList();
+        successfulLocks.Should().HaveCount(1);
+        successfulLocks.Single()!.ClusterIdentity.Should().BeEquivalentTo(identity);
     }
 
     [Fact]
@@ -219,7 +219,7 @@ public abstract class IdentityStorageTests : IDisposable
     }
 
     [Fact]
-    public async Task WillNotRemoveCurrentActivationByPrevMember()
+    public async Task WillNotRemoveCurrentActivationByPreviousMember()
     {
         var timeout = new CancellationTokenSource(TimeoutMs).Token;
         var (originalActivator, identity, origPid) = await GetActivatedClusterIdentity(timeout);


### PR DESCRIPTION
## Summary
- fix typo in identity storage tests variable name
- improve failure injection activation message
- correct identity project headers and test name typos

## Testing
- `dotnet test tests/Proto.Cluster.Identity.Tests/Proto.Cluster.Identity.Tests.csproj` *(failed: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(failed: Unable to locate package dotnet-sdk-8.0)*
- `curl -sSL https://dot.net/v1/dotnet-install.sh | bash` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688e03dd0c3083289996dc2d97d6c10c