### PR TITLE
chore: update copyright headers

### DIFF
--- a/src/Proto.Actor/ActorSystem.cs
+++ b/src/Proto.Actor/ActorSystem.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ActorSystem.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Behavior.cs
+++ b/src/Proto.Actor/Behavior.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Behavior.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/CancellationTokens.cs
+++ b/src/Proto.Actor/CancellationTokens.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="CancellationTokens.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Configuration/ActorSystemConfig.cs
+++ b/src/Proto.Actor/Configuration/ActorSystemConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ActorSystemConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ActorContext.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/ActorContextDecorator.cs
+++ b/src/Proto.Actor/Context/ActorContextDecorator.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ActorContextDecorator.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/ActorContextExtras.cs
+++ b/src/Proto.Actor/Context/ActorContextExtras.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ActorContextExtras.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/ActorLoggingContext.cs
+++ b/src/Proto.Actor/Context/ActorLoggingContext.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ActorLoggingDecorator.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/BatchContext.cs
+++ b/src/Proto.Actor/Context/BatchContext.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="BatchContext.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/ContextState.cs
+++ b/src/Proto.Actor/Context/ContextState.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ContextState.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/DeadlineContextDecorator.cs
+++ b/src/Proto.Actor/Context/DeadlineContextDecorator.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="DeadlineContextDecorator.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/IContext.cs
+++ b/src/Proto.Actor/Context/IContext.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="IContext.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/IContextStore.cs
+++ b/src/Proto.Actor/Context/IContextStore.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="IReceiverContext.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/IInfoContext.cs
+++ b/src/Proto.Actor/Context/IInfoContext.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IInfoContext.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/IReceiverContext.cs
+++ b/src/Proto.Actor/Context/IReceiverContext.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="IReceiverContext.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/ISenderContext.cs
+++ b/src/Proto.Actor/Context/ISenderContext.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ISenderContext.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/ISpawnerContext.cs
+++ b/src/Proto.Actor/Context/ISpawnerContext.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ISpawnerContext.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/IStopperContext.cs
+++ b/src/Proto.Actor/Context/IStopperContext.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IStopperContext.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/ISystemContext.cs
+++ b/src/Proto.Actor/Context/ISystemContext.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ISystemContext.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/RootContext.cs
+++ b/src/Proto.Actor/Context/RootContext.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="RootContext.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/RootContextDecorator.cs
+++ b/src/Proto.Actor/Context/RootContextDecorator.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="RootContextDecorator.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/StartupDeadlineContextDecorator.cs
+++ b/src/Proto.Actor/Context/StartupDeadlineContextDecorator.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="DeadlineContextDecorator.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Context/SystemContext.cs
+++ b/src/Proto.Actor/Context/SystemContext.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file = "SystemContext.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Deduplication/DeduplicationContext.cs
+++ b/src/Proto.Actor/Deduplication/DeduplicationContext.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="DeduplicationContext.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Delegates.cs
+++ b/src/Proto.Actor/Delegates.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Delegates.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/DependencyInjection/DIExtension.cs
+++ b/src/Proto.Actor/DependencyInjection/DIExtension.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="DIExtension.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/DependencyInjection/DependencyResolver.cs
+++ b/src/Proto.Actor/DependencyInjection/DependencyResolver.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="DependencyResolver.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/DependencyInjection/IDependencyResolver.cs
+++ b/src/Proto.Actor/DependencyInjection/IDependencyResolver.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IDependencyResolver.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Diagnostics/DiagnosticTools.cs
+++ b/src/Proto.Actor/Diagnostics/DiagnosticTools.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="DiagnosticTools.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Diagnostics/DiagnosticsSerializer.cs
+++ b/src/Proto.Actor/Diagnostics/DiagnosticsSerializer.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="DiagnosticsSerializer.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Diagnostics/IActorDiagnostics.cs
+++ b/src/Proto.Actor/Diagnostics/IActorDiagnostics.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IActorDiagnostics.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/EventStream/DeadLetter.cs
+++ b/src/Proto.Actor/EventStream/DeadLetter.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="DeadLetter.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/EventStream/EventExpectation.cs
+++ b/src/Proto.Actor/EventStream/EventExpectation.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="EventExpectation.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/EventStream/EventProbe.cs
+++ b/src/Proto.Actor/EventStream/EventProbe.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="EventProbe.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/EventStream/EventStream.cs
+++ b/src/Proto.Actor/EventStream/EventStream.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="EventStream.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/EventStream/EventStreamProcess.cs
+++ b/src/Proto.Actor/EventStream/EventStreamProcess.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="EventStreamProcess.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Exceptions.cs
+++ b/src/Proto.Actor/Exceptions.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Exceptions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Extensions.cs
+++ b/src/Proto.Actor/Extensions.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Extensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Extensions/ActorSystemExtensions.cs
+++ b/src/Proto.Actor/Extensions/ActorSystemExtensions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ActorSystemExtensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Extensions/IActorSystemExtension.cs
+++ b/src/Proto.Actor/Extensions/IActorSystemExtension.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IActorSystemExtension.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/FunctionActor.cs
+++ b/src/Proto.Actor/FunctionActor.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="FunctionActor.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Future/FutureBatch.cs
+++ b/src/Proto.Actor/Future/FutureBatch.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="FutureBatch.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Future/Futures.cs
+++ b/src/Proto.Actor/Future/Futures.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Futures.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Future/SharedFuture.cs
+++ b/src/Proto.Actor/Future/SharedFuture.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="SharedFuture.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/IActor.cs
+++ b/src/Proto.Actor/IActor.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="IActor.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/InternalsVisibleTo.cs
+++ b/src/Proto.Actor/InternalsVisibleTo.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="InternalsVisibleTo.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Logging/Extensions.cs
+++ b/src/Proto.Actor/Logging/Extensions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="Extensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Logging/InstanceLogger.cs
+++ b/src/Proto.Actor/Logging/InstanceLogger.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="InstanceLogger.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Logging/Log.cs
+++ b/src/Proto.Actor/Logging/Log.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="Log.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Logging/LogStore.cs
+++ b/src/Proto.Actor/Logging/LogStore.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="LogStore.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Logging/LogStoreEntry.cs
+++ b/src/Proto.Actor/Logging/LogStoreEntry.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="LogStoreEntry.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Logging/NullLoggerFactory.cs
+++ b/src/Proto.Actor/Logging/NullLoggerFactory.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="NullLoggerFactory.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Mailbox/BatchingMailbox.cs
+++ b/src/Proto.Actor/Mailbox/BatchingMailbox.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="BatchingMailbox.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Mailbox/BoundedMailboxQueue.cs
+++ b/src/Proto.Actor/Mailbox/BoundedMailboxQueue.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="BoundedMailboxQueue.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Mailbox/Dispatcher.cs
+++ b/src/Proto.Actor/Mailbox/Dispatcher.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Dispatcher.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Mailbox/LockingUnboundedMailboxQueue.cs
+++ b/src/Proto.Actor/Mailbox/LockingUnboundedMailboxQueue.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file = "LockingUnboundedMailboxQueue.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Mailbox/MPMCQueue.cs
+++ b/src/Proto.Actor/Mailbox/MPMCQueue.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="MPMCQueue.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Mailbox/Mailbox.cs
+++ b/src/Proto.Actor/Mailbox/Mailbox.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Mailbox.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Mailbox/Messages.cs
+++ b/src/Proto.Actor/Mailbox/Messages.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Messages.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Mailbox/NonBlockingBoundedMailbox.cs
+++ b/src/Proto.Actor/Mailbox/NonBlockingBoundedMailbox.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="NonBlockingBoundedMailbox.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Mailbox/Queue.cs
+++ b/src/Proto.Actor/Mailbox/Queue.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Queue.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Mailbox/UnboundedMailboxQueue.cs
+++ b/src/Proto.Actor/Mailbox/UnboundedMailboxQueue.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="UnboundedMailboxQueue.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Messages/IAutoRespond.cs
+++ b/src/Proto.Actor/Messages/IAutoRespond.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IMessageAutoAck.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Messages/IMessageBatch.cs
+++ b/src/Proto.Actor/Messages/IMessageBatch.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IMessageBatch.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Messages/MessageEnvelope.cs
+++ b/src/Proto.Actor/Messages/MessageEnvelope.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="MessageEnvelope.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Messages/MessageExtensions.cs
+++ b/src/Proto.Actor/Messages/MessageExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="MessageExtensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Messages/MessageHeader.cs
+++ b/src/Proto.Actor/Messages/MessageHeader.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="MessageHeader.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Messages/Messages.cs
+++ b/src/Proto.Actor/Messages/Messages.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Messages.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Metrics/ActorMetrics.cs
+++ b/src/Proto.Actor/Metrics/ActorMetrics.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ActorMetrics.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Metrics/MetricsExtensions.cs
+++ b/src/Proto.Actor/Metrics/MetricsExtensions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="MetricsExtensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Metrics/ObservableGaugeWrapper.cs
+++ b/src/Proto.Actor/Metrics/ObservableGaugeWrapper.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ObservableGaugeWrapper.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Middleware.cs
+++ b/src/Proto.Actor/Middleware.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="Middleware.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/PID.cs
+++ b/src/Proto.Actor/PID.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="PID.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Process/ActorProcess.cs
+++ b/src/Proto.Actor/Process/ActorProcess.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ActorProcess.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Process/Process.cs
+++ b/src/Proto.Actor/Process/Process.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Process.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Process/ProcessRegistry.cs
+++ b/src/Proto.Actor/Process/ProcessRegistry.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ProcessRegistry.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Properties/AssemblyInfo.cs
+++ b/src/Proto.Actor/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="AssemblyInfo.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Props/Props.cs
+++ b/src/Proto.Actor/Props/Props.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Props.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/HashRing.cs
+++ b/src/Proto.Actor/Router/HashRing.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="HashRing.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/IHashable.cs
+++ b/src/Proto.Actor/Router/IHashable.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IHashable.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Messages/RouterMessages.cs
+++ b/src/Proto.Actor/Router/Messages/RouterMessages.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="RouterMessages.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/RouterActor.cs
+++ b/src/Proto.Actor/Router/RouterActor.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="RouterActor.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/RouterExtensions.cs
+++ b/src/Proto.Actor/Router/RouterExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="RouterExtensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/RouterProcess.cs
+++ b/src/Proto.Actor/Router/RouterProcess.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="RouterProcess.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/BroadcastGroupRouterConfig.cs
+++ b/src/Proto.Actor/Router/Routers/BroadcastGroupRouterConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="BroadcastGroupRouterConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/BroadcastPoolRouterConfig.cs
+++ b/src/Proto.Actor/Router/Routers/BroadcastPoolRouterConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="BroadcastPoolRouterConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/BroadcastRouterState.cs
+++ b/src/Proto.Actor/Router/Routers/BroadcastRouterState.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="BroadcastRouterState.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/ConsistentHashGroupRouterConfig.cs
+++ b/src/Proto.Actor/Router/Routers/ConsistentHashGroupRouterConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ConsistentHashGroupRouterConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/ConsistentHashPoolRouterConfig.cs
+++ b/src/Proto.Actor/Router/Routers/ConsistentHashPoolRouterConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ConsistentHashPoolRouterConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/ConsistentHashRouterState.cs
+++ b/src/Proto.Actor/Router/Routers/ConsistentHashRouterState.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ConsistentHashRouterState.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/GroupRouterConfig.cs
+++ b/src/Proto.Actor/Router/Routers/GroupRouterConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="GroupRouterConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/PoolRouterConfig.cs
+++ b/src/Proto.Actor/Router/Routers/PoolRouterConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="PoolRouterConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/RandomGroupRouterConfig.cs
+++ b/src/Proto.Actor/Router/Routers/RandomGroupRouterConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="RandomGroupRouterConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/RandomPoolRouterConfig.cs
+++ b/src/Proto.Actor/Router/Routers/RandomPoolRouterConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="RandomPoolRouterConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/RandomRouterState.cs
+++ b/src/Proto.Actor/Router/Routers/RandomRouterState.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="RandomRouterState.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/RoundRobinGroupRouterConfig.cs
+++ b/src/Proto.Actor/Router/Routers/RoundRobinGroupRouterConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="RoundRobinGroupRouterConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/RoundRobinPoolRouterConfig.cs
+++ b/src/Proto.Actor/Router/Routers/RoundRobinPoolRouterConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="RoundRobinPoolRouterConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/RoundRobinRouterState.cs
+++ b/src/Proto.Actor/Router/Routers/RoundRobinRouterState.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="RoundRobinRouterState.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/RouterConfig.cs
+++ b/src/Proto.Actor/Router/Routers/RouterConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="RouterConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Router/Routers/RouterState.cs
+++ b/src/Proto.Actor/Router/Routers/RouterState.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="RouterState.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Stashing/CapturedContext.cs
+++ b/src/Proto.Actor/Stashing/CapturedContext.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="StashedMessage.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Stopper.cs
+++ b/src/Proto.Actor/Stopper.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file = "Stopper.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Supervision/AllForOneStrategy.cs
+++ b/src/Proto.Actor/Supervision/AllForOneStrategy.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="AllForOneStrategy.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Supervision/AlwaysRestartStrategy.cs
+++ b/src/Proto.Actor/Supervision/AlwaysRestartStrategy.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="AlwaysRestartStrategy.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Supervision/ExponentialBackoffStrategy.cs
+++ b/src/Proto.Actor/Supervision/ExponentialBackoffStrategy.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ExponentialBackoffStrategy.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Supervision/Guardians.cs
+++ b/src/Proto.Actor/Supervision/Guardians.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="Guardians.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Supervision/ISupervisor.cs
+++ b/src/Proto.Actor/Supervision/ISupervisor.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ISupervisor.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Supervision/ISupervisorStrategy.cs
+++ b/src/Proto.Actor/Supervision/ISupervisorStrategy.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ISupervisorStrategy.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Supervision/OneForOneStrategy.cs
+++ b/src/Proto.Actor/Supervision/OneForOneStrategy.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="OneForOneStrategy.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Supervision/RestartStatistics.cs
+++ b/src/Proto.Actor/Supervision/RestartStatistics.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="RestartStatistics.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Supervision/Supervision.cs
+++ b/src/Proto.Actor/Supervision/Supervision.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Supervision.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Supervision/SupervisorDirective.cs
+++ b/src/Proto.Actor/Supervision/SupervisorDirective.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="SupervisorDirective.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Utils/AsyncSemaphore.cs
+++ b/src/Proto.Actor/Utils/AsyncSemaphore.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ConnectionThrottlingPipeline.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Utils/ConcurrentKeyValueStore.cs
+++ b/src/Proto.Actor/Utils/ConcurrentKeyValueStore.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ConcurrentKeyValueStore.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Utils/ConcurrentSet.cs
+++ b/src/Proto.Actor/Utils/ConcurrentSet.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ConcurrentSet.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Utils/EmptyKeyValueStore.cs
+++ b/src/Proto.Actor/Utils/EmptyKeyValueStore.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="EmptyKeyValueStore<T>.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Utils/IKeyValueStore.cs
+++ b/src/Proto.Actor/Utils/IKeyValueStore.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IKeyValueStore.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Utils/MurMurHash2.cs
+++ b/src/Proto.Actor/Utils/MurMurHash2.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="MurMurHash2.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Utils/Retry.cs
+++ b/src/Proto.Actor/Utils/Retry.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="Retry.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Utils/TaskClock.cs
+++ b/src/Proto.Actor/Utils/TaskClock.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="TaskClock.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Utils/TaskExtensions.cs
+++ b/src/Proto.Actor/Utils/TaskExtensions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="TaskExtensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Utils/TaskFactory.cs
+++ b/src/Proto.Actor/Utils/TaskFactory.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="TaskFactory.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Utils/ThreadPoolStats.cs
+++ b/src/Proto.Actor/Utils/ThreadPoolStats.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ThreadPoolStats.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Utils/Throttle.cs
+++ b/src/Proto.Actor/Utils/Throttle.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Throttle.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Actor/Utils/TypedDictionary.cs
+++ b/src/Proto.Actor/Utils/TypedDictionary.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="TypedDictionary.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.AmazonECS/AmazonEcsProvider.cs
+++ b/src/Proto.Cluster.AmazonECS/AmazonEcsProvider.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="AmazonEcsProvider.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.AmazonECS/AmazonEcsProviderConfig.cs
+++ b/src/Proto.Cluster.AmazonECS/AmazonEcsProviderConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="AmazonEcsProviderConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.AmazonECS/AwsHttpClient.cs
+++ b/src/Proto.Cluster.AmazonECS/AwsHttpClient.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="AwsHttpClient.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.AmazonECS/EcsUtils.cs
+++ b/src/Proto.Cluster.AmazonECS/EcsUtils.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="EcsUtils.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.AmazonECS/ProtoLabels.cs
+++ b/src/Proto.Cluster.AmazonECS/ProtoLabels.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ProtoLabels.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.CodeGen/CodeGenerator.cs
+++ b/src/Proto.Cluster.CodeGen/CodeGenerator.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="GrainGen.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.CodeGen/Generator.cs
+++ b/src/Proto.Cluster.CodeGen/Generator.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="Generator.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.CodeGen/OutputFileName.cs
+++ b/src/Proto.Cluster.CodeGen/OutputFileName.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="OutputFileName.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.CodeGen/PathPolyfill.cs
+++ b/src/Proto.Cluster.CodeGen/PathPolyfill.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Polyfills.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.CodeGen/Properties/AssemblyInfo.cs
+++ b/src/Proto.Cluster.CodeGen/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="AssemblyInfo.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.CodeGen/Template.cs
+++ b/src/Proto.Cluster.CodeGen/Template.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Template.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.CodeGen/model/ProtoField.cs
+++ b/src/Proto.Cluster.CodeGen/model/ProtoField.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ProtoField.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.CodeGen/model/ProtoFile.cs
+++ b/src/Proto.Cluster.CodeGen/model/ProtoFile.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ProtoFile.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.CodeGen/model/ProtoHack.cs
+++ b/src/Proto.Cluster.CodeGen/model/ProtoHack.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ProtoHack.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.CodeGen/model/ProtoMessage.cs
+++ b/src/Proto.Cluster.CodeGen/model/ProtoMessage.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ProtoMessage.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.CodeGen/model/ProtoMethod.cs
+++ b/src/Proto.Cluster.CodeGen/model/ProtoMethod.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Proto.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.CodeGen/model/ProtoService.cs
+++ b/src/Proto.Cluster.CodeGen/model/ProtoService.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ProtoService.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/Proto.Cluster.Consul/ConsulProvider.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ConsulProvider.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.Consul/ConsulProviderConfig.cs
+++ b/src/Proto.Cluster.Consul/ConsulProviderConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ConsulProviderConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.Dashboard/DashboardSettings.cs
+++ b/src/Proto.Cluster.Dashboard/DashboardSettings.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file = "DashboardSettings.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.Identity.Redis/RedisIdentityStorage.cs
+++ b/src/Proto.Cluster.Identity.Redis/RedisIdentityStorage.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="RedisIdentityStorage.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.Kubernetes/KubernetesClusterMonitor.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesClusterMonitor.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="KubernetesClusterMonitor.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.Kubernetes/KubernetesExtensions.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesExtensions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="KubernetesExtensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProvider.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="KubernetesProvider.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.Kubernetes/KubernetesProviderConfig.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesProviderConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="KubernetesProviderConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.Kubernetes/Messages.cs
+++ b/src/Proto.Cluster.Kubernetes/Messages.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="Messages.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.Kubernetes/ProtoLabels.cs
+++ b/src/Proto.Cluster.Kubernetes/ProtoLabels.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ProtoLabels.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.TestProvider/AgentServiceRegistration.cs
+++ b/src/Proto.Cluster.TestProvider/AgentServiceRegistration.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="AgentServiceRegistration.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.TestProvider/InMemAgent.cs
+++ b/src/Proto.Cluster.TestProvider/InMemAgent.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="InMemAgent.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.TestProvider/Messages.cs
+++ b/src/Proto.Cluster.TestProvider/Messages.cs
@@ -1,6 +1,6 @@
 // // -----------------------------------------------------------------------
 // // <copyright file="Messages.cs" company="Asynkron AB">
