### PR TITLE
docs: fix Proto.Cluster terminology typo

### DIFF
--- a/Terminology.md
+++ b/Terminology.md
@@ -21,7 +21,7 @@ It basically provides the actor system to resolve `PIDs` that point to another a
 
 #### Cluster
 
-Proto.Cluster, is a orechestration mechanism built ontop of Proto.Remote, it makes it possible to work with Virtual Actors. see above.
+Proto.Cluster, is an orchestration mechanism built on top of Proto.Remote, it makes it possible to work with Virtual Actors. see above.
 
 #### Router
 


### PR DESCRIPTION
## Summary
- fix typo in Terminology for Proto.Cluster description

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_688e24c72b288328ace6b0cea41df406