### PR TITLE
Use atomic update for TTL refresh

### DIFF
--- a/src/Proto.Cluster.TestProvider/InMemAgent.cs
+++ b/src/Proto.Cluster.TestProvider/InMemAgent.cs
@@ -56,10 +56,28 @@ public sealed class InMemAgent
 
     public void RefreshServiceTTL(string id)
     {
-        //TODO: this is racy, but yolo for now
-        if (_services.TryGetValue(id, out var service))
+        while (true)
         {
-            service.TTL = DateTimeOffset.Now;
+            if (!_services.TryGetValue(id, out var current))
+            {
+                return;
+            }
+
+            var updated = new AgentServiceStatus
+            {
+                ID = current.ID,
+                TTL = DateTimeOffset.Now,
+                Host = current.Host,
+                Port = current.Port,
+                Kinds = current.Kinds
+            };
+
+            if (_services.TryUpdate(id, updated, current))
+            {
+                return;
+            }
+
+            // Service was modified or removed concurrently; retry if it still exists
         }
     }
 


### PR DESCRIPTION
## Summary
- safely refresh service TTL in InMemAgent using atomic dictionary update

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e5be7e3e483288c933e75329be14a