### PR TITLE
Add TLS remote communication example

### DIFF
--- a/examples/RemoteTLS/Client/Client.csproj
+++ b/examples/RemoteTLS/Client/Client.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj" />
+    <ProjectReference Include="..\..\..\src\Proto.Remote\Proto.Remote.csproj" />
+    <None Include="..\localhost.pfx" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/examples/RemoteTLS/Client/Program.cs
+++ b/examples/RemoteTLS/Client/Program.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
+using Grpc.Net.Client;
+using Proto;
+using Proto.Remote;
+using Proto.Remote.GrpcNet;
+using static Proto.Remote.GrpcNet.GrpcNetRemoteConfig;
+using Common;
+
+var certificate = new X509Certificate2("../localhost.pfx", "password");
+var handler = new HttpClientHandler();
+handler.ServerCertificateCustomValidationCallback = (request, cert, chain, errors) =>
+    cert != null && cert.Thumbprint == certificate.Thumbprint;
+
+var remoteConfig = BindToLocalhost() with
+{
+    UseHttps = true,
+    ChannelOptions = new GrpcChannelOptions { HttpHandler = handler }
+};
+
+var system = new ActorSystem().WithRemote(remoteConfig);
+await system.Remote().StartAsync();
+
+var pid = PID.FromAddress("127.0.0.1:8000", "greeter");
+var response = await system.Root.RequestAsync<HelloResponse>(pid, new HelloRequest("TLS"));
+Console.WriteLine(response.Message);

--- a/examples/RemoteTLS/Common/Common.csproj
+++ b/examples/RemoteTLS/Common/Common.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/examples/RemoteTLS/Common/Messages.cs
+++ b/examples/RemoteTLS/Common/Messages.cs
@@ -1,0 +1,4 @@
+namespace Common;
+
+public record HelloRequest(string Name);
+public record HelloResponse(string Message);

--- a/examples/RemoteTLS/README.md
+++ b/examples/RemoteTLS/README.md
@@ -1,0 +1,28 @@
+# RemoteTLS
+
+Demonstrates securing Proto.Remote communication with TLS.
+
+## Certificates
+
+Generate a self-signed development certificate `localhost.pfx` and place it next to this README. For example:
+
+```bash
+openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes -subj "/CN=localhost"
+openssl pkcs12 -export -out localhost.pfx -inkey key.pem -in cert.pem -passout pass:password
+```
+
+## Running the example
+
+1. Start the secure server:
+
+   ```bash
+   dotnet run --project Server
+   ```
+
+2. From another terminal, run the client:
+
+   ```bash
+   dotnet run --project Client
+   ```
+
+The client validates the server certificate by comparing thumbprints and prints the greeting returned by the remote actor.

--- a/examples/RemoteTLS/Server/Program.cs
+++ b/examples/RemoteTLS/Server/Program.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Proto;
+using Proto.Remote;
+using Proto.Remote.GrpcNet;
+using static Proto.Remote.GrpcNet.GrpcNetRemoteConfig;
+using Common;
+
+var certificate = new X509Certificate2("../localhost.pfx", "password");
+
+var remoteConfig = BindToLocalhost(8000) with
+{
+    UseHttps = true,
+    ConfigureKestrel = options =>
+    {
+        options.Protocols = HttpProtocols.Http2;
+        options.UseHttps(certificate);
+    }
+};
+
+var system = new ActorSystem().WithRemote(remoteConfig);
+
+var props = Props.FromProducer(() => new GreeterActor());
+system.Root.SpawnNamed(props, "greeter");
+
+await system.Remote().StartAsync();
+Console.WriteLine("Remote TLS server started. Press enter to exit.");
+Console.ReadLine();
+
+public class GreeterActor : IActor
+{
+    public Task ReceiveAsync(IContext context)
+        => context.Message switch
+        {
+            HelloRequest req => context.Respond(new HelloResponse($"Hello, {req.Name}!"))
+                .AsTask(),
+            _ => Task.CompletedTask
+        };
+}

--- a/examples/RemoteTLS/Server/Server.csproj
+++ b/examples/RemoteTLS/Server/Server.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj" />
+    <ProjectReference Include="..\..\..\src\Proto.Remote\Proto.Remote.csproj" />
+    <None Include="..\localhost.pfx" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- showcase TLS-secured Proto.Remote server and client
- explain how to generate required self-signed certificate

## Testing
- `apt-get update` *(fails: repository not signed)*
- `dotnet build examples/RemoteTLS/Server` *(fails: command not found)*
- `dotnet build examples/RemoteTLS/Client` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e658266e88328ba4587689d33f841