### PR TITLE
test: remove arbitrary delays in ClusterTests for determinism

### DIFF
--- a/tests/Proto.Cluster.Tests/ClusterFixture.cs
+++ b/tests/Proto.Cluster.Tests/ClusterFixture.cs
@@ -44,6 +44,8 @@ public interface IClusterFixture
 
     Task RemoveNode(Cluster member, bool graceful = true);
 
+    Task WaitForMemberAsync(string memberId, bool shouldExist, CancellationToken ct = default);
+
     Task Trace(Func<Task> test, [CallerMemberName] string testName = "");
 }
 
@@ -195,6 +197,33 @@ public abstract class ClusterFixture : IAsyncLifetime, IClusterFixture, IAsyncDi
         {
             throw new ArgumentException("No such member");
         }
+    }
+
+    public async Task WaitForMemberAsync(string memberId, bool shouldExist, CancellationToken ct = default)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        if (ct == default)
+        {
+            cts.CancelAfter(TimeSpan.FromSeconds(10));
+        }
+
+        while (!cts.IsCancellationRequested)
+        {
+            var all = Members.All(m =>
+            {
+                var ids = m.MemberList.GetMembers();
+                return shouldExist ? ids.Contains(memberId) : !ids.Contains(memberId);
+            });
+
+            if (all)
+            {
+                return;
+            }
+
+            await Task.Delay(100, cts.Token);
+        }
+
+        throw new TimeoutException($"Timed out waiting for member {(shouldExist ? "join" : "leave")}: {memberId}");
     }
 
     public Task Trace(Func<Task> test, [CallerMemberName] string testName = "")

--- a/tests/Proto.Cluster.Tests/ClusterTests.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTests.cs
@@ -281,12 +281,13 @@ public abstract class ClusterTests : ClusterTestBase
                 }
             );
 
-            await Task.Delay(1000);
+            await ClusterFixture.WaitForMemberAsync(victim.System.Id, true);
             _testOutputHelper.WriteLine("Terminating node");
             await ClusterFixture.RemoveNode(victim);
+            await ClusterFixture.WaitForMemberAsync(victim.System.Id, false);
             _testOutputHelper.WriteLine("Spawning node");
-            await ClusterFixture.SpawnMember();
-            await Task.Delay(1000);
+            var newMember = await ClusterFixture.SpawnMember();
+            await ClusterFixture.WaitForMemberAsync(newMember.System.Id, true);
             cts.Cancel();
             await worker;
         }, _testOutputHelper);


### PR DESCRIPTION
## Summary
- add a `WaitForMemberAsync` helper on test cluster fixtures
- replace arbitrary delays in `HandlesLosingANodeWhileProcessing` with deterministic membership waits

## Testing
- `dotnet test tests/Proto.Cluster.Tests` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e1eed375083289c19796c498fa49b