### PR TITLE
Only produce symbol packages in CI

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,8 +9,8 @@
         <RepositoryUrl>https://github.com/AsynkronIT/protoactor-dotnet</RepositoryUrl>
         <PackageTags>actors actor model concurrency proto protoactor</PackageTags>
         <LangVersion>10</LangVersion>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <IncludeSymbols Condition="'$(CI)' == 'true'">true</IncludeSymbols>
+        <SymbolPackageFormat Condition="'$(CI)' == 'true'">snupkg</SymbolPackageFormat>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
         <DefineConstants>TRACE;DEBUG</DefineConstants>


### PR DESCRIPTION
## Summary
- only emit symbol packages when running under CI

## Testing
- `dotnet test ProtoActor.sln` *(fails: MSBUILD: error, numerous test failures)*

------
https://chatgpt.com/codex/tasks/task_e_688fcc12336483288ab2d683095c7ee5