### PR TITLE
test: verify scheduler cancel repeated sends

### DIFF
--- a/tests/Proto.Actor.Tests/SchedulerTests.cs
+++ b/tests/Proto.Actor.Tests/SchedulerTests.cs
@@ -33,5 +33,52 @@ public class SchedulerTests
         timeProvider.Advance(TimeSpan.FromMinutes(10));
         await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(10));
     }
+
+    [Fact]
+    public async Task SendRepeatedlyCanBeCancelled()
+    {
+        await using var system = new ActorSystem();
+        var context = system.Root;
+        var count = 0;
+        var firstMessage = new TaskCompletionSource();
+        var extraMessage = new TaskCompletionSource();
+
+        var pid = context.Spawn(Props.FromFunc(ctx =>
+        {
+            if (ctx.Message is "Tick")
+            {
+                count++;
+
+                if (count == 1)
+                {
+                    firstMessage.SetResult();
+                }
+                else
+                {
+                    extraMessage.SetResult();
+                }
+            }
+
+            return Task.CompletedTask;
+        }));
+
+        var timeProvider = new FakeTimeProvider();
+        var scheduler = context.Scheduler(timeProvider);
+
+        var cts = scheduler.SendRepeatedly(TimeSpan.FromSeconds(5), pid, "Tick");
+
+        // Give SendRepeatedly's inner call to Task.Delay a head start
+        await Task.Delay(50);
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        await firstMessage.Task.WaitAsync(TimeSpan.FromMilliseconds(10));
+
+        cts.Cancel();
+
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        await Task.Delay(50);
+
+        Assert.Equal(1, count);
+        Assert.False(extraMessage.Task.IsCompleted);
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- add test to ensure repeated scheduler messages stop after cancellation

## Testing
- `dotnet test -f net8.0 tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688f3deb7a088328b58861dbdc175240