### PR TITLE
Add scheduler repeated send cancellation test

### DIFF
--- a/tests/Proto.Actor.Tests/SchedulerTests.cs
+++ b/tests/Proto.Actor.Tests/SchedulerTests.cs
@@ -33,5 +33,47 @@ public class SchedulerTests
         timeProvider.Advance(TimeSpan.FromMinutes(10));
         await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(10));
     }
+
+    [Fact]
+    public async Task SendRepeatedlyCanBeCancelledWithTimeProvider()
+    {
+        await using var system = new ActorSystem();
+        var context = system.Root;
+        var counter = 0;
+        var first = new TaskCompletionSource();
+        var second = new TaskCompletionSource();
+        var pid = context.Spawn(Props.FromFunc(ctx =>
+        {
+            if (ctx.Message is "tick")
+            {
+                counter++;
+                switch (counter)
+                {
+                    case 1:
+                        first.SetResult();
+                        break;
+                    case 2:
+                        second.SetResult();
+                        break;
+                }
+            }
+
+            return Task.CompletedTask;
+        }));
+
+        var scheduler = context.Scheduler();
+
+        var cts = scheduler.SendRepeatedly(TimeSpan.FromMilliseconds(10), TimeSpan.FromMilliseconds(100), pid, "tick");
+
+        await first.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await second.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        cts.Cancel();
+        var afterCancel = counter;
+        await Task.Delay(200);
+
+        Assert.Equal(afterCancel, counter);
+        Assert.Equal(2, counter);
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- Expand scheduler test suite with coverage for cancelling repeated message sends, ensuring no further ticks after cancellation

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_688f351886888328ad767dd5e95f9e47