### PR TITLE
chore: update OpenTelemetry dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,12 +62,12 @@
     <PackageVersion Include="MudBlazor" Version="6.21.0" />
     <PackageVersion Include="Neovolve.Logging.Xunit" Version="6.1.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="OpenTelemetry" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Jaeger" Version="1.5.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageVersion Include="prometheus-net" Version="8.2.1" />
     <PackageVersion Include="Proto.Cluster.CodeGen" Version="1.7.0" />

--- a/src/Proto.OpenTelemetry/OpenTelemetryMethodsDecorators.cs
+++ b/src/Proto.OpenTelemetry/OpenTelemetryMethodsDecorators.cs
@@ -26,8 +26,8 @@ internal static class OpenTelemetryMethodsDecorators
         }
         catch (Exception ex)
         {
-            activity?.RecordException(ex);
-            activity?.SetStatus(Status.Error);
+            activity?.AddException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error);
 
             throw;
         }
@@ -56,8 +56,8 @@ internal static class OpenTelemetryMethodsDecorators
         }
         catch (Exception ex)
         {
-            activity?.RecordException(ex);
-            activity?.SetStatus(Status.Error);
+            activity?.AddException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error);
 
             throw;
         }
@@ -79,8 +79,8 @@ internal static class OpenTelemetryMethodsDecorators
         }
         catch (Exception ex)
         {
-            activity?.RecordException(ex);
-            activity?.SetStatus(Status.Error);
+            activity?.AddException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error);
 
             throw;
         }
@@ -108,8 +108,8 @@ internal static class OpenTelemetryMethodsDecorators
         }
         catch (Exception ex)
         {
-            activity?.RecordException(ex);
-            activity?.SetStatus(Status.Error);
+            activity?.AddException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error);
 
             throw;
         }
@@ -135,16 +135,16 @@ internal static class OpenTelemetryMethodsDecorators
         catch (TimeoutException ex)
         {
             activity?.SetTag(ProtoTags.ActionType, nameof(RequestAsync));
-            activity?.RecordException(ex);
-            activity?.SetStatus(Status.Error);
+            activity?.AddException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error);
             activity?.AddEvent(new ActivityEvent("Request Timeout"));
 
             throw;
         }
         catch (Exception ex)
         {
-            activity?.RecordException(ex);
-            activity?.SetStatus(Status.Error);
+            activity?.AddException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error);
 
             throw;
         }
@@ -166,8 +166,8 @@ internal static class OpenTelemetryMethodsDecorators
         }
         catch (Exception ex)
         {
-            activity?.RecordException(ex);
-            activity?.SetStatus(Status.Error);
+            activity?.AddException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error);
 
             throw;
         }
@@ -187,8 +187,8 @@ internal static class OpenTelemetryMethodsDecorators
         }
         catch (Exception ex)
         {
-            activity?.RecordException(ex);
-            activity?.SetStatus(Status.Error);
+            activity?.AddException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error);
 
             throw;
         }
@@ -236,8 +236,8 @@ internal static class OpenTelemetryMethodsDecorators
         }
         catch (Exception ex)
         {
-            activity?.RecordException(ex);
-            activity?.SetStatus(Status.Error);
+            activity?.AddException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error);
 
             throw;
         }


### PR DESCRIPTION
## Summary
- update OpenTelemetry packages to 1.12.0
- replace obsolete OpenTelemetry calls with current `AddException`/`SetStatus`
- revert Couchbase upgrade

## Testing
- `dotnet build ProtoActor.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_688fab43e2548328ac9b062e0fd1adcb