### PR TITLE
Add tests for core utilities

### DIFF
--- a/src/Proto.Actor/InternalsVisibleTo.cs
+++ b/src/Proto.Actor/InternalsVisibleTo.cs
@@ -9,3 +9,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Proto.Cluster")]
 [assembly: InternalsVisibleTo("Proto.Remote")]
 [assembly: InternalsVisibleTo("Proto.OpenTelemetry.Tests")]
+[assembly: InternalsVisibleTo("Proto.Actor.Tests")]

--- a/tests/Proto.Actor.Tests/ActorMetricsTests.cs
+++ b/tests/Proto.Actor.Tests/ActorMetricsTests.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using Proto.Metrics;
+using Xunit;
+
+namespace Proto.Tests;
+
+public class ActorMetricsTests
+{
+    [Fact]
+    public void CounterProducesMeasurement()
+    {
+        var measurements = new List<long>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Name == ActorMetrics.ActorSpawnCount.Name)
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, state) => measurements.Add(value));
+        listener.Start();
+
+        ActorMetrics.ActorSpawnCount.Add(5);
+
+        Assert.Contains(5, measurements);
+    }
+}

--- a/tests/Proto.Actor.Tests/DeduplicationContextTests.cs
+++ b/tests/Proto.Actor.Tests/DeduplicationContextTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+using Proto.Deduplication;
+using Proto;
+using Xunit;
+
+namespace Proto.Tests;
+
+public class DeduplicationContextTests
+{
+    [Fact]
+    public async Task DuplicatesAreIgnored()
+    {
+        await using var system = new ActorSystem();
+        var context = system.Root;
+        var count = 0;
+
+        var props = Props.FromFunc(ctx =>
+        {
+            if (ctx.Message is string)
+            {
+                count++;
+            }
+            return Task.CompletedTask;
+        }).WithContextDecorator(c => new DeduplicationContext<string>(
+            c,
+            TimeSpan.FromSeconds(5),
+            (MessageEnvelope env, out string? key) =>
+            {
+                key = env.Message as string;
+                return key != null;
+            }
+        ));
+
+        var pid = context.Spawn(props);
+        context.Send(pid, "one");
+        context.Send(pid, "one");
+        context.Send(pid, "two");
+        await Task.Delay(100);
+
+        Assert.Equal(2, count);
+    }
+}

--- a/tests/Proto.Actor.Tests/FunctionActorTests.cs
+++ b/tests/Proto.Actor.Tests/FunctionActorTests.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Proto.Tests;
+
+public class FunctionActorTests
+{
+    [Fact]
+    public async Task FunctionActorHandlesMessages()
+    {
+        await using var system = new ActorSystem();
+        var context = system.Root;
+        var received = false;
+
+        var props = Props.FromFunc(ctx =>
+        {
+            if (ctx.Message is string)
+            {
+                received = true;
+            }
+            return Task.CompletedTask;
+        });
+
+        var pid = context.Spawn(props);
+        context.Send(pid, "hello");
+        await Task.Delay(50);
+
+        Assert.True(received);
+    }
+}

--- a/tests/Proto.Actor.Tests/ObservableGaugeWrapperTests.cs
+++ b/tests/Proto.Actor.Tests/ObservableGaugeWrapperTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using Proto.Metrics;
+using Xunit;
+
+namespace Proto.Tests;
+
+public class ObservableGaugeWrapperTests
+{
+    [Fact]
+    public void ObserverManagementWorks()
+    {
+        var gauge = new ObservableGaugeWrapper<int>();
+        Func<IEnumerable<Measurement<int>>> obs1 = () => new[] { new Measurement<int>(1) };
+        Func<IEnumerable<Measurement<int>>> obs2 = () => new[] { new Measurement<int>(2) };
+
+        gauge.AddObserver(obs1);
+        gauge.AddObserver(obs2);
+
+        var values = gauge.Observe().Select(m => m.Value).ToArray();
+        Assert.Contains(1, values);
+        Assert.Contains(2, values);
+
+        gauge.RemoveObserver(obs1);
+        values = gauge.Observe().Select(m => m.Value).ToArray();
+        Assert.DoesNotContain(1, values);
+        Assert.Contains(2, values);
+    }
+}


### PR DESCRIPTION
## Summary
- add visibility of internals to Proto.Actor.Tests
- exercise FunctionActor behavior
- validate deduplication context, actor metrics, and observable gauge helpers

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688f70f6444c8328b3b222b7d44852c1