### PR TITLE
Add OpenTelemetry tracing example

### DIFF
--- a/examples/OpenTelemetryTracing/OpenTelemetryTracing.csproj
+++ b/examples/OpenTelemetryTracing/OpenTelemetryTracing.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Proto.OpenTelemetry\Proto.OpenTelemetry.csproj" />
+    <ProjectReference Include="..\..\src\Proto.Remote\Proto.Remote.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
+  </ItemGroup>
+
+</Project>

--- a/examples/OpenTelemetryTracing/Program.cs
+++ b/examples/OpenTelemetryTracing/Program.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Proto;
+using Proto.OpenTelemetry;
+using Proto.Remote;
+using Proto.Remote.GrpcNet;
+
+var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+Log.SetLoggerFactory(loggerFactory);
+
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("OpenTelemetryTracingSample"))
+    .AddProtoActorInstrumentation()
+    .AddJaegerExporter()
+    .Build();
+
+var system1 = new ActorSystem().WithRemote(GrpcNetRemoteConfig.BindToLocalhost(12000));
+var system2 = new ActorSystem().WithRemote(GrpcNetRemoteConfig.BindToLocalhost(12001));
+
+await system1.Remote().StartAsync();
+await system2.Remote().StartAsync();
+
+var remoteProps = Props.FromFunc(ctx =>
+{
+    if (ctx.Message is string msg)
+    {
+        Console.WriteLine($"[remote] received '{msg}' traceId={Activity.Current?.TraceId}");
+        ctx.Respond("pong");
+    }
+    return Task.CompletedTask;
+}).WithTracing();
+
+system2.Root.SpawnNamed(remoteProps, "remote");
+
+var localProps = Props.FromFunc(async ctx =>
+{
+    if (ctx.Message is string msg)
+    {
+        Console.WriteLine($"[local] received '{msg}' traceId={Activity.Current?.TraceId}");
+        var remotePid = PID.FromAddress("127.0.0.1:12001", "remote");
+        var res = await ctx.RequestAsync<string>(remotePid, "ping");
+        Console.WriteLine($"[local] got reply '{res}' traceId={Activity.Current?.TraceId}");
+    }
+}).WithTracing();
+
+var localPid = system1.Root.Spawn(localProps);
+
+var tracedRoot = system1.Root.WithTracing();
+
+using var rootActivity = new ActivitySource(Proto.OpenTelemetry.ProtoTags.ActivitySourceName).StartActivity("root");
+tracedRoot.Send(localPid, "start");
+
+Console.WriteLine("Press enter to exit");
+Console.ReadLine();

--- a/examples/OpenTelemetryTracing/README.md
+++ b/examples/OpenTelemetryTracing/README.md
@@ -1,0 +1,19 @@
+# OpenTelemetryTracing
+
+Demonstrates Proto.Actor tracing with OpenTelemetry and a Jaeger exporter. The sample runs two actor systems communicating over gRPC Remote and shows trace context flowing from a local actor to a remote actor.
+
+## Run
+
+1. Start Jaeger:
+
+   ```bash
+   docker run --rm -p 16686:16686 -p 6831:6831/udp jaegertracing/all-in-one:1.39
+   ```
+
+2. Run the example:
+
+   ```bash
+   dotnet run --project examples/OpenTelemetryTracing
+   ```
+
+3. Open [http://localhost:16686](http://localhost:16686) and look for the `OpenTelemetryTracingSample` service to see spans for the root, local actor and remote actor belonging to the same trace.


### PR DESCRIPTION
## Summary
- add example demonstrating OpenTelemetry tracing with Jaeger exporter
- show trace context propagation between local and remote actors over gRPC Remote

## Testing
- `dotnet build examples/OpenTelemetryTracing/OpenTelemetryTracing.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e658266e88328ba4587689d33f841