### PR TITLE
Add coverage for ProcessRegistry helper methods

### DIFF
--- a/tests/Proto.Actor.Tests/ProcessRegistryTests.cs
+++ b/tests/Proto.Actor.Tests/ProcessRegistryTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Proto.TestFixtures;
 using Xunit;
@@ -86,5 +87,51 @@ public class ProcessRegistryTests
         var p2 = reg.Get(pid);
 
         Assert.Same(p, p2);
+    }
+
+    [Fact]
+    public async Task Given_ProcessRegistry_NextIdShouldReturnSequentialIds()
+    {
+        var system = new ActorSystem();
+        await using var _ = system;
+        var reg = new ProcessRegistry(system);
+
+        var id1 = reg.NextId();
+        var id2 = reg.NextId();
+
+        Assert.Equal("$1", id1);
+        Assert.Equal("$2", id2);
+    }
+
+    [Fact]
+    public async Task Given_PIDs_FindShouldReturnMatchingPIDs()
+    {
+        var system = new ActorSystem();
+        await using var _ = system;
+        var reg = new ProcessRegistry(system);
+        var p1 = new TestProcess(system);
+        var p2 = new TestProcess(system);
+        var p3 = new TestProcess(system);
+        reg.TryAdd("alpha", p1);
+        reg.TryAdd("beta", p2);
+        reg.TryAdd("ALPHANUM", p3);
+
+        var results = reg.Find("Alp").ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, pid => Assert.Equal(system.Address, pid.Address));
+        Assert.Contains(results, pid => pid.Id == "alpha");
+        Assert.Contains(results, pid => pid.Id == "ALPHANUM");
+    }
+
+    [Fact]
+    public async Task Given_RemotePIDWithoutResolver_GetShouldThrow()
+    {
+        var system = new ActorSystem();
+        await using var _ = system;
+        var reg = new ProcessRegistry(system);
+        var pid = PID.FromAddress("remote", "123");
+
+        Assert.Throws<NotSupportedException>(() => reg.Get(pid));
     }
 }


### PR DESCRIPTION
## Summary
- test ProcessRegistry generates sequential IDs
- test PID lookup with Find
- test remote lookup failure without resolver

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_688f5e704ee08328acda0bd83d0eabe0