### PR TITLE
Replace Thread.Sleep with async delay

### DIFF
--- a/benchmarks/ClusterBenchmark/Program.cs
+++ b/benchmarks/ClusterBenchmark/Program.cs
@@ -47,7 +47,7 @@ public static class Program
             {
                 worker.ShutdownAsync().Wait();
             };
-            Thread.Sleep(Timeout.Infinite);
+            await Task.Delay(Timeout.InfiniteTimeSpan);
 
             return;
         }

--- a/examples/Patterns/Saga/Account.cs
+++ b/examples/Patterns/Saga/Account.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using Proto;
 using Saga.Messages;
@@ -79,7 +78,7 @@ internal class Account : IActor
     ///     * slow processing
     ///     * successful processing
     /// </summary>
-    private Task AdjustBalance(IContext context, PID replyTo, decimal amount)
+    private async Task AdjustBalance(IContext context, PID replyTo, decimal amount)
     {
         if (RefusePermanently())
         {
@@ -97,11 +96,12 @@ internal class Account : IActor
 
         if (behaviour == Behavior.FailBeforeProcessing)
         {
-            return Failure();
+            await Failure();
+            return;
         }
 
         // simulate potential long-running process
-        Thread.Sleep(_random.Next(0, 150));
+        await Task.Delay(_random.Next(0, 150));
 
         _balance += amount;
         _processedMessages.Add(replyTo, new OK());
@@ -111,12 +111,13 @@ internal class Account : IActor
         // is idempotent
         if (behaviour == Behavior.FailAfterProcessing)
         {
-            return Failure();
+            await Failure();
+            return;
         }
 
         context.Send(replyTo, new OK());
 
-        return Task.CompletedTask;
+        return;
 
         Task Failure()
         {

--- a/examples/Patterns/Saga/README.md
+++ b/examples/Patterns/Saga/README.md
@@ -134,7 +134,7 @@ When a `Credit` or `Debit` request is received, we attempt to adjust the balance
 for a number of reasons:
 
 ```c#
-private Task AdjustBalance(PID replyTo, decimal amount)
+private async Task AdjustBalance(PID replyTo, decimal amount)
 {
     if (RefusePermanently())
     {
@@ -146,21 +146,20 @@ private Task AdjustBalance(PID replyTo, decimal amount)
         replyTo.Tell(new ServiceUnavailable());
     
     var behaviour = DetermineProcessingBehavior();
-    if (behaviour == Behavior.FailBeforeProcessing)
-        return Failure(replyTo);
+      if (behaviour == Behavior.FailBeforeProcessing)
+          return await Failure(replyTo);
     
     // simulate potential slow service
-    Thread.Sleep(_random.Next(0, 150));
+    await Task.Delay(_random.Next(0, 150));
     
     _balance += amount;
     _processedMessages.Add(replyTo, new OK());
     
-    if (behaviour == Behavior.FailAfterProcessing)
-        return Failure(replyTo);
-    
-    replyTo.Tell(new OK());
-    return Actor.Done;
-}
+      if (behaviour == Behavior.FailAfterProcessing)
+          return await Failure(replyTo);
+
+      replyTo.Tell(new OK());
+  }
 ```
 
 This allows us to introduce a degree of randomness to the saga to simulate various types of failures.
@@ -921,7 +920,7 @@ RESULTS for 50% uptime, 20.1% chance of refusal, 0.2% of being busy and 15 retry
 ```
 
 The biggest effect comes from not retrying at all, as we are in danger of timing out on our requests (`Account` actor
-has `Thread.Sleep(_random.Next(0,150)` in it, whilst the `AccountProxy` expects a response back within 100
+has `await Task.Delay(_random.Next(0,150))` in it, whilst the `AccountProxy` expects a response back within 100
 milliseconds):
 
  ```

--- a/examples/Patterns/Saga/Runner.cs
+++ b/examples/Patterns/Saga/Runner.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using Proto;
 using Saga.Factories;
@@ -50,28 +49,28 @@ public class Runner : IActor
         _verbose = verbose;
     }
 
-    public Task ReceiveAsync(IContext context)
+    public async Task ReceiveAsync(IContext context)
     {
         switch (context.Message)
         {
             case Result.SuccessResult msg:
                 _successResults++;
-                CheckForCompletion(msg.Pid);
+                await CheckForCompletion(msg.Pid);
 
                 break;
             case UnknownResult msg:
                 _unknownResults++;
-                CheckForCompletion(msg.Pid);
+                await CheckForCompletion(msg.Pid);
 
                 break;
             case Result.FailedAndInconsistent msg:
                 _failedAndInconsistentResults++;
-                CheckForCompletion(msg.Pid);
+                await CheckForCompletion(msg.Pid);
 
                 break;
             case Result.FailedButConsistentResult msg:
                 _failedButConsistentResults++;
-                CheckForCompletion(msg.Pid);
+                await CheckForCompletion(msg.Pid);
 
                 break;
             case Started _:
@@ -104,8 +103,6 @@ public class Runner : IActor
 
                 break;
         }
-
-        return Task.CompletedTask;
     }
 
     private PID CreateAccount(IContext context, string name, Random random)
@@ -117,7 +114,7 @@ public class Runner : IActor
         return context.SpawnNamed(accountProps, name);
     }
 
-    private void CheckForCompletion(PID pid)
+    private async Task CheckForCompletion(PID pid)
     {
         _transfers.Remove(pid);
 
@@ -140,7 +137,7 @@ public class Runner : IActor
 
         if (remaining == 0)
         {
-            Thread.Sleep(250);
+            await Task.Delay(250);
             Console.WriteLine();
 
             Console.WriteLine(

--- a/examples/ReceiveTimeout/Program.cs
+++ b/examples/ReceiveTimeout/Program.cs
@@ -5,13 +5,12 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Proto;
 
 internal class Program
 {
-    private static void Main(string[] args)
+    private static async Task Main(string[] args)
     {
         var rootContext = new RootContext(new ActorSystem());
         var c = 0;
@@ -49,7 +48,7 @@ internal class Program
         for (var i = 0; i < 6; i++)
         {
             rootContext.Send(pid, "hello");
-            Thread.Sleep(500);
+            await Task.Delay(500);
         }
 
         Console.WriteLine("Hit [return] to send no-influence messages");
@@ -58,7 +57,7 @@ internal class Program
         for (var i = 0; i < 6; i++)
         {
             rootContext.Send(pid, new NoInfluence());
-            Thread.Sleep(500);
+            await Task.Delay(500);
         }
 
         Console.WriteLine("Hit [return] to send a message to cancel the timeout");

--- a/examples/Supervision/Program.cs
+++ b/examples/Supervision/Program.cs
@@ -6,14 +6,13 @@
 
 using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Proto;
 
 internal class Program
 {
-    private static void Main()
+    private static async Task Main()
     {
         var context = new RootContext(new ActorSystem());
         Log.SetLoggerFactory(LoggerFactory.Create(b => b.AddConsole().SetMinimumLevel(LogLevel.Debug)));
@@ -36,7 +35,7 @@ internal class Program
         //Stop is a system message and is not processed through the user message mailbox
         //thus, it will be handled _before_ any user message
         //we only do this to show the correct order of events in the console
-        Thread.Sleep(TimeSpan.FromSeconds(1));
+        await Task.Delay(TimeSpan.FromSeconds(1));
         context.Stop(actor);
         Console.ReadLine();
     }

--- a/src/Proto.Actor/Mailbox/BoundedMailboxQueue.cs
+++ b/src/Proto.Actor/Mailbox/BoundedMailboxQueue.cs
@@ -6,6 +6,7 @@
 
 using System.Threading;
 using System.Threading.Channels;
+using System.Threading.Tasks;
 
 namespace Proto.Mailbox;
 
@@ -27,10 +28,7 @@ public class BoundedMailboxQueue : IMailboxQueue
 
     public void Push(object message)
     {
-        while (!_messages.Writer.TryWrite(message))
-        {
-            Thread.Sleep(50);
-        }
+        _messages.Writer.WriteAsync(message).AsTask().GetAwaiter().GetResult();
 
         Interlocked.Increment(ref _length);
     }

--- a/src/Proto.Actor/Mailbox/MPMCQueue.cs
+++ b/src/Proto.Actor/Mailbox/MPMCQueue.cs
@@ -82,7 +82,7 @@ public class MPMCQueue
             }
 
             Task.Delay(1)
-                .Wait(); // Could be Thread.Sleep(1) or Thread.SpinWait() if the assembly is not portable lib.
+                .Wait(); // Could be Task.Delay(1) or Thread.SpinWait() if the assembly is not portable lib.
         }
     }
 

--- a/tests/Proto.Actor.Tests/Mailbox/MailboxQueuesTests.cs
+++ b/tests/Proto.Actor.Tests/Mailbox/MailboxQueuesTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Proto.Mailbox.Tests;
@@ -45,7 +46,7 @@ public class MailboxQueuesTests
     [Theory]
     [InlineData(MailboxQueueKind.Unbounded)]
     //[InlineData(MailboxQueueKind.Bounded)] -- temporarily disabled because the Bounded queue doesn't seem to work correctly
-    public void
+    public async Task
         Given_MailboxQueue_when_enqueue_and_dequeue_in_different_threads_Then_we_get_the_elements_in_the_FIFO_order(
             MailboxQueueKind kind)
     {
@@ -54,8 +55,8 @@ public class MailboxQueuesTests
 
         var sut = GetMailboxQueue(kind);
 
-        var producer = new Thread(
-            _ =>
+        var producer = Task.Run(
+            () =>
             {
                 for (var i = 0; i < msgCount; i++)
                 {
@@ -71,11 +72,9 @@ public class MailboxQueuesTests
 
         var consumerList = new List<int>();
 
-        var consumer = new Thread(
-            l =>
+        var consumer = Task.Run(
+            async () =>
             {
-                var list = (List<int>)l!;
-
                 for (var i = 0; i < msgCount; i++)
                 {
                     var popped = sut.Pop();
@@ -87,19 +86,16 @@ public class MailboxQueuesTests
                             return;
                         }
 
-                        Thread.Sleep(1);
+                        await Task.Delay(1, cancelSource.Token);
                         popped = sut.Pop();
                     }
 
-                    list.Add((int)popped);
+                    consumerList.Add((int)popped);
                 }
             }
         );
 
-        producer.Start();
-        consumer.Start(consumerList);
-        producer.Join(1000);
-        consumer.Join(1000);
+        await Task.WhenAll(producer, consumer).WaitAsync(TimeSpan.FromSeconds(1));
         cancelSource.Cancel();
 
         Assert.Equal(msgCount, consumerList.Count);

--- a/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Proto.Mailbox;
 using Proto.TestFixtures;
@@ -109,8 +108,8 @@ public class SupervisionTestsOneForOne
         context.Send(parent, "2nd restart");
         context.Send(parent, "3rd restart");
 
-        // wait more than the time period 
-        Thread.Sleep(500);
+        // wait more than the time period
+        await Task.Delay(500);
         Assert.DoesNotContain(Stop.Instance, childMailboxStats.Posted);
         Assert.DoesNotContain(Stop.Instance, childMailboxStats.Received);
 


### PR DESCRIPTION
## Summary
- replace remaining Thread.Sleep calls with Task.Delay across code, tests and examples
- update saga documentation to show async delays

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e159611f4832890e133dc2906ae11