### PR TITLE
Fix BuildStartedActivity overload to start activity with original message

### DIFF
--- a/src/Proto.OpenTelemetry/OpenTelemetryHelpers.cs
+++ b/src/Proto.OpenTelemetry/OpenTelemetryHelpers.cs
@@ -27,7 +27,17 @@ internal static class OpenTelemetryHelpers
     )
     {
         var messageType = message.GetMessageTypeName();
-        return BuildStartedActivity(parent, source, verb, messageType, activitySetup, activityKind);
+
+        var name = $"Proto {source}.{verb} {messageType}";
+        var tags = new[] { new KeyValuePair<string, object?>(ProtoTags.MessageType, messageType) };
+        var activity = ActivitySource.StartActivity(name, activityKind, parent, tags);
+
+        if (activity is not null)
+        {
+            activitySetup(activity, message);
+        }
+
+        return activity;
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary
- ensure BuildStartedActivity(object) starts its own Activity and passes the original message to `activitySetup`

## Testing
- `dotnet test ProtoActor.sln` *(fails: Docker is either not running or misconfigured)*

------
https://chatgpt.com/codex/tasks/task_e_688fb772e4548328978357faea7ddf0d