### PR TITLE
remote: replace async void Disconnect with Task-returning method

### DIFF
--- a/src/Proto.Remote/Endpoints/EndpointReader.cs
+++ b/src/Proto.Remote/Endpoints/EndpointReader.cs
@@ -44,7 +44,7 @@ public sealed class EndpointReader : Remoting.RemotingBase
 
         var cancellationTokenSource = new CancellationTokenSource();
 
-        async void Disconnect()
+        async Task DisconnectAsync()
         {
             try
             {
@@ -65,13 +65,13 @@ public sealed class EndpointReader : Remoting.RemotingBase
             finally
             {
                 // When we disconnect, cancel the token, so the reader and writer both stop, and this method returns,
-                // so that the stream actually closes. Without this, when kestrel begins shutdown, it's possible the 
+                // so that the stream actually closes. Without this, when kestrel begins shutdown, it's possible the
                 // connection will stay open until the kestrel shutdown timeout is reached.
                 cancellationTokenSource.Cancel();
             }
         }
 
-        await using (_endpointManager.CancellationToken.Register(Disconnect).ConfigureAwait(false))
+        await using (_endpointManager.CancellationToken.Register(() => DisconnectAsync()).ConfigureAwait(false))
         {
             IEndpoint endpoint;
             string? address = null;


### PR DESCRIPTION
## Summary
- use Task-returning DisconnectAsync with async cancellation registration

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e1ef7c148832880267a2978faed47