### PR TITLE
test(cluster): add gossip request validation tests

### DIFF
--- a/src/Proto.Remote/InternalsVisibleTo.cs
+++ b/src/Proto.Remote/InternalsVisibleTo.cs
@@ -8,3 +8,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Proto.Cluster")]
 [assembly: InternalsVisibleTo("Proto.Remote.Tests")]
+[assembly: InternalsVisibleTo("Proto.Cluster.Tests")]

--- a/tests/Proto.Cluster.Tests/GossipRequestValidationTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipRequestValidationTests.cs
@@ -5,7 +5,6 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Reflection;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Proto;
@@ -52,8 +51,7 @@ public class GossipRequestValidationTests
         var blocked = clusterFixture.Members[1];
 
         var blockList = target.System.Remote().BlockList;
-        var blockMethod = typeof(BlockList).GetMethod("Block", BindingFlags.Instance | BindingFlags.NonPublic);
-        blockMethod!.Invoke(blockList, new object[] { new[] { blocked.System.Id }, "test" });
+        blockList.Block(new[] { blocked.System.Id }, "test");
 
         var pid = PID.FromAddress(target.System.Address, Gossiper.GossipActorName);
         var response = await target.System.Root.RequestAsync<GossipResponse>(

--- a/tests/Proto.Cluster.Tests/GossipRequestValidationTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipRequestValidationTests.cs
@@ -1,0 +1,71 @@
+// -----------------------------------------------------------------------
+// <copyright file="GossipRequestValidationTests.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Proto;
+using Proto.Cluster;
+using Proto.Cluster.Gossip;
+using Proto.Remote;
+using Xunit;
+
+namespace Proto.Cluster.Tests;
+
+[Collection("ClusterTests")]
+public class GossipRequestValidationTests
+{
+    [Fact]
+    public async Task GossipRequest_from_unknown_member_should_be_rejected()
+    {
+        var clusterFixture = new InMemoryClusterFixture();
+        await using var _ = clusterFixture;
+        await clusterFixture.InitializeAsync();
+
+        var target = clusterFixture.Members[0];
+        var pid = PID.FromAddress(target.System.Address, Gossiper.GossipActorName);
+
+        var response = await target.System.Root.RequestAsync<GossipResponse>(
+            pid,
+            new GossipRequest
+            {
+                MemberId = Guid.NewGuid().ToString("N"),
+                State = new GossipState()
+            },
+            CancellationTokens.FromSeconds(5));
+
+        response.Rejected.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GossipRequest_from_blocked_member_should_be_rejected()
+    {
+        var clusterFixture = new InMemoryClusterFixture();
+        await using var _ = clusterFixture;
+        await clusterFixture.InitializeAsync();
+
+        var target = clusterFixture.Members[0];
+        var blocked = clusterFixture.Members[1];
+
+        var blockList = target.System.Remote().BlockList;
+        var blockMethod = typeof(BlockList).GetMethod("Block", BindingFlags.Instance | BindingFlags.NonPublic);
+        blockMethod!.Invoke(blockList, new object[] { new[] { blocked.System.Id }, "test" });
+
+        var pid = PID.FromAddress(target.System.Address, Gossiper.GossipActorName);
+        var response = await target.System.Root.RequestAsync<GossipResponse>(
+            pid,
+            new GossipRequest
+            {
+                MemberId = blocked.System.Id,
+                State = new GossipState()
+            },
+            CancellationTokens.FromSeconds(5));
+
+        response.Rejected.Should().BeTrue();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tests asserting gossip actor rejects requests from unknown or blocked members

## Testing
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj --filter GossipRequestValidationTests`

------
https://chatgpt.com/codex/tasks/task_e_6891cb1a28ac83288efe557a48318e6b