### PR TITLE
docs: fix spelling of synonym in Terminology.md

### DIFF
--- a/Terminology.md
+++ b/Terminology.md
@@ -12,7 +12,7 @@ You access such actors by identity/name, if they do not already exist, the clust
 
 #### Grain
 
-Grains are a synomym with Virtual Actors, in Project Orleans, Grains live inside a Silo (a host).
+Grains are a synonym with Virtual Actors, in Project Orleans, Grains live inside a Silo (a host).
 
 #### Remote
 


### PR DESCRIPTION
## Summary
- fix misspelled word in Terminology.md

## Testing
- `rg synonym Terminology.md`
- `npx markdownlint Terminology.md` *(fails: 403 Forbidden)*
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e1ecb3c1c832895a4b611575a5ec8