-// //      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+// //      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // // </copyright>
 // // -----------------------------------------------------------------------
 // using JetBrains.Annotations;

--- a/src/Proto.Cluster.TestProvider/QueryOptions.cs
+++ b/src/Proto.Cluster.TestProvider/QueryOptions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="QueryOptions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.TestProvider/TestProvider.cs
+++ b/src/Proto.Cluster.TestProvider/TestProvider.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="TestProvider.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster.TestProvider/TestProviderOptions.cs
+++ b/src/Proto.Cluster.TestProvider/TestProviderOptions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="TestProviderOptions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/ActivatedClusterKind.cs
+++ b/src/Proto.Cluster/ActivatedClusterKind.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ClusterKind.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Cache/CacheInvalidationExtensions.cs
+++ b/src/Proto.Cluster/Cache/CacheInvalidationExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="CacheInvalidationExtensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Cache/ClusterCacheInvalidation.cs
+++ b/src/Proto.Cluster/Cache/ClusterCacheInvalidation.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ClusterCacheInvalidation.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Cluster.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/ClusterConfig.cs
+++ b/src/Proto.Cluster/ClusterConfig.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ClusterConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/ClusterContext.cs
+++ b/src/Proto.Cluster/ClusterContext.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="RequestAsyncStrategy.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/ClusterExtension.cs
+++ b/src/Proto.Cluster/ClusterExtension.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ClusterExtension.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/ClusterExtensions.cs
+++ b/src/Proto.Cluster/ClusterExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ClusterExtensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/ClusterKind.cs
+++ b/src/Proto.Cluster/ClusterKind.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ClusterKind.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/DefaultClusterContext.cs
+++ b/src/Proto.Cluster/DefaultClusterContext.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ExperimentalClusterContext.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Gossip/Consensus.cs
+++ b/src/Proto.Cluster/Gossip/Consensus.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ClusterConsensus.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Gossip/ConsensusChecks.cs
+++ b/src/Proto.Cluster/Gossip/ConsensusChecks.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ConsensusState.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Gossip/Extensions.cs
+++ b/src/Proto.Cluster/Gossip/Extensions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="Extensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Gossip/Gossip.cs
+++ b/src/Proto.Cluster/Gossip/Gossip.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="GossipFoo.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Gossip/GossipActor.cs
+++ b/src/Proto.Cluster/Gossip/GossipActor.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="GossipActor.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Gossip/GossipKeyValue.cs
+++ b/src/Proto.Cluster/Gossip/GossipKeyValue.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="GossipKeyValue.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Gossip/GossipKeys.cs
+++ b/src/Proto.Cluster/Gossip/GossipKeys.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file = "GossipKeys.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Gossip/GossipStateManagement.cs
+++ b/src/Proto.Cluster/Gossip/GossipStateManagement.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="GossipState.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ClusterHeartBeat.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Gossip/IConsensusCheckDefinition.cs
+++ b/src/Proto.Cluster/Gossip/IConsensusCheckDefinition.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="IConsensusCheck.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Gossip/IDeltaValue.cs
+++ b/src/Proto.Cluster/Gossip/IDeltaValue.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IDeltaValue.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Gossip/IGossip.cs
+++ b/src/Proto.Cluster/Gossip/IGossip.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IGossipInternal.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Gossip/MemberStateDelta.cs
+++ b/src/Proto.Cluster/Gossip/MemberStateDelta.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="MemberStateDelta.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Gossip/RandomOrderExtensions.cs
+++ b/src/Proto.Cluster/Gossip/RandomOrderExtensions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="RandomOrderExtensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Grain/ContextExtensions.cs
+++ b/src/Proto.Cluster/Grain/ContextExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ContextExtensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Grain/GrainRequest.cs
+++ b/src/Proto.Cluster/Grain/GrainRequest.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="GrainRequest.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Grain/GrainRequestMessage.cs
+++ b/src/Proto.Cluster/Grain/GrainRequestMessage.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="Extensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Grain/GrainResponse.cs
+++ b/src/Proto.Cluster/Grain/GrainResponse.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="GrainResponse.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Grain/GrainResponseMessage.cs
+++ b/src/Proto.Cluster/Grain/GrainResponseMessage.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="GrainResponseMessage.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Healthchecks/Healthcheck.cs
+++ b/src/Proto.Cluster/Healthchecks/Healthcheck.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file = "Healthcheck.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/IClusterProvider.cs
+++ b/src/Proto.Cluster/IClusterProvider.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="IClusterProvider.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Identity/IIdentityLookup.cs
+++ b/src/Proto.Cluster/Identity/IIdentityLookup.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IIdentityLookup.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Identity/IIdentityStorage.cs
+++ b/src/Proto.Cluster/Identity/IIdentityStorage.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="IIdentityStorage.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Identity/IdentityActivatorProxy.cs
+++ b/src/Proto.Cluster/Identity/IdentityActivatorProxy.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="IdentityActivatorProxy.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Identity/IdentityIsBlockedException.cs
+++ b/src/Proto.Cluster/Identity/IdentityIsBlockedException.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file = "IdentityIsBlockedException.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Identity/IdentityMetrics.cs
+++ b/src/Proto.Cluster/Identity/IdentityMetrics.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IdentityMetrics.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
+++ b/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 //   <copyright file="IdentityStoragePlacementActor.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IdentityStorageWorker.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/InternalsVisibleTo.cs
+++ b/src/Proto.Cluster/InternalsVisibleTo.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="InternalsVisibleTo.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Member.cs
+++ b/src/Proto.Cluster/Member.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Member.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Member/GossipMemberStrategy.cs
+++ b/src/Proto.Cluster/Member/GossipMemberStrategy.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file = "GossipMemberStrategy.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Collections.Concurrent;

