### PR TITLE
Enable NuGet caching in GitHub workflows

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -43,6 +43,13 @@ jobs:
             8.0.x
             7.0.x
             6.0.x
+          cache: true
+          cache-dependency-path: |
+            Directory.Packages.props
+            **/*.csproj
+
+      - name: Restore dependencies
+        run: dotnet restore ProtoActor.sln
 
       - name: Run tests ${{ matrix.test }}
         timeout-minutes: 15
@@ -73,6 +80,13 @@ jobs:
             8.0.x
             7.0.x
             6.0.x
+          cache: true
+          cache-dependency-path: |
+            Directory.Packages.props
+            **/*.csproj
+
+      - name: Restore dependencies
+        run: dotnet restore ProtoActor.sln
       - name: Run tests ${{ matrix.test }}
         timeout-minutes: 15
         run: |
@@ -92,7 +106,14 @@ jobs:
             8.0.x
             7.0.x
             6.0.x
-          
+          cache: true
+          cache-dependency-path: |
+            Directory.Packages.props
+            **/*.csproj
+
+      - name: Restore dependencies
+        run: dotnet restore ProtoActor.sln
+
       - name: Create and push NuGet package
         run: |
           dotnet pack ProtoActor.sln -c Release -o nuget -p:SymbolPackageFormat=snupkg -p:GenerateDocumentationFile=true -p:NoWarn=CS1591

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,6 +31,13 @@ jobs:
             8.0.x
             7.0.x
             6.0.x
+          cache: true
+          cache-dependency-path: |
+            Directory.Packages.props
+            **/*.csproj
+
+      - name: Restore dependencies
+        run: dotnet restore ProtoActor.sln
 
       - name: Build
         run: dotnet build ProtoActor.sln -c Release
@@ -67,6 +74,13 @@ jobs:
             8.0.x
             7.0.x
             6.0.x
+          cache: true
+          cache-dependency-path: |
+            Directory.Packages.props
+            **/*.csproj
+
+      - name: Restore dependencies
+        run: dotnet restore ProtoActor.sln
 
       - name: Run tests ${{ matrix.test }}
         timeout-minutes: 15
@@ -97,6 +111,13 @@ jobs:
             8.0.x
             7.0.x
             6.0.x
+          cache: true
+          cache-dependency-path: |
+            Directory.Packages.props
+            **/*.csproj
+
+      - name: Restore dependencies
+        run: dotnet restore ProtoActor.sln
       - name: Run tests ${{ matrix.test }}
         timeout-minutes: 15
         run: |


### PR DESCRIPTION
## Summary
- cache NuGet packages in build-dev and pull-request workflows
- warm caches by restoring packages before build and tests

## Testing
- `dotnet restore ProtoActor.sln`
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -c Release --no-restore -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_688f9a9618e4832894bc002f07bb75be