### PR TITLE
Use TaskCompletionSource for mailbox scheduling tests

### DIFF
--- a/tests/Proto.Actor.Tests/Mailbox/MailboxSchedulingTests.cs
+++ b/tests/Proto.Actor.Tests/Mailbox/MailboxSchedulingTests.cs
@@ -21,15 +21,13 @@ public class MailboxSchedulingTests
         mailbox.PostUserMessage(msg1);
         mailbox.PostUserMessage(msg2);
 
-        await Task.Delay(1000);
-
         Assert.True(userMailbox.HasMessages,
             "Mailbox should not have processed msg2 because processing of msg1 is not completed."
         );
 
         msg2.TaskCompletionSource.SetResult(0);
         msg1.TaskCompletionSource.SetResult(0);
-        await Task.Delay(1000);
+        await Task.WhenAll(msg2.TaskCompletionSource.Task, msg1.TaskCompletionSource.Task);
 
         Assert.False(userMailbox.HasMessages,
             "Mailbox should have processed msg2 because processing of msg1 is completed."
@@ -53,7 +51,7 @@ public class MailboxSchedulingTests
         mailbox.PostUserMessage(msg1);
         mailbox.PostUserMessage(msg2);
 
-        await Task.Delay(1000);
+        await Task.WhenAll(msg1.TaskCompletionSource.Task, msg2.TaskCompletionSource.Task);
 
         Assert.False(userMailbox.HasMessages,
             "Mailbox should have processed both messages because they were already completed."
@@ -81,7 +79,7 @@ public class MailboxSchedulingTests
 
         msg2.TaskCompletionSource.SetResult(0);
         msg1.TaskCompletionSource.SetResult(0);
-        await Task.Delay(1000);
+        await Task.WhenAll(msg2.TaskCompletionSource.Task, msg1.TaskCompletionSource.Task);
 
         Assert.False(systemMessages.HasMessages,
             "Mailbox should have processed msg2 because processing of msg1 is completed."
@@ -104,7 +102,7 @@ public class MailboxSchedulingTests
 
         mailbox.PostSystemMessage(msg1);
         mailbox.PostSystemMessage(msg2);
-        await Task.Delay(1000);
+        await Task.WhenAll(msg1.TaskCompletionSource.Task, msg2.TaskCompletionSource.Task);
 
         Assert.False(systemMessages.HasMessages,
             "Mailbox should have processed both messages because they were already completed."
@@ -123,9 +121,9 @@ public class MailboxSchedulingTests
         var msg1 = new TestMessageWithTaskCompletionSource();
         mailbox.PostUserMessage(msg1);
 
-        await Task.Delay(1000);
+        Assert.Equal(MailboxStatus.Busy, mailbox.Status);
         msg1.TaskCompletionSource.SetResult(0);
-        await Task.Delay(1000);
+        await msg1.TaskCompletionSource.Task;
 
         Assert.True(mailbox.Status == MailboxStatus.Idle,
             "Mailbox should be set back to Idle after completion of message."

--- a/tests/Proto.Actor.Tests/Mailbox/MailboxSchedulingTests.cs
+++ b/tests/Proto.Actor.Tests/Mailbox/MailboxSchedulingTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Proto.TestFixtures;
 using Xunit;
 
@@ -22,15 +23,16 @@ public class MailboxSchedulingTests
         mailbox.PostUserMessage(msg2);
 
         Assert.True(userMailbox.HasMessages,
-            "Mailbox should not have processed msg2 because processing of msg1 is not completed."
+            "Mailbox should not have processed msg2 because processing of msg1 is not completed.",
         );
 
         msg2.TaskCompletionSource.SetResult(0);
         msg1.TaskCompletionSource.SetResult(0);
         await Task.WhenAll(msg2.TaskCompletionSource.Task, msg1.TaskCompletionSource.Task);
+        SpinWait.SpinUntil(() => !userMailbox.HasMessages, 1000);
 
         Assert.False(userMailbox.HasMessages,
-            "Mailbox should have processed msg2 because processing of msg1 is completed."
+            "Mailbox should have processed msg2 because processing of msg1 is completed.",
         );
     }
 
@@ -54,7 +56,7 @@ public class MailboxSchedulingTests
         await Task.WhenAll(msg1.TaskCompletionSource.Task, msg2.TaskCompletionSource.Task);
 
         Assert.False(userMailbox.HasMessages,
-            "Mailbox should have processed both messages because they were already completed."
+            "Mailbox should have processed both messages because they were already completed.",
         );
     }
 
@@ -74,15 +76,16 @@ public class MailboxSchedulingTests
         mailbox.PostSystemMessage(msg2);
 
         Assert.True(systemMessages.HasMessages,
-            "Mailbox should not have processed msg2 because processing of msg1 is not completed."
+            "Mailbox should not have processed msg2 because processing of msg1 is not completed.",
         );
 
         msg2.TaskCompletionSource.SetResult(0);
         msg1.TaskCompletionSource.SetResult(0);
         await Task.WhenAll(msg2.TaskCompletionSource.Task, msg1.TaskCompletionSource.Task);
+        SpinWait.SpinUntil(() => !systemMessages.HasMessages, 1000);
 
         Assert.False(systemMessages.HasMessages,
-            "Mailbox should have processed msg2 because processing of msg1 is completed."
+            "Mailbox should have processed msg2 because processing of msg1 is completed.",
         );
     }
 
@@ -105,7 +108,7 @@ public class MailboxSchedulingTests
         await Task.WhenAll(msg1.TaskCompletionSource.Task, msg2.TaskCompletionSource.Task);
 
         Assert.False(systemMessages.HasMessages,
-            "Mailbox should have processed both messages because they were already completed."
+            "Mailbox should have processed both messages because they were already completed.",
         );
     }
 
@@ -124,9 +127,11 @@ public class MailboxSchedulingTests
         Assert.Equal(MailboxStatus.Busy, mailbox.Status);
         msg1.TaskCompletionSource.SetResult(0);
         await msg1.TaskCompletionSource.Task;
+        SpinWait.SpinUntil(() => mailbox.Status == MailboxStatus.Idle, 1000);
 
         Assert.True(mailbox.Status == MailboxStatus.Idle,
-            "Mailbox should be set back to Idle after completion of message."
+            "Mailbox should be set back to Idle after completion of message.",
         );
     }
 }
+


### PR DESCRIPTION
## Summary
- replace Task.Delay with TaskCompletionSource.Task in mailbox scheduling tests
- ensure mailbox becomes idle after message completion without fixed waits

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e24bb179c83288fbea8d7ba93bf39