### PR TITLE
Add cluster gossip example

### DIFF
--- a/CLUSTER_MEMBERSHIP_GOSSIP.md
+++ b/CLUSTER_MEMBERSHIP_GOSSIP.md
@@ -3,6 +3,8 @@
 This document explains how cluster membership events are detected and how
 membership state is propagated through gossip.
 
+For a runnable demonstration, see [examples/ClusterGossip](examples/ClusterGossip).
+
 ## Detecting members
 
 Cluster providers (e.g., Kubernetes) watch the environment for running nodes and

--- a/examples/ClusterGossip/ClusterGossip.csproj
+++ b/examples/ClusterGossip/ClusterGossip.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Proto.Cluster.TestProvider\Proto.Cluster.TestProvider.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+  </ItemGroup>
+
+</Project>

--- a/examples/ClusterGossip/Program.cs
+++ b/examples/ClusterGossip/Program.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+using Proto;
+using Proto.Cluster;
+using Proto.Cluster.Gossip;
+using Proto.Cluster.Partition;
+using Proto.Cluster.Testing;
+using Proto.Remote;
+using Proto.Remote.GrpcNet;
+using System.Linq;
+
+namespace ClusterGossip;
+
+internal static class Program
+{
+    private const string GossipKey = "demo-key";
+
+    public static async Task Main()
+    {
+        Log.SetLoggerFactory(LoggerFactory.Create(b => b.AddConsole().SetMinimumLevel(LogLevel.Information)));
+
+        var agent = new InMemAgent();
+
+        var cluster1 = CreateCluster(agent);
+        var cluster2 = CreateCluster(agent);
+
+        await cluster1.StartMemberAsync();
+        await cluster2.StartMemberAsync();
+
+        await cluster1.Gossip.SetStateAsync(GossipKey, new StringValue { Value = "hello from node1" });
+
+        await Task.Delay(1000);
+
+        var values = await cluster2.Gossip.GetState<StringValue>(GossipKey);
+        foreach (var (member, v) in values)
+        {
+            Console.WriteLine($"Node2 received '{v.Value}' from {member}");
+        }
+
+        var topology = await cluster2.Gossip.GetState<ClusterTopology>(GossipKeys.Topology);
+        var first = topology.Values.FirstOrDefault();
+
+        Console.WriteLine("Members seen via gossip:");
+        if (first != null)
+        {
+            foreach (var member in first.Members)
+            {
+                Console.WriteLine($" - {member.Id}");
+            }
+        }
+
+        Console.WriteLine("Press any key to exit");
+        Console.ReadKey();
+
+        await cluster1.ShutdownAsync();
+        await cluster2.ShutdownAsync();
+    }
+
+    private static Cluster CreateCluster(InMemAgent agent)
+    {
+        var system = new ActorSystem()
+            .WithRemote(GrpcNetRemoteConfig.BindToLocalhost().WithProtoMessages(WrappersReflection.Descriptor))
+            .WithCluster(
+                ClusterConfig.Setup("gossip-cluster", new TestProvider(new TestProviderOptions(), agent),
+                        new PartitionIdentityLookup())
+                    .WithClusterKind("empty", Props.FromProducer(() => new EmptyActor())));
+
+        return system.Cluster();
+    }
+
+    private class EmptyActor : IActor
+    {
+        public Task ReceiveAsync(IContext context) => Task.CompletedTask;
+    }
+}

--- a/examples/ClusterGossip/README.md
+++ b/examples/ClusterGossip/README.md
@@ -1,0 +1,10 @@
+# ClusterGossip
+
+Demonstrates how gossip replicates state across Proto.Cluster members.
+The sample starts two in-memory nodes, sets a gossip value on one, and reads it from the other while showing the cluster topology.
+
+Run the sample with:
+
+```
+dotnet run -p examples/ClusterGossip/ClusterGossip.csproj
+```


### PR DESCRIPTION
## Summary
- document cluster membership gossip example location
- add ClusterGossip sample demonstrating gossip state replication

## Testing
- `dotnet build examples/ClusterGossip/ClusterGossip.csproj -c Release`
- `dotnet test ProtoActor.sln -c Release` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6890eb1354888328ba85ee7affa3aa2b