### PR TITLE
Add comprehensive supervision tests

### DIFF
--- a/tests/Proto.Actor.Tests/SupervisionTests_AllForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_AllForOne.cs
@@ -34,7 +34,7 @@ public class SupervisionTestsAllForOne
 
         context.Send(parent, "hello");
 
-        child1MailboxStats.Reset.Wait(5000);
+        Assert.True(child1MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
         Assert.Contains(ResumeMailbox.Instance, child1MailboxStats.Posted);
         Assert.Contains(ResumeMailbox.Instance, child1MailboxStats.Received);
         Assert.DoesNotContain(ResumeMailbox.Instance, child2MailboxStats.Posted);
@@ -47,8 +47,8 @@ public class SupervisionTestsAllForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Stop);
+        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Stop);
         var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Stop, 1, null);
 
         var child1Props = Props.FromProducer(() => new ChildActor())
@@ -64,8 +64,8 @@ public class SupervisionTestsAllForOne
 
         context.Send(parent, "hello");
 
-        child1MailboxStats.Reset.Wait(1000);
-        child2MailboxStats.Reset.Wait(1000);
+        Assert.True(child1MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
+        Assert.True(child2MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
         Assert.Contains(Stop.Instance, child1MailboxStats.Posted);
         Assert.Contains(Stop.Instance, child1MailboxStats.Received);
         Assert.Contains(Stop.Instance, child2MailboxStats.Posted);
@@ -78,8 +78,8 @@ public class SupervisionTestsAllForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Restart);
+        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Restart);
         var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
 
         var child1Props = Props.FromProducer(() => new ChildActor())
@@ -95,8 +95,8 @@ public class SupervisionTestsAllForOne
 
         context.Send(parent, "hello");
 
-        child1MailboxStats.Reset.Wait(1000);
-        child2MailboxStats.Reset.Wait(1000);
+        Assert.True(child1MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
+        Assert.True(child2MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
         Assert.Contains(child1MailboxStats.Posted, msg => msg is Restart);
         Assert.Contains(child1MailboxStats.Received, msg => msg is Restart);
         Assert.Contains(child2MailboxStats.Posted, msg => msg is Restart);
@@ -109,8 +109,8 @@ public class SupervisionTestsAllForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Restart);
+        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Restart);
         var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
 
         var child1Props = Props.FromProducer(() => new ChildActor())
@@ -126,8 +126,8 @@ public class SupervisionTestsAllForOne
 
         context.Send(parent, "hello");
 
-        child1MailboxStats.Reset.Wait(1000);
-        child2MailboxStats.Reset.Wait(1000);
+        Assert.True(child1MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
+        Assert.True(child2MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
         Assert.Contains(child1MailboxStats.Posted, msg => msg is Restart r && r.Reason == Exception);
         Assert.Contains(child1MailboxStats.Received, msg => msg is Restart r && r.Reason == Exception);
         Assert.Contains(child2MailboxStats.Posted, msg => msg is Restart r && r.Reason == Exception);
@@ -140,7 +140,7 @@ public class SupervisionTestsAllForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var parentMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var parentMailboxStats = new TestMailboxStatistics(msg => msg is Failure);
         var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Escalate, 1, null);
         var childProps = Props.FromProducer(() => new ChildActor());
 
@@ -152,7 +152,7 @@ public class SupervisionTestsAllForOne
 
         context.Send(parent, "hello");
 
-        parentMailboxStats.Reset.Wait(1000);
+        Assert.True(parentMailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
         var failure = parentMailboxStats.Received.OfType<Failure>().Single();
         Assert.IsType<Exception>(failure.Reason);
     }

--- a/tests/Proto.Actor.Tests/SupervisionTests_AlwaysRestart.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_AlwaysRestart.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Proto.Mailbox;
+using Proto.TestFixtures;
+using Xunit;
+
+namespace Proto.Tests;
+
+public class SupervisionTestsAlwaysRestart
+{
+    private static readonly Exception Exception = new("boom");
+
+    [Fact]
+    public async Task AlwaysRestartStrategy_Should_RestartChildOnEveryFailure()
+    {
+        await using var system = new ActorSystem();
+        var context = system.Root;
+
+        var restartCount = 0;
+        var childMailboxStats = new TestMailboxStatistics(msg =>
+        {
+            if (msg is Restart)
+            {
+                restartCount++;
+                return restartCount == 3;
+            }
+
+            return false;
+        });
+
+        var childProps = Props.FromProducer(() => new ChildActor())
+            .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
+
+        var parentProps = Props.FromProducer(() => new ParentActor(childProps))
+            .WithChildSupervisorStrategy(Supervision.AlwaysRestartStrategy);
+
+        var parent = context.Spawn(parentProps);
+
+        context.Send(parent, "1");
+        context.Send(parent, "2");
+        context.Send(parent, "3");
+
+        Assert.True(childMailboxStats.Reset.Wait(TimeSpan.FromSeconds(2)));
+        Assert.Equal(3, childMailboxStats.Received.OfType<Restart>().Count());
+        Assert.DoesNotContain(childMailboxStats.Posted, msg => msg is Stop);
+    }
+
+    private class ParentActor : IActor
+    {
+        private readonly Props _childProps;
+
+        public ParentActor(Props childProps)
+        {
+            _childProps = childProps;
+        }
+
+        private PID? _child;
+
+        public Task ReceiveAsync(IContext context)
+        {
+            switch (context.Message)
+            {
+                case Started:
+                    _child = context.Spawn(_childProps);
+                    break;
+                default:
+                    if (_child != null)
+                    {
+                        context.Forward(_child);
+                    }
+                    break;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private class ChildActor : IActor
+    {
+        public Task ReceiveAsync(IContext context)
+        {
+            if (context.Message is string)
+            {
+                throw Exception;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
@@ -30,7 +30,7 @@ public class SupervisionTestsOneForOne
 
         context.Send(parent, "hello");
 
-        childMailboxStats.Reset.Wait(1000);
+        Assert.True(childMailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
         Assert.Contains(ResumeMailbox.Instance, childMailboxStats.Posted);
         Assert.Contains(ResumeMailbox.Instance, childMailboxStats.Received);
     }
@@ -55,7 +55,7 @@ public class SupervisionTestsOneForOne
 
         context.Send(parent, "hello");
 
-        childMailboxStats.Reset.Wait(1000);
+        Assert.True(childMailboxStats.Reset.Wait(TimeSpan.FromSeconds(2)));
         Assert.Contains(Stop.Instance, childMailboxStats.Posted);
         Assert.Contains(Stop.Instance, childMailboxStats.Received);
     }
@@ -66,7 +66,7 @@ public class SupervisionTestsOneForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var childMailboxStats = new TestMailboxStatistics(msg => msg is Restart);
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
 
         var childProps = Props.FromProducer(() => new ChildActor())
@@ -79,7 +79,7 @@ public class SupervisionTestsOneForOne
 
         context.Send(parent, "hello");
 
-        childMailboxStats.Reset.Wait(2000);
+        Assert.True(childMailboxStats.Reset.Wait(TimeSpan.FromSeconds(2)));
         Assert.Contains(childMailboxStats.Posted, msg => msg is Restart);
         Assert.Contains(childMailboxStats.Received, msg => msg is Restart);
     }


### PR DESCRIPTION
## Summary
- add coverage for AlwaysRestartStrategy
- harden existing supervision tests and ensure they wait for the correct system messages

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -c Release -f net8.0`

------
https://chatgpt.com/codex/tasks/task_e_688f6228dee4832883a202fd29d8caf2