### PR TITLE
chore: reduce workflow fetch depth

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # Full history required for versioning
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |


### PR DESCRIPTION
## Summary
- limit checkout depth to 1 in build and test jobs
- keep full history only for NuGet packaging

## Testing
- `dotnet build ProtoActor.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_688fb91f5308832880f92d4219313102