### PR TITLE
Add supervision tests for restart strategies

### DIFF
--- a/tests/Proto.Actor.Tests/DisposableActorTests.cs
+++ b/tests/Proto.Actor.Tests/DisposableActorTests.cs
@@ -16,10 +16,10 @@ public class DisposableActorTests
         var context = system.Root;
 
         var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-        var disposeCalled = false;
+        var disposed = new TaskCompletionSource<bool>();
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 0, null);
 
-        var childProps = Props.FromProducer(() => new DisposableActor(() => disposeCalled = true))
+        var childProps = Props.FromProducer(() => new DisposableActor(() => disposed.TrySetResult(true)))
             .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats))
             .WithChildSupervisorStrategy(strategy);
 
@@ -30,7 +30,7 @@ public class DisposableActorTests
         var parent = context.Spawn(props);
         context.Send(parent, "crash");
         childMailboxStats.Reset.Wait(1000);
-        Assert.True(disposeCalled);
+        Assert.True(await disposed.Task.WaitAsync(TimeSpan.FromSeconds(1)));
     }
 
     [Fact]
@@ -41,10 +41,10 @@ public class DisposableActorTests
         var context = system.Root;
 
         var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-        var disposeCalled = false;
+        var disposed = new TaskCompletionSource<bool>();
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 0, null);
 
-        var childProps = Props.FromProducer(() => new AsyncDisposableActor(() => disposeCalled = true))
+        var childProps = Props.FromProducer(() => new AsyncDisposableActor(() => disposed.TrySetResult(true)))
             .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats))
             .WithChildSupervisorStrategy(strategy);
 
@@ -55,7 +55,7 @@ public class DisposableActorTests
         var parent = context.Spawn(props);
         context.Send(parent, "crash");
         childMailboxStats.Reset.Wait(2000);
-        Assert.True(disposeCalled);
+        Assert.True(await disposed.Task.WaitAsync(TimeSpan.FromSeconds(1)));
     }
 
     [Fact]

--- a/tests/Proto.Actor.Tests/ProcessRegistryTests.cs
+++ b/tests/Proto.Actor.Tests/ProcessRegistryTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Proto.TestFixtures;
 using Xunit;
@@ -86,5 +87,51 @@ public class ProcessRegistryTests
         var p2 = reg.Get(pid);
 
         Assert.Same(p, p2);
+    }
+
+    [Fact]
+    public async Task Given_ProcessRegistry_NextIdShouldReturnSequentialIds()
+    {
+        var system = new ActorSystem();
+        await using var _ = system;
+        var reg = new ProcessRegistry(system);
+
+        var id1 = reg.NextId();
+        var id2 = reg.NextId();
+
+        Assert.Equal("$1", id1);
+        Assert.Equal("$2", id2);
+    }
+
+    [Fact]
+    public async Task Given_PIDs_FindShouldReturnMatchingPIDs()
+    {
+        var system = new ActorSystem();
+        await using var _ = system;
+        var reg = new ProcessRegistry(system);
+        var p1 = new TestProcess(system);
+        var p2 = new TestProcess(system);
+        var p3 = new TestProcess(system);
+        reg.TryAdd("alpha", p1);
+        reg.TryAdd("beta", p2);
+        reg.TryAdd("ALPHANUM", p3);
+
+        var results = reg.Find("Alp").ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, pid => Assert.Equal(system.Address, pid.Address));
+        Assert.Contains(results, pid => pid.Id == "alpha");
+        Assert.Contains(results, pid => pid.Id == "ALPHANUM");
+    }
+
+    [Fact]
+    public async Task Given_RemotePIDWithoutResolver_GetShouldThrow()
+    {
+        var system = new ActorSystem();
+        await using var _ = system;
+        var reg = new ProcessRegistry(system);
+        var pid = PID.FromAddress("remote", "123");
+
+        Assert.Throws<NotSupportedException>(() => reg.Get(pid));
     }
 }

--- a/tests/Proto.Actor.Tests/SupervisionTests_AllForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_AllForOne.cs
@@ -34,7 +34,7 @@ public class SupervisionTestsAllForOne
 
         context.Send(parent, "hello");
 
-        Assert.True(child1MailboxStats.Reset.Wait(5000));
+        Assert.True(child1MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
         Assert.Contains(ResumeMailbox.Instance, child1MailboxStats.Posted);
         Assert.Contains(ResumeMailbox.Instance, child1MailboxStats.Received);
         Assert.DoesNotContain(ResumeMailbox.Instance, child2MailboxStats.Posted);
@@ -47,8 +47,8 @@ public class SupervisionTestsAllForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Stop);
+        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Stop);
         var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Stop, 1, null);
 
         var child1Props = Props.FromProducer(() => new ChildActor())
