### PR TITLE
test supervision strategy override in actor

### DIFF
--- a/tests/Proto.Actor.Tests/SupervisionTests_ActorSupervisorStrategy.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_ActorSupervisorStrategy.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Threading.Tasks;
+using Proto;
+using Xunit;
+
+namespace Proto.Tests;
+
+public class SupervisionTestsActorSupervisorStrategy
+{
+    [Fact]
+    public async Task ActorImplementingISupervisorStrategy_Should_HandleFailureWithCustomStrategy()
+    {
+        await using var system = new ActorSystem();
+        var customHandled = new TaskCompletionSource<bool>();
+        var defaultHandled = new TaskCompletionSource<bool>();
+
+        var childProps = Props.FromProducer(() => new FailingChildActor());
+        var defaultStrategy = new TrackingSupervisorStrategy(defaultHandled);
+
+        var parentProps = Props.FromProducer(() => new SupervisingActor(childProps, customHandled))
+            .WithChildSupervisorStrategy(defaultStrategy);
+
+        var parent = system.Root.Spawn(parentProps);
+        system.Root.Send(parent, "fail");
+
+        await customHandled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(defaultHandled.Task.IsCompleted);
+    }
+
+    [Fact]
+    public async Task ActorWithoutISupervisorStrategy_Should_UseDefaultStrategy()
+    {
+        await using var system = new ActorSystem();
+        var defaultHandled = new TaskCompletionSource<bool>();
+
+        var childProps = Props.FromProducer(() => new FailingChildActor());
+        var defaultStrategy = new TrackingSupervisorStrategy(defaultHandled);
+
+        var parentProps = Props.FromProducer(() => new NonSupervisingParent(childProps))
+            .WithChildSupervisorStrategy(defaultStrategy);
+
+        var parent = system.Root.Spawn(parentProps);
+        system.Root.Send(parent, "fail");
+
+        await defaultHandled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    private class SupervisingActor : IActor, ISupervisorStrategy
+    {
+        private readonly Props _childProps;
+        private readonly TaskCompletionSource<bool> _handled;
+        private PID? _child;
+
+        public SupervisingActor(Props childProps, TaskCompletionSource<bool> handled)
+        {
+            _childProps = childProps;
+            _handled = handled;
+        }
+
+        public Task ReceiveAsync(IContext context)
+        {
+            switch (context.Message)
+            {
+                case Started:
+                    _child = context.Spawn(_childProps);
+                    break;
+                case string:
+                    context.Send(_child!, "fail");
+                    break;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public void HandleFailure(ISupervisor supervisor, PID child, RestartStatistics rs, Exception cause, object? message)
+        {
+            _handled.TrySetResult(true);
+            supervisor.ResumeChildren(child);
+        }
+    }
+
+    private class NonSupervisingParent : IActor
+    {
+        private readonly Props _childProps;
+        private PID? _child;
+
+        public NonSupervisingParent(Props childProps) => _childProps = childProps;
+
+        public Task ReceiveAsync(IContext context)
+        {
+            switch (context.Message)
+            {
+                case Started:
+                    _child = context.Spawn(_childProps);
+                    break;
+                case string:
+                    context.Send(_child!, "fail");
+                    break;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private class FailingChildActor : IActor
+    {
+        public Task ReceiveAsync(IContext context)
+        {
+            if (context.Message is string)
+            {
+                throw new Exception("boom");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private class TrackingSupervisorStrategy : ISupervisorStrategy
+    {
+        private readonly TaskCompletionSource<bool> _handled;
+
+        public TrackingSupervisorStrategy(TaskCompletionSource<bool> handled) => _handled = handled;
+
+        public void HandleFailure(ISupervisor supervisor, PID child, RestartStatistics rs, Exception cause, object? message)
+        {
+            _handled.TrySetResult(true);
+            supervisor.ResumeChildren(child);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for actors that implement ISupervisorStrategy
- ensure default child supervisor strategy is used when actor doesn't implement ISupervisorStrategy

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6890d30ae9848328ba945e4d8952c04d