### PR TITLE
fix duplicate dotnet-etcd package entry

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,6 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageVersion Include="JsonPatch.Net" Version="3.1.1" />
     <PackageVersion Include="KubernetesClient" Version="15.0.1" />
-    <PackageVersion Include="dotnet-etcd" Version="7.2.0" />
     <PackageVersion Include="Marten" Version="7.27.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.8" />

--- a/src/Proto.Actor/Context/ActorLoggingContext.cs
+++ b/src/Proto.Actor/Context/ActorLoggingContext.cs
@@ -131,7 +131,7 @@ public class ActorLoggingContext : ActorContextDecorator
 
             return response;
         }
-        catch (Exception x)
+        catch (Exception)
         {
             if (_exceptionLogLevel != LogLevel.None && _logger.IsEnabled(_exceptionLogLevel))
             {


### PR DESCRIPTION
## Summary
- remove duplicate dotnet-etcd version in central package management
- drop unused exception variable in ActorLoggingContext

## Testing
- `dotnet build src/Proto.Actor/Proto.Actor.csproj`
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_e_688fa528a65c8328a3f5a8182eb1a3ee