### PR TITLE
Build workflows compile before tests

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -47,12 +47,15 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ProtoActor.sln
 
+      - name: Build
+        run: dotnet build ProtoActor.sln -c Release --no-restore
+
       - name: Run tests ${{ matrix.test }}
         timeout-minutes: 15
         env:
           ConnectionStrings__Redis: localhost:${{ job.services.redis.ports[6379] }},syncTimeout=10000
         run: |
-          dotnet test ${{ matrix.test }} -c Release -f ${{ matrix.dotnet }} --logger GitHubActions
+          dotnet test ${{ matrix.test }} -c Release -f ${{ matrix.dotnet }} --no-build --no-restore --logger GitHubActions
           
   test-fast:  # fast tests where setting up a parallel job run is more overhead than just running the tests side by side
     runs-on: ubuntu-latest
@@ -81,10 +84,13 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore ProtoActor.sln
+
+      - name: Build
+        run: dotnet build ProtoActor.sln -c Release --no-restore
       - name: Run tests ${{ matrix.test }}
         timeout-minutes: 15
         run: |
-          dotnet test ${{ matrix.test }} -c Release --logger GitHubActions
+          dotnet test ${{ matrix.test }} -c Release --no-build --no-restore --logger GitHubActions
 
   nuget:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -76,12 +76,15 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ProtoActor.sln
 
+      - name: Build
+        run: dotnet build ProtoActor.sln -c Release --no-restore
+
       - name: Run tests ${{ matrix.test }}
         timeout-minutes: 15
         env:
           ConnectionStrings__Redis: localhost:${{ job.services.redis.ports[6379] }},syncTimeout=10000
         run: |
-          dotnet test ${{ matrix.test }} -c Release -f ${{ matrix.dotnet }} --logger GitHubActions
+          dotnet test ${{ matrix.test }} -c Release -f ${{ matrix.dotnet }} --no-build --no-restore --logger GitHubActions
 
   test-fast:  # fast tests where setting up a parallel job run is more overhead than just running the tests side by side
     runs-on: ubuntu-latest
@@ -110,7 +113,10 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore ProtoActor.sln
+
+      - name: Build
+        run: dotnet build ProtoActor.sln -c Release --no-restore
       - name: Run tests ${{ matrix.test }}
         timeout-minutes: 15
         run: |
-          dotnet test ${{ matrix.test }} -c Release --logger GitHubActions
+          dotnet test ${{ matrix.test }} -c Release --no-build --no-restore --logger GitHubActions


### PR DESCRIPTION
## Summary
- build solution before running tests to ensure consistent Release builds
- run tests without rebuild or restore to save CI time

## Testing
- `dotnet build ProtoActor.sln -c Release`
- `dotnet test ProtoActor.sln -c Release` *(fails: MongoDB connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_688fb945812c8328a6209c341951f001