### PR TITLE
Add GrpcNet WithTLS helper

### DIFF
--- a/examples/RemoteTLS/Client/Program.cs
+++ b/examples/RemoteTLS/Client/Program.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
-using Grpc.Net.Client;
 using Proto;
 using Proto.Remote;
 using Proto.Remote.GrpcNet;
@@ -13,11 +12,7 @@ var handler = new HttpClientHandler();
 handler.ServerCertificateCustomValidationCallback = (request, cert, chain, errors) =>
     cert != null && cert.Thumbprint == certificate.Thumbprint;
 
-var remoteConfig = BindToLocalhost() with
-{
-    UseHttps = true,
-    ChannelOptions = new GrpcChannelOptions { HttpHandler = handler }
-};
+var remoteConfig = BindToLocalhost().WithTLS(httpHandler: handler);
 
 var system = new ActorSystem().WithRemote(remoteConfig);
 await system.Remote().StartAsync();

--- a/examples/RemoteTLS/Server/Program.cs
+++ b/examples/RemoteTLS/Server/Program.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Security.Cryptography.X509Certificates;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Proto;
 using Proto.Remote;
 using Proto.Remote.GrpcNet;
@@ -9,15 +8,7 @@ using Common;
 
 var certificate = new X509Certificate2("../localhost.pfx", "password");
 
-var remoteConfig = BindToLocalhost(8000) with
-{
-    UseHttps = true,
-    ConfigureKestrel = options =>
-    {
-        options.Protocols = HttpProtocols.Http2;
-        options.UseHttps(certificate);
-    }
-};
+var remoteConfig = BindToLocalhost(8000).WithTLS(certificate: certificate);
 
 var system = new ActorSystem().WithRemote(remoteConfig);
 

--- a/src/Proto.Remote/GrpcNet/GrpcNetExtensions.cs
+++ b/src/Proto.Remote/GrpcNet/GrpcNetExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
-using System.Reflection;
 using Grpc.HealthCheck;
 using Grpc.Net.Client;
 using JetBrains.Annotations;
@@ -10,7 +9,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
-using Microsoft.AspNetCore.Server.Kestrel.Https;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -49,15 +48,10 @@ public static class Extensions
         Action<ListenOptions>? configure = existingConfigureKestrel;
         if (certificate is not null)
         {
-            var useHttps = Type
-                .GetType(
-                    "Microsoft.AspNetCore.Server.Kestrel.Https.ListenOptionsHttpsExtensions, Microsoft.AspNetCore.Server.Kestrel.Https")
-                ?.GetMethod("UseHttps", new[] { typeof(ListenOptions), typeof(X509Certificate2) });
-
             configure = options =>
             {
                 options.Protocols = HttpProtocols.Http2;
-                useHttps?.Invoke(null, new object[] { options, certificate });
+                options.UseHttps(certificate);
                 existingConfigureKestrel?.Invoke(options);
             };
         }

--- a/src/Proto.Remote/GrpcNet/GrpcNetExtensions.cs
+++ b/src/Proto.Remote/GrpcNet/GrpcNetExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
+using System.Reflection;
 using Grpc.HealthCheck;
 using Grpc.Net.Client;
 using JetBrains.Annotations;
@@ -48,10 +49,15 @@ public static class Extensions
         Action<ListenOptions>? configure = existingConfigureKestrel;
         if (certificate is not null)
         {
+            var useHttps = Type
+                .GetType(
+                    "Microsoft.AspNetCore.Server.Kestrel.Https.ListenOptionsHttpsExtensions, Microsoft.AspNetCore.Server.Kestrel.Https")
+                ?.GetMethod("UseHttps", new[] { typeof(ListenOptions), typeof(X509Certificate2) });
+
             configure = options =>
             {
                 options.Protocols = HttpProtocols.Http2;
-                options.UseHttps(certificate);
+                useHttps?.Invoke(null, new object[] { options, certificate });
                 existingConfigureKestrel?.Invoke(options);
             };
         }

--- a/src/Proto.Remote/GrpcNet/GrpcNetExtensions.cs
+++ b/src/Proto.Remote/GrpcNet/GrpcNetExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 

--- a/src/Proto.Remote/GrpcNet/GrpcNetExtensions.cs
+++ b/src/Proto.Remote/GrpcNet/GrpcNetExtensions.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
 using Grpc.HealthCheck;
 using Grpc.Net.Client;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -28,6 +31,37 @@ public static class Extensions
     public static GrpcNetRemoteConfig WithUriChooser(this GrpcNetRemoteConfig config,
         Func<IEnumerable<Uri>?, Uri?> uriChooser) =>
         config with { UriChooser = uriChooser };
+
+    public static GrpcNetRemoteConfig WithTLS(this GrpcNetRemoteConfig remoteConfig,
+        X509Certificate2? certificate = null,
+        HttpMessageHandler? httpHandler = null)
+    {
+        var channelOptions = remoteConfig.ChannelOptions;
+        if (httpHandler is not null)
+        {
+            channelOptions.HttpHandler = httpHandler;
+        }
+
+        var existingConfigureKestrel = remoteConfig.ConfigureKestrel;
+
+        Action<ListenOptions>? configure = existingConfigureKestrel;
+        if (certificate is not null)
+        {
+            configure = options =>
+            {
+                options.Protocols = HttpProtocols.Http2;
+                options.UseHttps(certificate);
+                existingConfigureKestrel?.Invoke(options);
+            };
+        }
+
+        return remoteConfig with
+        {
+            UseHttps = true,
+            ChannelOptions = channelOptions,
+            ConfigureKestrel = configure
+        };
+    }
 
     /// <summary>
     ///     Registers the Remote extension in the <see cref="ActorSystem" />. This mode opens connections both ways between the

--- a/src/Proto.Remote/Proto.Remote.csproj
+++ b/src/Proto.Remote/Proto.Remote.csproj
@@ -16,6 +16,9 @@
         <PackageReference Include="System.Text.Json" />
     </ItemGroup>
     <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+    <ItemGroup>
         <ProjectReference Include="..\Proto.Actor\Proto.Actor.csproj" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
## Summary
- add `WithTLS` extension to GrpcNetRemoteConfig
- update RemoteTLS examples to use `WithTLS`
- move `WithTLS` into existing `GrpcNetExtensions` class

## Testing
- `dotnet test` *(fails: command not found)*
- `wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb` *(fails: Proxy tunneling failed)*

------
https://chatgpt.com/codex/tasks/task_e_688ef6741d9c8328a0cf924bf4ec231b