### PR TITLE
Escalate unknown system messages

### DIFF
--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -29,6 +29,8 @@
 4. **Extensibility**
    - Extension points (`ActorSystemExtensions`, etc.) allow custom components.
    - Roslyn analyzers and code generators help with strongly typed grains and error detection.
+5. **System Messages and Supervision**
+   - Unrecognized system messages cause the actor to escalate a failure to its supervisor.
 
 ## Next Steps
 

--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -608,11 +608,12 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
         _ = Continue(target, cont, this);
     }
 
-    private static Task HandleUnknownSystemMessage(object msg)
+    private Task HandleUnknownSystemMessage(SystemMessage msg)
     {
-        //TODO: sounds like a pretty severe issue if we end up here? what todo?
+        // Escalate to supervision so the failure can be handled by the actor's supervisor
+        var exception = new InvalidOperationException($"Unknown system message {msg}");
         Logger.UnknownSystemMessage(msg);
-
+        EscalateFailure(exception, msg);
         return Task.CompletedTask;
     }
 

--- a/tests/Proto.Actor.Tests/UnknownSystemMessageTests.cs
+++ b/tests/Proto.Actor.Tests/UnknownSystemMessageTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Proto.Mailbox;
+using Proto.TestFixtures;
+using Xunit;
+
+namespace Proto.Tests;
+
+public class UnknownSystemMessageTests
+{
+    private class UnknownSystemMessage : SystemMessage
+    {
+    }
+
+    private record GetChild;
+
+    private class ParentActor : IActor
+    {
+        private readonly Props _childProps;
+
+        public ParentActor(Props childProps)
+        {
+            _childProps = childProps;
+        }
+
+        public PID? Child { get; set; }
+
+        public Task ReceiveAsync(IContext context)
+        {
+            switch (context.Message)
+            {
+                case Started:
+                    Child = context.Spawn(_childProps);
+                    break;
+                case GetChild:
+                    context.Respond(Child!);
+                    break;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task Unknown_system_message_should_escalate_to_parent()
+    {
+        await using var system = new ActorSystem();
+        var parentStats = new TestMailboxStatistics(m => m is Failure);
+
+        var childProps = Props.FromFunc(ctx => Task.CompletedTask);
+        var parentProps = Props.FromProducer(() => new ParentActor(childProps))
+            .WithMailbox(() => UnboundedMailbox.Create(parentStats));
+
+        var parent = system.Root.Spawn(parentProps);
+        var child = await system.Root.RequestAsync<PID>(parent, new GetChild());
+
+        child.SendSystemMessage(system, new UnknownSystemMessage());
+
+        Assert.True(parentStats.Reset.Wait(TimeSpan.FromSeconds(5)));
+        var failure = Assert.Single(parentStats.Received.OfType<Failure>());
+        Assert.Equal(child, failure.Who);
+        Assert.IsType<InvalidOperationException>(failure.Reason);
+    }
+}


### PR DESCRIPTION
## Summary
- escalate unknown system messages to supervision and log them
- document how unrecognized system messages are escalated
- test escalation when actors receive unknown system messages

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6890d31b001083289f9dead5d747da21