### PR TITLE
refactor: streamline gossip callbacks

### DIFF
--- a/src/Proto.Cluster/Gossip/Gossip.cs
+++ b/src/Proto.Cluster/Gossip/Gossip.cs
@@ -70,7 +70,6 @@ internal class Gossip
     private long _localSequenceNo;
     private Member[] _otherMembers = Array.Empty<Member>();
     private GossipState _state = new();
-    private bool _needsPurge;
 
     public Gossip(string myId, int gossipFanout, int gossipMaxSend, InstanceLogger? logger,
         Func<ImmutableHashSet<string>> getMembers, bool gossipDebugLogging)
@@ -100,8 +99,8 @@ internal class Gossip
 
         _otherMembers = others.ToArray();
         _activeMemberIds = activeIds.ToImmutable();
-        _needsPurge = true;
 
+        Purge();
         SetState(GossipKeys.Topology, clusterTopology);
 
         return Task.CompletedTask;
@@ -308,11 +307,6 @@ internal class Gossip
 
     private void CheckConsensus(string updatedKey)
     {
-        if (_needsPurge)
-        {
-            Purge();
-        }
-
         foreach (var consensusCheck in _consensusChecks.GetByUpdatedKey(updatedKey))
         {
             consensusCheck.Check(_state, _activeMemberIds);
@@ -321,11 +315,6 @@ internal class Gossip
 
     private void CheckConsensus(IEnumerable<string> updatedKeys)
     {
-        if (_needsPurge)
-        {
-            Purge();
-        }
-
         foreach (var consensusCheck in _consensusChecks.GetByUpdatedKeys(updatedKeys))
         {
             consensusCheck.Check(_state, _activeMemberIds);
@@ -357,8 +346,6 @@ internal class Gossip
                 _committedOffsets = _committedOffsets.Remove(x);
             }
         }
-
-        _needsPurge = false;
     }
 
     private void CommitPendingOffsets(ImmutableDictionary<string, long> pendingOffsets)

--- a/src/Proto.Cluster/Gossip/Gossip.cs
+++ b/src/Proto.Cluster/Gossip/Gossip.cs
@@ -70,6 +70,7 @@ internal class Gossip
     private long _localSequenceNo;
     private Member[] _otherMembers = Array.Empty<Member>();
     private GossipState _state = new();
+    private bool _needsPurge;
 
     public Gossip(string myId, int gossipFanout, int gossipMaxSend, InstanceLogger? logger,
         Func<ImmutableHashSet<string>> getMembers, bool gossipDebugLogging)
@@ -84,9 +85,23 @@ internal class Gossip
 
     public Task UpdateClusterTopology(ClusterTopology clusterTopology)
     {
-        //TODO: optimize
-        _otherMembers = clusterTopology.Members.Where(m => m.Id != _myId).ToArray();
-        _activeMemberIds = clusterTopology.Members.Select(m => m.Id).ToImmutableHashSet();
+        var others = new List<Member>();
+        var activeIds = ImmutableHashSet.CreateBuilder<string>();
+
+        foreach (var m in clusterTopology.Members)
+        {
+            activeIds.Add(m.Id);
+
+            if (m.Id != _myId)
+            {
+                others.Add(m);
+            }
+        }
+
+        _otherMembers = others.ToArray();
+        _activeMemberIds = activeIds.ToImmutable();
+        _needsPurge = true;
+
         SetState(GossipKeys.Topology, clusterTopology);
 
         return Task.CompletedTask;
@@ -164,12 +179,13 @@ internal class Gossip
         CheckConsensus(key);
     }
 
-    //TODO: this does not need to use a callback, it can return a list of MemberStates
-    public void SendState(SendStateAction sendStateToMember)
+    public IEnumerable<(Member member, MemberStateDelta memberState)> SendState()
     {
+        var sends = new List<(Member member, MemberStateDelta memberState)>();
+
         try
         {
-            var logger = _logger?.BeginMethodScope();
+            _logger?.BeginMethodScope();
 
             foreach (var member in _otherMembers)
             {
@@ -179,7 +195,7 @@ internal class Gossip
             var randomMembers = _otherMembers.OrderByRandom(_rnd).ToArray();
 
             var fanoutCount = 0;
-            
+
             if (_gossipDebugLogging)
             {
                 var ids = randomMembers.Select(m => m.Id).ToArray();
@@ -188,8 +204,6 @@ internal class Gossip
 
             foreach (var member in randomMembers)
             {
-                //TODO: we can chunk up sends here
-                //instead of sending less state, we can send all of it, but in chunks
                 var memberState = GetMemberStateDelta(member.Id);
 
                 if (!memberState.HasState)
@@ -197,8 +211,7 @@ internal class Gossip
                     continue;
                 }
 
-                //fire and forget, we handle results in ReenterAfter
-                sendStateToMember(memberState, member, logger);
+                sends.Add((member, memberState));
 
                 fanoutCount++;
 
@@ -212,6 +225,8 @@ internal class Gossip
         {
             Logger.LogError(x, "SendState failed");
         }
+
+        return sends;
     }
 
     public MemberStateDelta GetMemberStateDelta(string targetMemberId)
@@ -293,8 +308,10 @@ internal class Gossip
 
     private void CheckConsensus(string updatedKey)
     {
-        //TODO: Optimize
-        Purge();
+        if (_needsPurge)
+        {
+            Purge();
+        }
 
         foreach (var consensusCheck in _consensusChecks.GetByUpdatedKey(updatedKey))
         {
@@ -304,8 +321,10 @@ internal class Gossip
 
     private void CheckConsensus(IEnumerable<string> updatedKeys)
     {
-        //TODO: Optimize
-        Purge();
+        if (_needsPurge)
+        {
+            Purge();
+        }
 
         foreach (var consensusCheck in _consensusChecks.GetByUpdatedKeys(updatedKeys))
         {
@@ -338,18 +357,15 @@ internal class Gossip
                 _committedOffsets = _committedOffsets.Remove(x);
             }
         }
+
+        _needsPurge = false;
     }
 
     private void CommitPendingOffsets(ImmutableDictionary<string, long> pendingOffsets)
     {
         foreach (var (key, sequenceNumber) in pendingOffsets)
         {
-            //TODO: this needs to be improved with filter state on sender side, and then Ack from here
-            //update our state with the data from the remote node
-            //GossipStateManagement.MergeState(_state, response.State, out var newState);
-            //_state = newState;
-
-            if (!_committedOffsets.ContainsKey(key) || _committedOffsets[key] < pendingOffsets[key])
+            if (!_committedOffsets.TryGetValue(key, out var current) || current < sequenceNumber)
             {
                 _committedOffsets = _committedOffsets.SetItem(key, sequenceNumber);
             }

--- a/src/Proto.Cluster/Gossip/GossipActor.cs
+++ b/src/Proto.Cluster/Gossip/GossipActor.cs
@@ -184,9 +184,11 @@ public class GossipActor : IActor
 
     private Task OnSendGossipState(IContext context)
     {
-        void SendStateToMember(MemberStateDelta memberState, Member member, InstanceLogger? logger) => SendGossipForMember(context, member, memberState);
+        foreach (var (member, memberState) in _internal.SendState())
+        {
+            SendGossipForMember(context, member, memberState);
+        }
 
-        _internal.SendState(SendStateToMember);
         context.Respond(new SendGossipStateResponse());
 
         return Task.CompletedTask;

--- a/src/Proto.Cluster/Gossip/IGossip.cs
+++ b/src/Proto.Cluster/Gossip/IGossip.cs
@@ -4,20 +4,13 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
-using Proto.Logging;
 
 namespace Proto.Cluster.Gossip;
-
-/// <summary>
-///     memberStateDelta is the delta state
-///     member is the target member
-///     logger is the instance logger
-/// </summary>
-public delegate void SendStateAction(MemberStateDelta memberStateDelta, Member member, InstanceLogger? logger);
 
 internal interface IGossip : IGossipStateStore, IGossipConsensusChecker, IGossipCore
 {
@@ -35,10 +28,9 @@ internal interface IGossipCore
     ImmutableList<GossipUpdate> ReceiveState(GossipState remoteState);
 
     /// <summary>
-    ///     Sends the gossip to a random set of receiving members
+    ///     Produces the gossip state for a random set of receiving members
     /// </summary>
-    /// <param name="sendStateToMember"></param>
-    void SendState(SendStateAction sendStateToMember);
+    IEnumerable<(Member member, MemberStateDelta memberState)> SendState();
 }
 
 internal interface IGossipConsensusChecker

--- a/tests/Proto.Cluster.Tests/GossipCoreTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipCoreTests.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Proto.Cluster.Gossip;
-using Proto.Logging;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -50,14 +49,6 @@ public class GossipCoreTests
 
         var sends = 0L;
 
-        void SendState(MemberStateDelta memberStateDelta, Member targetMember, InstanceLogger _)
-        {
-            Interlocked.Increment(ref sends);
-            var target = environment[targetMember.Id];
-            target.Gossip.ReceiveState(memberStateDelta.State);
-            memberStateDelta.CommitOffsets();
-        }
-
         var topology = new ClusterTopology
         {
             TopologyHash = Member.TopologyHash(members),
@@ -91,7 +82,13 @@ public class GossipCoreTests
 
                     foreach (var m in environment.Values)
                     {
-                        m.Gossip.SendState(SendState);
+                        foreach (var (member, delta) in m.Gossip.SendState())
+                        {
+                            Interlocked.Increment(ref sends);
+                            var target = environment[member.Id];
+                            target.Gossip.ReceiveState(delta.State);
+                            delta.CommitOffsets();
+                        }
                     }
                 }
             }

--- a/tests/Proto.Cluster.Tests/GossipCoreTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipCoreTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using ClusterTest.Messages;
 using Proto.Cluster.Gossip;
 using Xunit;
 using Xunit.Abstractions;
@@ -101,5 +102,177 @@ public class GossipCoreTests
         _output.WriteLine("Send count " + Interlocked.Read(ref sends));
         x.consensus.Should().BeTrue();
 
+    }
+
+    [Fact]
+    public async Task Small_cluster_should_get_data_consensus()
+    {
+        const int memberCount = 5;
+        const int fanout = 2;
+
+        var members = Enumerable
+            .Range(0, memberCount)
+            .Select(_ => new Member { Id = Guid.NewGuid().ToString("N") })
+            .ToList();
+
+        var environment = members.ToDictionary(
+            m => m.Id,
+            m => (
+                Gossip: new Gossip.Gossip(m.Id, fanout, memberCount, null,
+                    () => members.Select(x => x.Id).ToImmutableHashSet(), false),
+                Member: m));
+
+        var topology = new ClusterTopology
+        {
+            TopologyHash = Member.TopologyHash(members),
+            Members = { members }
+        };
+
+        foreach (var m in environment.Values)
+        {
+            await m.Gossip.UpdateClusterTopology(topology.Clone());
+        }
+
+        const string stateKey = "data";
+        const string stateValue = "value";
+
+        foreach (var m in environment.Values)
+        {
+            m.Gossip.SetState(stateKey, new SomeGossipState { Key = stateValue });
+        }
+
+        var first = environment.Values.First().Gossip;
+
+        var checkDefinition = Gossiper.ConsensusCheckBuilder<string>
+            .Create<SomeGossipState>(stateKey, s => s.Key);
+
+        var id = Guid.NewGuid().ToString();
+        var (handle, check) = checkDefinition.Build(() => first.RemoveConsensusCheck(id));
+        first.AddConsensusCheck(id, check);
+
+        var ct = CancellationTokens.FromSeconds(10);
+
+        _ = Task.Run(() =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                foreach (var m in environment.Values)
+                {
+                    foreach (var (member, delta) in m.Gossip.SendState())
+                    {
+                        var target = environment[member.Id];
+                        target.Gossip.ReceiveState(delta.State);
+                        delta.CommitOffsets();
+                    }
+                }
+            }
+        }, ct);
+
+        var result = await handle.TryGetConsensus(ct);
+        result.consensus.Should().BeTrue();
+        result.value.Should().Be(stateValue);
+    }
+
+    [Fact]
+    public async Task Gossip_should_replicate_large_state_with_small_batches()
+    {
+        const int memberCount = 5;
+        const int fanout = 2;
+        const int maxSend = 2;
+        const int keysPerMember = 5;
+
+        var members = Enumerable
+            .Range(0, memberCount)
+            .Select(_ => new Member { Id = Guid.NewGuid().ToString("N") })
+            .ToList();
+
+        var environment = members.ToDictionary(
+            m => m.Id,
+            m => (
+                Gossip: new Gossip.Gossip(m.Id, fanout, maxSend, null,
+                    () => members.Select(x => x.Id).ToImmutableHashSet(), false),
+                Member: m));
+
+        var topology = new ClusterTopology
+        {
+            TopologyHash = Member.TopologyHash(members),
+            Members = { members }
+        };
+
+        foreach (var m in environment.Values)
+        {
+            await m.Gossip.UpdateClusterTopology(topology.Clone());
+        }
+
+        var expected = members.ToDictionary(m => m.Id, _ => new System.Collections.Generic.Dictionary<string, string>());
+
+        foreach (var m in members.Select((member, index) => (member, index)))
+        {
+            for (var i = 0; i < keysPerMember; i++)
+            {
+                var key = $"k{m.index}-{i}";
+                var value = $"v{m.index}-{i}";
+                environment[m.member.Id].Gossip.SetState(key, new SomeGossipState { Key = value });
+                expected[m.member.Id][key] = value;
+            }
+        }
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+
+        var loop = Task.Run(() =>
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                foreach (var g in environment.Values)
+                {
+                    foreach (var (member, delta) in g.Gossip.SendState())
+                    {
+                        var target = environment[member.Id];
+                        target.Gossip.ReceiveState(delta.State);
+                        delta.CommitOffsets();
+                    }
+                }
+            }
+        }, cts.Token);
+
+        while (!cts.IsCancellationRequested && !AllReplicated())
+        {
+            await Task.Delay(50, cts.Token);
+        }
+
+        cts.Cancel();
+        await loop;
+
+        AllReplicated().Should().BeTrue();
+
+        bool AllReplicated()
+        {
+            var first = environment.Values.First();
+            var snap = first.Gossip.GetStateSnapshot();
+            if (snap.Members.Count != memberCount)
+            {
+                return false;
+            }
+
+            foreach (var (ownerId, kvs) in expected)
+            {
+                if (!snap.Members.TryGetValue(ownerId, out var ms) || ms.Values.Count < keysPerMember + 1)
+                {
+                    return false;
+                }
+
+                foreach (var (key, value) in kvs)
+                {
+                    if (!ms.Values.TryGetValue(key, out var any) ||
+                        !any.Value.TryUnpack<SomeGossipState>(out var state) ||
+                        state.Key != value)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- streamline cluster topology updates and track pending purges
- replace callback-based gossip sends with enumerable state deltas
- simplify consensus checks and committed offset updates

## Testing
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6890d396b11c8328ac19dd14be8a0368