### PR TITLE
test: extend scheduler coverage

### DIFF
--- a/tests/Proto.Actor.Tests/SchedulerTests.cs
+++ b/tests/Proto.Actor.Tests/SchedulerTests.cs
@@ -1,6 +1,7 @@
 #if NET8_0_OR_GREATER
 using System;
 using System.Threading.Tasks;
+using System.Threading;
 using Microsoft.Extensions.Time.Testing;
 using Proto.Timers;
 using Xunit;
@@ -79,6 +80,102 @@ public class SchedulerTests
 
         Assert.Equal(1, count);
         Assert.False(extraMessage.Task.IsCompleted);
+    }
+
+    [Fact]
+    public async Task SendOnceCanBeCancelled()
+    {
+        await using var system = new ActorSystem();
+        var context = system.Root;
+        var tcs = new TaskCompletionSource();
+
+        var pid = context.Spawn(Props.FromFunc(ctx =>
+        {
+            if (ctx.Message is "Wakeup")
+            {
+                tcs.SetResult();
+            }
+
+            return Task.CompletedTask;
+        }));
+
+        var timeProvider = new FakeTimeProvider();
+        var scheduler = context.Scheduler(timeProvider);
+
+        var cts = scheduler.SendOnce(TimeSpan.FromSeconds(5), pid, "Wakeup");
+
+        // Give SendOnce's inner call to Task.Delay a head start
+        await Task.Delay(50);
+        cts.Cancel();
+
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        await Task.Delay(50);
+
+        Assert.False(tcs.Task.IsCompleted);
+    }
+
+    [Fact]
+    public async Task RequestRepeatedlyCanBeCancelled()
+    {
+        await using var system = new ActorSystem();
+        var context = system.Root;
+
+        var responder = context.Spawn(Props.FromFunc(ctx =>
+        {
+            if (ctx.Message is "Ping")
+            {
+                ctx.Respond("Pong");
+            }
+
+            return Task.CompletedTask;
+        }));
+
+        var firstResponse = new TaskCompletionSource();
+        var extraResponse = new TaskCompletionSource();
+
+        var timeProvider = new FakeTimeProvider();
+
+        CancellationTokenSource? cts = null;
+        var requester = context.Spawn(Props.FromFunc(ctx =>
+        {
+            switch (ctx.Message)
+            {
+                case Started:
+                    var scheduler = ctx.Scheduler(timeProvider);
+                    cts = scheduler.RequestRepeatedly(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5), responder, "Ping");
+                    break;
+                case string msg when msg == "Pong":
+                    if (!firstResponse.Task.IsCompleted)
+                    {
+                        firstResponse.SetResult();
+                    }
+                    else
+                    {
+                        extraResponse.SetResult();
+                    }
+                    break;
+                case "Cancel":
+                    cts?.Cancel();
+                    break;
+            }
+
+            return Task.CompletedTask;
+        }));
+
+        // Give RequestRepeatedly's inner call to Task.Delay a head start
+        await Task.Delay(50);
+        timeProvider.Advance(TimeSpan.FromSeconds(5));
+        await firstResponse.Task.WaitAsync(TimeSpan.FromMilliseconds(10));
+
+        context.Send(requester, "Cancel");
+
+        // ensure cancellation is processed before advancing time
+        await Task.Delay(50);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(10));
+        await Task.Delay(50);
+
+        Assert.False(extraResponse.Task.IsCompleted);
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- test ability to cancel a single scheduled message
- verify periodic request scheduling can be canceled

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -f net8.0 --filter "FullyQualifiedName~SchedulerTests"`


------
https://chatgpt.com/codex/tasks/task_e_688f582fa1d08328a4a4f7fc3cd5e1a8