### PR TITLE
Improve mailbox scheduling test assertion

### DIFF
--- a/tests/Proto.Actor.Tests/Mailbox/MailboxSchedulingTests.cs
+++ b/tests/Proto.Actor.Tests/Mailbox/MailboxSchedulingTests.cs
@@ -127,8 +127,6 @@ public class MailboxSchedulingTests
         msg1.TaskCompletionSource.SetResult(0);
         await Task.Delay(1000);
 
-        Assert.True(mailbox.Status == MailboxStatus.Idle,
-            "Mailbox should be set back to Idle after completion of message."
-        );
+        Assert.Equal(MailboxStatus.Idle, mailbox.Status);
     }
 }


### PR DESCRIPTION
## Summary
- use explicit assertion for mailbox status in scheduling test

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -f net8.0`

------
https://chatgpt.com/codex/tasks/task_e_688f329b5f848328b843bad84341907b