@@ -64,8 +64,8 @@ public class SupervisionTestsAllForOne
 
         context.Send(parent, "hello");
 
-        child1MailboxStats.Reset.Wait(1000);
-        child2MailboxStats.Reset.Wait(1000);
+        Assert.True(child1MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
+        Assert.True(child2MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
         Assert.Contains(Stop.Instance, child1MailboxStats.Posted);
         Assert.Contains(Stop.Instance, child1MailboxStats.Received);
         Assert.Contains(Stop.Instance, child2MailboxStats.Posted);
@@ -78,8 +78,8 @@ public class SupervisionTestsAllForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Restart);
+        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Restart);
         var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
 
         var child1Props = Props.FromProducer(() => new ChildActor())
@@ -95,8 +95,8 @@ public class SupervisionTestsAllForOne
 
         context.Send(parent, "hello");
 
-        child1MailboxStats.Reset.Wait(1000);
-        child2MailboxStats.Reset.Wait(1000);
+        Assert.True(child1MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
+        Assert.True(child2MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
         Assert.Contains(child1MailboxStats.Posted, msg => msg is Restart);
         Assert.Contains(child1MailboxStats.Received, msg => msg is Restart);
         Assert.Contains(child2MailboxStats.Posted, msg => msg is Restart);
@@ -109,8 +109,8 @@ public class SupervisionTestsAllForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Restart);
+        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Restart);
         var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
 
         var child1Props = Props.FromProducer(() => new ChildActor())
@@ -126,8 +126,8 @@ public class SupervisionTestsAllForOne
 
         context.Send(parent, "hello");
 
