### PR TITLE
Add routing coverage for pool routers

### DIFF
--- a/tests/Proto.Actor.Tests/Router/PoolRouterTests.cs
+++ b/tests/Proto.Actor.Tests/Router/PoolRouterTests.cs
@@ -1,6 +1,8 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Proto.Router;
 using Proto.Router.Messages;
 using Proto.Router.Routers;
 using Proto.TestFixtures;
@@ -11,6 +13,8 @@ namespace Proto.Router.Tests;
 public class PoolRouterTests
 {
     private static readonly Props MyActorProps = Props.FromProducer(() => new DoNothingActor());
+    private static readonly Props TrackingActorProps = Props.FromProducer(() => new MyTestActor())
+        .WithMailbox(() => new TestMailbox());
     private readonly TimeSpan _timeout = TimeSpan.FromMilliseconds(1000);
 
     [Fact]
@@ -70,6 +74,86 @@ public class PoolRouterTests
     }
 
     [Fact]
+    public async Task BroadcastPoolRouter_BroadcastsMessagesToAllRoutees()
+    {
+        var system = new ActorSystem();
+        await using var _ = system;
+
+        var props = system.Root.NewBroadcastPool(TrackingActorProps, 3)
+            .WithMailbox(() => new TestMailbox());
+
+        var router = system.Root.Spawn(props);
+
+        system.Root.Send(router, "hello");
+
+        var routees = await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
+
+        foreach (var pid in routees.Pids)
+        {
+            Assert.Equal(1, await system.Root.RequestAsync<int>(pid, "received?", _timeout));
+        }
+    }
+
+    [Fact]
+    public async Task RoundRobinPoolRouter_DistributesMessagesInRoundRobinStyle()
+    {
+        var system = new ActorSystem();
+        await using var _ = system;
+
+        var props = system.Root.NewRoundRobinPool(TrackingActorProps, 3)
+            .WithMailbox(() => new TestMailbox());
+
+        var router = system.Root.Spawn(props);
+
+        system.Root.Send(router, "1");
+        system.Root.Send(router, "2");
+        system.Root.Send(router, "3");
+        system.Root.Send(router, "4");
+
+        var routees = await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
+
+        var counts = new List<int>();
+
+        foreach (var pid in routees.Pids)
+        {
+            counts.Add(await system.Root.RequestAsync<int>(pid, "received?", _timeout));
+        }
+
+        counts.Sort();
+
+        Assert.Equal(new[] {1, 1, 2}, counts);
+    }
+
+    [Fact]
+    public async Task ConsistentHashPoolRouter_MessageWithSameHashAlwaysGoesToSameRoutee()
+    {
+        var system = new ActorSystem();
+        await using var _ = system;
+
+        var props = system.Root.NewConsistentHashPool(TrackingActorProps, 3)
+            .WithMailbox(() => new TestMailbox());
+
+        var router = system.Root.Spawn(props);
+
+        system.Root.Send(router, new Message("message1"));
+        system.Root.Send(router, new Message("message1"));
+        system.Root.Send(router, new Message("message1"));
+
+        var routees = await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
+
+        var counts = new List<int>();
+
+        foreach (var pid in routees.Pids)
+        {
+            counts.Add(await system.Root.RequestAsync<int>(pid, "received?", _timeout));
+        }
+
+        counts.Sort();
+
+        Assert.Equal(new[] {0, 0, 3}, counts);
+    }
+
+    [Fact]
     public async Task If_routee_props_then_router_creation_fails()
     {
         var system = new ActorSystem();
@@ -83,4 +167,39 @@ public class PoolRouterTests
             .WithInnerException<Exception>()
             .WithMessage("Failing props");
     }
+
+    private class MyTestActor : IActor
+    {
+        private readonly List<string> _receivedMessages = new();
+
+        public Task ReceiveAsync(IContext context)
+        {
+            switch (context.Message)
+            {
+                case string msg when msg == "received?":
+                    context.Respond(_receivedMessages.Count);
+                    break;
+                case Message msg:
+                    _receivedMessages.Add(msg.ToString());
+                    break;
+                case string msg:
+                    _receivedMessages.Add(msg);
+                    break;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private class Message : IHashable
+    {
+        private readonly string _value;
+
+        public Message(string value) => _value = value;
+
+        public string HashBy() => _value;
+
+        public override string ToString() => _value;
+    }
 }
+


### PR DESCRIPTION
## Summary
- test BroadcastPool to ensure messages reach every routee
- verify RoundRobinPool cycles messages across routees
- assert ConsistentHashPool keeps same hash on same routee

## Testing
- `/root/.dotnet/dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -f net8.0`

------
https://chatgpt.com/codex/tasks/task_e_688f5b3db564832886cbcd15dd7409d5