### PR TITLE
feat: cache build outputs

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -44,6 +44,15 @@ jobs:
             Directory.Packages.props
             **/*.csproj
 
+      - name: Restore bin/obj cache
+        id: cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+
       - name: Restore dependencies
         run: dotnet restore ProtoActor.sln
 
@@ -53,6 +62,15 @@ jobs:
           ConnectionStrings__Redis: localhost:${{ job.services.redis.ports[6379] }},syncTimeout=10000
         run: |
           dotnet test ${{ matrix.test }} -c Release -f ${{ matrix.dotnet }} --logger GitHubActions
+
+      - name: Save bin/obj cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ steps.cache.outputs.cache-primary-key }}
           
   test-fast:  # fast tests where setting up a parallel job run is more overhead than just running the tests side by side
     runs-on: ubuntu-latest
@@ -79,12 +97,30 @@ jobs:
             Directory.Packages.props
             **/*.csproj
 
+      - name: Restore bin/obj cache
+        id: cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+
       - name: Restore dependencies
         run: dotnet restore ProtoActor.sln
       - name: Run tests ${{ matrix.test }}
         timeout-minutes: 15
         run: |
           dotnet test ${{ matrix.test }} -c Release --logger GitHubActions
+
+      - name: Save bin/obj cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ steps.cache.outputs.cache-primary-key }}
 
   nuget:
     runs-on: ubuntu-latest
@@ -103,6 +139,15 @@ jobs:
             Directory.Packages.props
             **/*.csproj
 
+      - name: Restore bin/obj cache
+        id: cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+
       - name: Restore dependencies
         run: dotnet restore ProtoActor.sln
 
@@ -110,3 +155,12 @@ jobs:
         run: |
           dotnet pack ProtoActor.sln -c Release -o nuget -p:SymbolPackageFormat=snupkg -p:GenerateDocumentationFile=true -p:NoWarn=CS1591
           dotnet nuget push nuget/**/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Save bin/obj cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,11 +34,29 @@ jobs:
             Directory.Packages.props
             **/*.csproj
 
+      - name: Restore bin/obj cache
+        id: cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+
       - name: Restore dependencies
         run: dotnet restore ProtoActor.sln
 
       - name: Build
         run: dotnet build ProtoActor.sln -c Release
+
+      - name: Save bin/obj cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ steps.cache.outputs.cache-primary-key }}
 
   test-slow:  # slow tests that should run in parallel
     runs-on: ubuntu-latest
@@ -73,6 +91,15 @@ jobs:
             Directory.Packages.props
             **/*.csproj
 
+      - name: Restore bin/obj cache
+        id: cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+
       - name: Restore dependencies
         run: dotnet restore ProtoActor.sln
 
@@ -82,6 +109,15 @@ jobs:
           ConnectionStrings__Redis: localhost:${{ job.services.redis.ports[6379] }},syncTimeout=10000
         run: |
           dotnet test ${{ matrix.test }} -c Release -f ${{ matrix.dotnet }} --logger GitHubActions
+
+      - name: Save bin/obj cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ steps.cache.outputs.cache-primary-key }}
 
   test-fast:  # fast tests where setting up a parallel job run is more overhead than just running the tests side by side
     runs-on: ubuntu-latest
@@ -108,9 +144,27 @@ jobs:
             Directory.Packages.props
             **/*.csproj
 
+      - name: Restore bin/obj cache
+        id: cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+
       - name: Restore dependencies
         run: dotnet restore ProtoActor.sln
       - name: Run tests ${{ matrix.test }}
         timeout-minutes: 15
         run: |
           dotnet test ${{ matrix.test }} -c Release --logger GitHubActions
+
+      - name: Save bin/obj cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ steps.cache.outputs.cache-primary-key }}


### PR DESCRIPTION
## Summary
- cache bin/obj directories during PR builds
- cache build outputs for dev builds

## Testing
- `dotnet test ProtoActor.sln -c Release` *(fails: MongoDB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688fb8f30a9483289360ab702d61c080