### PR TITLE
Make coverage optional

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,6 +5,7 @@
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+        <CollectCoverage Condition="'$(CollectCoverage)' == ''">false</CollectCoverage>
     </PropertyGroup>
 
     <ItemGroup>
@@ -18,6 +19,13 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Roslynator.Analyzers">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(CollectCoverage)' == 'true'">
+        <PackageReference Include="coverlet.collector">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/tests/Proto.Analyzers.Tests/Proto.Analyzers.Tests.csproj
+++ b/tests/Proto.Analyzers.Tests/Proto.Analyzers.Tests.csproj
@@ -11,10 +11,6 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" />
-        <PackageReference Include="coverlet.collector">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Proto.Cluster.PartitionIdentity.Tests/Proto.Cluster.PartitionIdentity.Tests.csproj
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/Proto.Cluster.PartitionIdentity.Tests.csproj
@@ -8,13 +8,6 @@
         <LangVersion>10</LangVersion>
     </PropertyGroup>
 
-    <ItemGroup>
-
-        <PackageReference Include="coverlet.collector">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Proto.Cluster.Tests\Proto.Cluster.Tests.csproj" />

--- a/tests/Proto.OpenTelemetry.Tests/Proto.OpenTelemetry.Tests.csproj
+++ b/tests/Proto.OpenTelemetry.Tests/Proto.OpenTelemetry.Tests.csproj
@@ -15,10 +15,6 @@
         </PackageReference>
         <PackageReference Include="OpenTelemetry" />
         
-        <PackageReference Include="coverlet.collector">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- default CollectCoverage to false and include coverlet.collector only when coverage is requested
- remove direct coverlet.collector references from test project files

## Testing
- `dotnet test ProtoActor.sln` *(fails: MongoDB Driver Timeout; Failed: 58, Passed: 0, Skipped: 0)*

------
https://chatgpt.com/codex/tasks/task_e_688fcc214b5c8328a49309422034a81d