-        child1MailboxStats.Reset.Wait(1000);
-        child2MailboxStats.Reset.Wait(1000);
+        Assert.True(child1MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
+        Assert.True(child2MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
         Assert.Contains(child1MailboxStats.Posted, msg => msg is Restart r && r.Reason == Exception);
         Assert.Contains(child1MailboxStats.Received, msg => msg is Restart r && r.Reason == Exception);
         Assert.Contains(child2MailboxStats.Posted, msg => msg is Restart r && r.Reason == Exception);
@@ -140,7 +140,7 @@ public class SupervisionTestsAllForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var parentMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var parentMailboxStats = new TestMailboxStatistics(msg => msg is Failure);
         var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Escalate, 1, null);
         var childProps = Props.FromProducer(() => new ChildActor());
 
@@ -152,7 +152,7 @@ public class SupervisionTestsAllForOne
 
         context.Send(parent, "hello");
 
-        parentMailboxStats.Reset.Wait(1000);
+        Assert.True(parentMailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
         var failure = parentMailboxStats.Received.OfType<Failure>().Single();
         Assert.IsType<Exception>(failure.Reason);
     }

--- a/tests/Proto.Actor.Tests/SupervisionTests_AllForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_AllForOne.cs
@@ -34,7 +34,7 @@ public class SupervisionTestsAllForOne
 
         context.Send(parent, "hello");
 
-        child1MailboxStats.Reset.Wait(5000);
+        Assert.True(child1MailboxStats.Reset.Wait(5000));
         Assert.Contains(ResumeMailbox.Instance, child1MailboxStats.Posted);
         Assert.Contains(ResumeMailbox.Instance, child1MailboxStats.Received);
         Assert.DoesNotContain(ResumeMailbox.Instance, child2MailboxStats.Posted);

--- a/tests/Proto.Actor.Tests/SupervisionTests_AlwaysRestart.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_AlwaysRestart.cs
@@ -1,12 +1,15 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
+using Proto.Mailbox;
+using Proto.TestFixtures;
 using Xunit;
 
 namespace Proto.Tests;
 
 public class SupervisionTestsAlwaysRestart
 {
-    private static readonly Exception Exception = new("boo hoo");
+    private static readonly Exception Exception = new("boom");
 
     [Fact]
     public async Task AlwaysRestartStrategy_Should_RestartFailingChildOnly()
@@ -34,31 +37,61 @@ public class SupervisionTestsAlwaysRestart
         Assert.Equal(1, child2Started);
     }
 
+    [Fact]
+    public async Task AlwaysRestartStrategy_Should_RestartChildOnEveryFailure()
+    {
+        await using var system = new ActorSystem();
+        var context = system.Root;
+
+        var restartCount = 0;
+        var childMailboxStats = new TestMailboxStatistics(msg =>
+        {
+            if (msg is Restart)
+            {
+                restartCount++;
+                return restartCount == 3;
+            }
+
+            return false;
+        });
+
+        var childProps = Props.FromProducer(() => new ChildActor())
+            .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
+
+        var parentProps = Props.FromProducer(() => new ParentActor(childProps))
+            .WithChildSupervisorStrategy(Supervision.AlwaysRestartStrategy);
+
+        var parent = context.Spawn(parentProps);
+
+        context.Send(parent, "1");
+        context.Send(parent, "2");
+        context.Send(parent, "3");
+
+        Assert.True(childMailboxStats.Reset.Wait(TimeSpan.FromSeconds(2)));
+        Assert.Equal(3, childMailboxStats.Received.OfType<Restart>().Count());
+        Assert.DoesNotContain(childMailboxStats.Posted, msg => msg is Stop);
+    }
+
     private class ParentActor : IActor
     {
-        private readonly Props _child1Props;
-        private readonly Props _child2Props;
+        private readonly Props[] _childProps;
+        private PID[]? _children;
 
-        public ParentActor(Props child1Props, Props child2Props)
+        public ParentActor(params Props[] childProps)
         {
-            _child1Props = child1Props;
-            _child2Props = child2Props;
+            _childProps = childProps;
         }
-
-        private PID? Child1 { get; set; }
-        private PID? Child2 { get; set; }
 
         public Task ReceiveAsync(IContext context)
         {
-            if (context.Message is Started)
+            switch (context.Message)
             {
-                Child1 = context.Spawn(_child1Props);
-                Child2 = context.Spawn(_child2Props);
-            }
-
-            if (context.Message is string)
-            {
-                context.Forward(Child1!);
+                case Started:
+                    _children = _childProps.Select(context.Spawn).ToArray();
+                    break;
+                case string when _children != null:
+                    context.Forward(_children[0]);
+                    break;
             }
 
             return Task.CompletedTask;
@@ -67,9 +100,9 @@ public class SupervisionTestsAlwaysRestart
 
     private class ChildActor : IActor
     {
-        private readonly Action _onStarted;
+        private readonly Action? _onStarted;
 
-        public ChildActor(Action onStarted)
+        public ChildActor(Action? onStarted = null)
         {
             _onStarted = onStarted;
         }
@@ -79,7 +112,7 @@ public class SupervisionTestsAlwaysRestart
             switch (context.Message)
             {
                 case Started:
-                    _onStarted();
+                    _onStarted?.Invoke();
                     break;
                 case string:
                     throw Exception;
@@ -89,4 +122,3 @@ public class SupervisionTestsAlwaysRestart
         }
     }
 }
-

--- a/tests/Proto.Actor.Tests/SupervisionTests_AlwaysRestart.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_AlwaysRestart.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Proto.Tests;
+
+public class SupervisionTestsAlwaysRestart
+{
+    private static readonly Exception Exception = new("boo hoo");
+
+    [Fact]
+    public async Task AlwaysRestartStrategy_Should_RestartFailingChildOnly()
+    {
+        await using var system = new ActorSystem();
+        var context = system.Root;
+
+        var child1Started = 0;
+        var child2Started = 0;
+        var strategy = new AlwaysRestartStrategy();
+
+        var child1Props = Props.FromProducer(() => new ChildActor(() => child1Started++));
+        var child2Props = Props.FromProducer(() => new ChildActor(() => child2Started++));
+
+        var parentProps = Props.FromProducer(() => new ParentActor(child1Props, child2Props))
+            .WithChildSupervisorStrategy(strategy);
+
+        var parent = context.Spawn(parentProps);
+
+        context.Send(parent, "fail");
+
+        await Task.Delay(1000);
+
+        Assert.Equal(2, child1Started);
+        Assert.Equal(1, child2Started);
+    }
+
+    private class ParentActor : IActor
+    {
+        private readonly Props _child1Props;
+        private readonly Props _child2Props;
+
+        public ParentActor(Props child1Props, Props child2Props)
+        {
+            _child1Props = child1Props;
+            _child2Props = child2Props;
+        }
+
+        private PID? Child1 { get; set; }
+        private PID? Child2 { get; set; }
+
+        public Task ReceiveAsync(IContext context)
+        {
+            if (context.Message is Started)
+            {
+                Child1 = context.Spawn(_child1Props);
+                Child2 = context.Spawn(_child2Props);
+            }
+
+            if (context.Message is string)
+            {
+                context.Forward(Child1!);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private class ChildActor : IActor
+    {
+        private readonly Action _onStarted;
+
+        public ChildActor(Action onStarted)
+        {
+            _onStarted = onStarted;
+        }
+
+        public Task ReceiveAsync(IContext context)
+        {
+            switch (context.Message)
+            {
+                case Started:
+                    _onStarted();
+                    break;
+                case string:
+                    throw Exception;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}
+

--- a/tests/Proto.Actor.Tests/SupervisionTests_ExponentialBackoff.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_ExponentialBackoff.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Threading.Tasks;
+using Proto.Mailbox;
+using Proto.TestFixtures;
 using Xunit;
 
 namespace Proto.Tests;
@@ -23,5 +26,66 @@ public class SupervisionTestsExponentialBackoff
         strategy.HandleFailure(null!, null!, rs, null!, null);
         strategy.HandleFailure(null!, null!, rs, null!, null);
         Assert.Equal(3, rs.FailureCount);
+    }
+
+    [Fact]
+    public async Task ExponentialBackoffStrategy_Should_RestartChild()
+    {
+        await using var system = new ActorSystem();
+        var context = system.Root;
+
+        var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var strategy = new ExponentialBackoffStrategy(TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(50));
+
+        var childProps = Props.FromProducer(() => new BackoffChild())
+            .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
+
+        var parentProps = Props.FromProducer(() => new ParentActor(childProps))
+            .WithChildSupervisorStrategy(strategy);
+
+        var parent = context.Spawn(parentProps);
+
+        context.Send(parent, "fail");
+        childMailboxStats.Reset.Wait(5000);
+
+        Assert.Contains(childMailboxStats.Posted, m => m is Restart);
+        Assert.Contains(childMailboxStats.Received, m => m is Restart);
+    }
+
+    private class ParentActor : IActor
+    {
+        private readonly Props _childProps;
+
+        public ParentActor(Props childProps) => _childProps = childProps;
+
+        private PID? Child { get; set; }
+
+        public Task ReceiveAsync(IContext context)
+        {
+            if (context.Message is Started)
+            {
+                Child = context.Spawn(_childProps);
+            }
+
+            if (context.Message is string)
+            {
+                context.Forward(Child!);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private class BackoffChild : IActor
+    {
+        public Task ReceiveAsync(IContext context)
+        {
+            if (context.Message is string)
+            {
+                throw new Exception("boom");
+            }
+
+            return Task.CompletedTask;
+        }
     }
 }

--- a/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
@@ -30,7 +30,7 @@ public class SupervisionTestsOneForOne
 
         context.Send(parent, "hello");
 
-        Assert.True(childMailboxStats.Reset.Wait(1000));
+        Assert.True(childMailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
         Assert.Contains(ResumeMailbox.Instance, childMailboxStats.Posted);
         Assert.Contains(ResumeMailbox.Instance, childMailboxStats.Received);
     }
@@ -55,7 +55,7 @@ public class SupervisionTestsOneForOne
 
         context.Send(parent, "hello");
 
-        childMailboxStats.Reset.Wait(1000);
+        Assert.True(childMailboxStats.Reset.Wait(TimeSpan.FromSeconds(2)));
         Assert.Contains(Stop.Instance, childMailboxStats.Posted);
         Assert.Contains(Stop.Instance, childMailboxStats.Received);
     }
@@ -66,7 +66,7 @@ public class SupervisionTestsOneForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var childMailboxStats = new TestMailboxStatistics(msg => msg is Restart);
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
 
         var childProps = Props.FromProducer(() => new ChildActor())
@@ -79,7 +79,7 @@ public class SupervisionTestsOneForOne
 
         context.Send(parent, "hello");
 
-        childMailboxStats.Reset.Wait(2000);
+        Assert.True(childMailboxStats.Reset.Wait(TimeSpan.FromSeconds(2)));
         Assert.Contains(childMailboxStats.Posted, msg => msg is Restart);
         Assert.Contains(childMailboxStats.Received, msg => msg is Restart);
     }

--- a/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
@@ -30,7 +30,7 @@ public class SupervisionTestsOneForOne
 
         context.Send(parent, "hello");
 
-        childMailboxStats.Reset.Wait(1000);
+        Assert.True(childMailboxStats.Reset.Wait(1000));
         Assert.Contains(ResumeMailbox.Instance, childMailboxStats.Posted);
         Assert.Contains(ResumeMailbox.Instance, childMailboxStats.Received);
     }


### PR DESCRIPTION
## Summary
- add coverage for AlwaysRestart supervision strategy
- exercise exponential backoff supervisor restarts
- tighten supervision tests by waiting for resume signals
- wait for dispose callbacks when a supervised actor is restarted

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_688f6228dee4832883a202fd29d8caf2