--- a/src/Proto.Cluster/Member/ImmutableMemberSet.cs
+++ b/src/Proto.Cluster/Member/ImmutableMemberSet.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ImmutableMemberSet.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Member/LeaderElection.cs
+++ b/src/Proto.Cluster/Member/LeaderElection.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="LeaderElection.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Member/LocalAffinityExtensions.cs
+++ b/src/Proto.Cluster/Member/LocalAffinityExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="LocalAffinityPropsExtensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Member/LocalAffinityOptions.cs
+++ b/src/Proto.Cluster/Member/LocalAffinityOptions.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="LocalAffinityOptions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Member/LocalAffinityStrategy.cs
+++ b/src/Proto.Cluster/Member/LocalAffinityStrategy.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="LocalAffinityStrategy.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Member/MemberList.cs
+++ b/src/Proto.Cluster/Member/MemberList.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="MemberList.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Member/MemberStrategy.cs
+++ b/src/Proto.Cluster/Member/MemberStrategy.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="MemberStrategy.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Member/MetaMember.cs
+++ b/src/Proto.Cluster/Member/MetaMember.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="MetaMember.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Member/RoundRobinMemberSelector.cs
+++ b/src/Proto.Cluster/Member/RoundRobinMemberSelector.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="RoundRobinMemberSelector.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Messages/Messages.cs
+++ b/src/Proto.Cluster/Messages/Messages.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Messages.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Metrics/ClusterMetrics.cs
+++ b/src/Proto.Cluster/Metrics/ClusterMetrics.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ClusterMetrics.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Partition/Extensions.cs
+++ b/src/Proto.Cluster/Partition/Extensions.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Extensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Partition/HandoverSink.cs
+++ b/src/Proto.Cluster/Partition/HandoverSink.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="PartitionIdentityHandover.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Partition/HandoverSource.cs
+++ b/src/Proto.Cluster/Partition/HandoverSource.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="HandoverSource.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Partition/IndexSet.cs
+++ b/src/Proto.Cluster/Partition/IndexSet.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ChunkEvaluator.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Partition/MemberHashRing.cs
+++ b/src/Proto.Cluster/Partition/MemberHashRing.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="MemberRing.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Partition/PartitionConfig.cs
+++ b/src/Proto.Cluster/Partition/PartitionConfig.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="PartitionConfig.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="PartitionIdentityActor.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Partition/PartitionIdentityLookup.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityLookup.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="PartitionIdentityLookup.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Partition/PartitionIdentityRebalanceWorker.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityRebalanceWorker.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="TopologyRelocationActor.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Partition/PartitionManager.cs
+++ b/src/Proto.Cluster/Partition/PartitionManager.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="PartitionManager.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Partition/PartitionMemberSelector.cs
+++ b/src/Proto.Cluster/Partition/PartitionMemberSelector.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="PartitionMemberSelector.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="PartitionPlacementActor.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Partition/Rendezvous.cs
+++ b/src/Proto.Cluster/Partition/Rendezvous.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Rendezvous.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="PartitionActivatorActor.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorLookup.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorLookup.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="PartitionActivatorLookup.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorManager.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorManager.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="PartitionManager.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorSelector.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorSelector.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="PartitionActivatorSelector.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PartitionActivator/RendezvousFast.cs
+++ b/src/Proto.Cluster/PartitionActivator/RendezvousFast.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="PartitionActivatorActor.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PidCache.cs
+++ b/src/Proto.Cluster/PidCache.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="PidCache.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Properties/AssemblyInfo.cs
+++ b/src/Proto.Cluster/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="AssemblyInfo.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PubSub/BatchingProducer.cs
+++ b/src/Proto.Cluster/PubSub/BatchingProducer.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="Publisher.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PubSub/BatchingProducerConfig.cs
+++ b/src/Proto.Cluster/PubSub/BatchingProducerConfig.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file = "BatchingProducerConfig.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PubSub/DeliverBatchRequest.cs
+++ b/src/Proto.Cluster/PubSub/DeliverBatchRequest.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="SubscriberBatchMessage.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PubSub/IPublisher.cs
+++ b/src/Proto.Cluster/PubSub/IPublisher.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file = "IPublisher.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PubSub/PubSubAutoRespondBatch.cs
+++ b/src/Proto.Cluster/PubSub/PubSubAutoRespondBatch.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="Messages.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PubSub/PubSubBatch.cs
+++ b/src/Proto.Cluster/PubSub/PubSubBatch.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="Messages.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PubSub/PubSubConfig.cs
+++ b/src/Proto.Cluster/PubSub/PubSubConfig.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file = "PubSubConfig.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PubSub/PubSubDeliveryException.cs
+++ b/src/Proto.Cluster/PubSub/PubSubDeliveryException.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file = "PubSubDeliveryException.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PubSub/PubSubExtension.cs
+++ b/src/Proto.Cluster/PubSub/PubSubExtension.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="PubSubManager.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PubSub/PubSubExtensions.cs
+++ b/src/Proto.Cluster/PubSub/PubSubExtensions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="Extensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PubSub/PubSubMemberDeliveryActor.cs
+++ b/src/Proto.Cluster/PubSub/PubSubMemberDeliveryActor.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="PubSubMemberDeliveryActor.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PubSub/Publisher.cs
+++ b/src/Proto.Cluster/PubSub/Publisher.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file = "Publisher.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PubSub/PublishingErrorDecision.cs
+++ b/src/Proto.Cluster/PubSub/PublishingErrorDecision.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file = "PublishingErrorDecision.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/PubSub/TopicActor.cs
+++ b/src/Proto.Cluster/PubSub/TopicActor.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="TopicActor.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Seed/Messages.cs
+++ b/src/Proto.Cluster/Seed/Messages.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file = "Messages.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Seed/SeedClientNodeActor.cs
+++ b/src/Proto.Cluster/Seed/SeedClientNodeActor.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file = "SeedClientNodeActor.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Seed/SeedNodeActor.cs
+++ b/src/Proto.Cluster/Seed/SeedNodeActor.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file = "SeedNodeActor.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Seed/SeedNodeClusterProvider.cs
+++ b/src/Proto.Cluster/Seed/SeedNodeClusterProvider.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file = "SeedNodeClusterProvider.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/Seed/SeedNodeClusterProviderOptions.cs
+++ b/src/Proto.Cluster/Seed/SeedNodeClusterProviderOptions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file = "SeedNodeClusterProviderOptions.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/SingleNode/SingleNodeActivatorActor.cs
+++ b/src/Proto.Cluster/SingleNode/SingleNodeActivatorActor.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="SingleNodeActivatorActor.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/SingleNode/SingleNodeLookup.cs
+++ b/src/Proto.Cluster/SingleNode/SingleNodeLookup.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="SingleNodeLookup.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Cluster/SingleNode/SingleNodeProvider.cs
+++ b/src/Proto.Cluster/SingleNode/SingleNodeProvider.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file = "SingleNodeProvider.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.OpenTelemetry/OpenTelemetryMetricsExtensions.cs
+++ b/src/Proto.OpenTelemetry/OpenTelemetryMetricsExtensions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="OpenTelemetryMetricsExtensions.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Persistence.Couchbase/CouchbaseProvider.cs
+++ b/src/Proto.Persistence.Couchbase/CouchbaseProvider.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 //  <copyright file="CouchbaseProvider.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //  </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Persistence.DynamoDB/DynamoDBExtensions.cs
+++ b/src/Proto.Persistence.DynamoDB/DynamoDBExtensions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 //  <copyright file="DynamoDBHelper.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //  </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Persistence.DynamoDB/DynamoDBProvider.cs
+++ b/src/Proto.Persistence.DynamoDB/DynamoDBProvider.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 //  <copyright file="DynamoDBProvider.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //  </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Persistence.DynamoDB/DynamoDBProviderOptions.cs
+++ b/src/Proto.Persistence.DynamoDB/DynamoDBProviderOptions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 //  <copyright file="DynamoDBProvider.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //  </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Persistence.MongoDB/Event.cs
+++ b/src/Proto.Persistence.MongoDB/Event.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 //  <copyright file="Event.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //  </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Persistence.MongoDB/MongoDBProvider.cs
+++ b/src/Proto.Persistence.MongoDB/MongoDBProvider.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 //  <copyright file="MongoDBProvider.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //  </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Persistence.MongoDB/Snapshot.cs
+++ b/src/Proto.Persistence.MongoDB/Snapshot.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 //  <copyright file="Snapshot.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //  </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Persistence/IProvider.cs
+++ b/src/Proto.Persistence/IProvider.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="IProvider.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Persistence/ISnapshotStrategy.cs
+++ b/src/Proto.Persistence/ISnapshotStrategy.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ISnapshotStrategy.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Persistence/Messages.cs
+++ b/src/Proto.Persistence/Messages.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="Messages.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Persistence/Persistence.cs
+++ b/src/Proto.Persistence/Persistence.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="Persistence.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Persistence/SnapshotStrategies/EventTypeStrategy.cs
+++ b/src/Proto.Persistence/SnapshotStrategies/EventTypeStrategy.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="EventTypeStrategy.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Persistence/SnapshotStrategies/IntervalStrategy.cs
+++ b/src/Proto.Persistence/SnapshotStrategies/IntervalStrategy.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IntervalStrategy.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Persistence/SnapshotStrategies/TimeStrategy.cs
+++ b/src/Proto.Persistence/SnapshotStrategies/TimeStrategy.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="TimeStrategy.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Activator.cs
+++ b/src/Proto.Remote/Activator.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 //   <copyright file="Activator.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/BlockList.cs
+++ b/src/Proto.Remote/BlockList.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="BlockList.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Endpoints/BlockedEndpoint.cs
+++ b/src/Proto.Remote/Endpoints/BlockedEndpoint.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 //   <copyright file="BlockedEndpoint.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Endpoints/Endpoint.cs
+++ b/src/Proto.Remote/Endpoints/Endpoint.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 //   <copyright file="Endpoint.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Endpoints/EndpointManager.cs
+++ b/src/Proto.Remote/Endpoints/EndpointManager.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 //   <copyright file="EndpointManager.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Endpoints/EndpointReader.cs
+++ b/src/Proto.Remote/Endpoints/EndpointReader.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 //   <copyright file="EndpointReader.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Endpoints/IEndpoint.cs
+++ b/src/Proto.Remote/Endpoints/IEndpoint.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 //   <copyright file="IEndpoint.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Endpoints/RemoteMessageHandler.cs
+++ b/src/Proto.Remote/Endpoints/RemoteMessageHandler.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 //   <copyright file="RemoteMessageHandler.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Endpoints/ServerConnector.cs
+++ b/src/Proto.Remote/Endpoints/ServerConnector.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 //   <copyright file="ServerConnector.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Endpoints/ServerEndpoint.cs
+++ b/src/Proto.Remote/Endpoints/ServerEndpoint.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 //   <copyright file="ServerEndpoint.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Endpoints/ServerSideClientEndpoint.cs
+++ b/src/Proto.Remote/Endpoints/ServerSideClientEndpoint.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 //   <copyright file="ServerSideClientEndpoint.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/GrpcNet/GrpcNetRemoteConfig.cs
+++ b/src/Proto.Remote/GrpcNet/GrpcNetRemoteConfig.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 //   <copyright file="GrpcNetRemoteConfig.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/GrpcNet/RemoteHostedService.cs
+++ b/src/Proto.Remote/GrpcNet/RemoteHostedService.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 //   <copyright file="RemoteHostedService.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Healthchecks/Healthcheck.cs
+++ b/src/Proto.Remote/Healthchecks/Healthcheck.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file = "Healthcheck.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/InternalsVisibleTo.cs
+++ b/src/Proto.Remote/InternalsVisibleTo.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="InternalsVisibleTo.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Messages.cs
+++ b/src/Proto.Remote/Messages.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 //   <copyright file="Messages.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Metrics/RemoteMetrics.cs
+++ b/src/Proto.Remote/Metrics/RemoteMetrics.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="RemoteMetrics.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Properties/AssemblyInfo.cs
+++ b/src/Proto.Remote/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="AssemblyInfo.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/RemoteConfigBase.cs
+++ b/src/Proto.Remote/RemoteConfigBase.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 //   <copyright file="RemoteConfig.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/RemoteConfigExtensions.cs
+++ b/src/Proto.Remote/RemoteConfigExtensions.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 //   <copyright file="RemoteConfigExtensions.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/RemoteProcess.cs
+++ b/src/Proto.Remote/RemoteProcess.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 //   <copyright file="RemoteProcess.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Serialization/ForcedSerializationSenderMiddleware.cs
+++ b/src/Proto.Remote/Serialization/ForcedSerializationSenderMiddleware.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file = "ForceSerializationSenderMiddleware.cs" company = "Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Serialization/ICachedSerialization.cs
+++ b/src/Proto.Remote/Serialization/ICachedSerialization.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ICachedSerialization.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Serialization/IMessageSurrogate.cs
+++ b/src/Proto.Remote/Serialization/IMessageSurrogate.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="IMessageSurrogate.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Serialization/ISerializer.cs
+++ b/src/Proto.Remote/Serialization/ISerializer.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ISerializer.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Serialization/JsonSerializer.cs
+++ b/src/Proto.Remote/Serialization/JsonSerializer.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="JsonSerializer.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Serialization/ProtobufSerializer.cs
+++ b/src/Proto.Remote/Serialization/ProtobufSerializer.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="ProtobufSerializer.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.Remote/Serialization/Serialization.cs
+++ b/src/Proto.Remote/Serialization/Serialization.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 //   <copyright file="Serialization.cs" company="Asynkron AB">
-//       Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.TestKit/ITestProbe.cs
+++ b/src/Proto.TestKit/ITestProbe.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ITestProbe.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.TestKit/MessageAndSender.cs
+++ b/src/Proto.TestKit/MessageAndSender.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="MessageAndSender.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.TestKit/TestKit.cs
+++ b/src/Proto.TestKit/TestKit.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="TestKit.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.TestKit/TestKitBase.cs
+++ b/src/Proto.TestKit/TestKitBase.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="TestKitBase.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.TestKit/TestKitException.cs
+++ b/src/Proto.TestKit/TestKitException.cs
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------
 // <copyright file="TestKitException.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 

--- a/src/Proto.TestKit/TestProbe.cs
+++ b/src/Proto.TestKit/TestProbe.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="TestProbe.cs" company="Asynkron AB">
-//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- update copyright headers to 2025

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e38806da88328a502b9ae584178a0