### PR TITLE
Avoid redundant restores in CI workflows

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           ConnectionStrings__Redis: localhost:${{ job.services.redis.ports[6379] }},syncTimeout=10000
         run: |
-          dotnet test ${{ matrix.test }} -c Release -f ${{ matrix.dotnet }} --logger GitHubActions
+          dotnet test ${{ matrix.test }} -c Release -f ${{ matrix.dotnet }} --logger GitHubActions --no-restore
           
   test-fast:  # fast tests where setting up a parallel job run is more overhead than just running the tests side by side
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
       - name: Run tests ${{ matrix.test }}
         timeout-minutes: 15
         run: |
-          dotnet test ${{ matrix.test }} -c Release --logger GitHubActions
+          dotnet test ${{ matrix.test }} -c Release --logger GitHubActions --no-restore
 
   nuget:
     runs-on: ubuntu-latest
@@ -108,5 +108,5 @@ jobs:
 
       - name: Create and push NuGet package
         run: |
-          dotnet pack ProtoActor.sln -c Release -o nuget -p:SymbolPackageFormat=snupkg -p:GenerateDocumentationFile=true -p:NoWarn=CS1591
+          dotnet pack ProtoActor.sln -c Release -o nuget -p:SymbolPackageFormat=snupkg -p:GenerateDocumentationFile=true -p:NoWarn=CS1591 --no-restore
           dotnet nuget push nuget/**/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,7 +38,7 @@ jobs:
         run: dotnet restore ProtoActor.sln
 
       - name: Build
-        run: dotnet build ProtoActor.sln -c Release
+        run: dotnet build ProtoActor.sln -c Release --no-restore
 
   test-slow:  # slow tests that should run in parallel
     runs-on: ubuntu-latest
@@ -81,7 +81,7 @@ jobs:
         env:
           ConnectionStrings__Redis: localhost:${{ job.services.redis.ports[6379] }},syncTimeout=10000
         run: |
-          dotnet test ${{ matrix.test }} -c Release -f ${{ matrix.dotnet }} --logger GitHubActions
+          dotnet test ${{ matrix.test }} -c Release -f ${{ matrix.dotnet }} --logger GitHubActions --no-restore
 
   test-fast:  # fast tests where setting up a parallel job run is more overhead than just running the tests side by side
     runs-on: ubuntu-latest
@@ -113,4 +113,4 @@ jobs:
       - name: Run tests ${{ matrix.test }}
         timeout-minutes: 15
         run: |
-          dotnet test ${{ matrix.test }} -c Release --logger GitHubActions
+          dotnet test ${{ matrix.test }} -c Release --logger GitHubActions --no-restore


### PR DESCRIPTION
## Summary
- Skip restoring during builds/tests by adding `--no-restore` to CI workflows.
- Apply the same optimization to NuGet packaging.

## Testing
- `yamllint .github/workflows/pull-request.yml .github/workflows/build-dev.yml` *(fails: trailing spaces, line too long)*
- `dotnet build ProtoActor.sln -c Release`
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -c Release -f net8.0 --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_688fb90bf158832886a9ccbf4307e6d8