### PR TITLE
Return early on duplicate cluster activation requests

### DIFF
--- a/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
+++ b/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
@@ -150,6 +150,8 @@ internal class IdentityStoragePlacementActor : IActor
                     Failed = true
                 }
             );
+
+            return;
         }
 
         var canSpawn = clusterKind.CanSpawnIdentity!(msg.Identity,

--- a/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
@@ -366,6 +366,8 @@ internal class PartitionPlacementActor : IActor, IDisposable
                     TopologyHash = msg.TopologyHash
                 }
             );
+
+            return;
         }
 
         var canSpawn = clusterKind.CanSpawnIdentity!(msg.Identity,

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
@@ -210,6 +210,8 @@ public class PartitionActivatorActor : IActor
                     Failed = true
                 }
             );
+
+            return;
         }
 
         var canSpawn = clusterKind.CanSpawnIdentity!(msg.Identity,

--- a/src/Proto.Cluster/SingleNode/SingleNodeActivatorActor.cs
+++ b/src/Proto.Cluster/SingleNode/SingleNodeActivatorActor.cs
@@ -155,6 +155,8 @@ internal class SingleNodeActivatorActor : IActor
                     Failed = true
                 }
             );
+
+            return;
         }
 
         var canSpawn = clusterKind.CanSpawnIdentity!(msg.Identity,


### PR DESCRIPTION
## Summary
- prevent follow-on activation logic after rejecting duplicate activation checks

## Testing
- `dotnet test ProtoActor.sln` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_e_688f9383324883288027cb1762c4697f