### PR TITLE
refactor: move message batching out of Endpoint

### DIFF
--- a/src/Proto.Remote/Endpoints/Endpoint.cs
+++ b/src/Proto.Remote/Endpoints/Endpoint.cs
@@ -11,10 +11,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using Google.Protobuf;
 using Microsoft.Extensions.Logging;
 using Proto.Extensions;
-using Proto.Remote.Metrics;
 
 namespace Proto.Remote;
 
@@ -315,137 +313,6 @@ public abstract class Endpoint : IEndpoint
         }
     }
 
-    internal MessageBatch CreateBatch(IReadOnlyCollection<RemoteDeliver> m)
-    {
-        var envelopes = new List<MessageEnvelope>(m.Count);
-        var typeNames = new Dictionary<string, int>();
-        var targets = new Dictionary<(string address, string id), int>();
-        var targetList = new List<string>();
-        var typeNameList = new List<string>();
-        var senders = new Dictionary<(string address, string id), int>();
-        var senderList = new List<PID>();
-
-        foreach (var rd in m)
-        {
-            var target = rd.Target;
-
-            var targetKey = (target.Address, target.Id);
-
-            if (!targets.TryGetValue(targetKey, out var targetId))
-            {
-                targetId = targets[targetKey] = targets.Count;
-                targetList.Add(target.Id);
-            }
-
-            var senderId = 0;
-
-            var sender = rd.Sender;
-
-            if (sender != null)
-            {
-                var senderKey = (sender.Address, sender.Id);
-
-                if (!senders.TryGetValue(senderKey, out senderId))
-                {
-                    senderId = senders[senderKey] = senders.Count + 1;
-
-                    senderList.Add(sender.Address == System.Address
-                        ? PID.FromAddress("", sender.Id)
-                        : PID.FromAddress(sender.Address, sender.Id));
-                }
-            }
-
-            var message = rd.Message;
-
-            //if the message can be translated to a serialization representation, we do this here
-            //this only apply to root level messages and never to nested child objects inside the message
-            if (message is IRootSerializable deserialized)
-            {
-                message = deserialized.Serialize(System);
-            }
-
-            if (message is null)
-            {
-                _logger.LogError("Null message passed to EndpointActor, ignoring message");
-
-                continue;
-            }
-
-            ByteString bytes;
-            string typeName;
-            int serializerId;
-
-            try
-            {
-                (bytes, typeName, serializerId) = RemoteConfig.Serialization.Serialize(message);
-            }
-            catch (CodedOutputStream.OutOfSpaceException oom)
-            {
-                System.Diagnostics.RegisterEvent("Remote", $"Message is too large {message.GetMessageTypeName()}");
-                _logger.LogError(oom, "Message is too large {MessagePayload}", message.GetMessageTypeName());
-
-                throw;
-            }
-            catch (Exception x)
-            {
-                System.Diagnostics.RegisterEvent("Remote", $"Missing serializer for {message.GetMessageTypeName()}");
-                _logger.LogError(x, "Serialization failed for message {MessagePayload}", message.GetMessageTypeName());
-
-                throw;
-            }
-
-            if (System.Metrics.Enabled)
-            {
-                RemoteMetrics.RemoteSerializedMessageCount.Add(1,
-                    new KeyValuePair<string, object?>("id", System.Id),
-                    new KeyValuePair<string, object?>("address", System.Address),
-                    new KeyValuePair<string, object?>("messagetype", typeName)
-                );
-            }
-
-            if (!typeNames.TryGetValue(typeName, out var typeId))
-            {
-                typeId = typeNames[typeName] = typeNames.Count;
-                typeNameList.Add(typeName);
-            }
-
-            MessageHeader? header = null;
-
-            if (rd.Header?.Count > 0)
-            {
-                header = new MessageHeader();
-                header.HeaderData.Add(rd.Header.ToDictionary());
-            }
-
-            var envelope = new MessageEnvelope
-            {
-                MessageData = bytes,
-                Sender = senderId,
-                Target = targetId,
-                TypeId = typeId,
-                SerializerId = serializerId,
-                MessageHeader = header,
-                TargetRequestId = rd.Target.RequestId,
-                SenderRequestId = sender?.RequestId ?? default
-            };
-
-            // if (Logger.IsEnabled(LogLevel.Trace))
-            //     Logger.LogTrace("[{SystemAddress}] Endpoint adding Envelope {Envelope}", System.Address, envelope);
-            envelopes.Add(envelope);
-        }
-
-        var batch = new MessageBatch
-        {
-            Targets = { targetList },
-            TypeNames = { typeNameList },
-            Envelopes = { envelopes },
-            Senders = { senderList }
-        };
-
-        // if (Logger.IsEnabled(LogLevel.Trace))
-        //     Logger.LogTrace("[{SystemAddress}] Sending {Count} envelopes for {Address}", System.Address, envelopes.Count, Address);
-        return batch;
-    }
     
     /// <summary>
     /// Preserves non completed Tasks between <see cref="WaitAnyAsync"/> calls.

--- a/src/Proto.Remote/Endpoints/EndpointReader.cs
+++ b/src/Proto.Remote/Endpoints/EndpointReader.cs
@@ -253,7 +253,7 @@ public sealed class EndpointReader : Remoting.RemotingBase
                 while (!cancellationTokenSource.Token.IsCancellationRequested &&
                        endpoint.OutgoingStash.TryPop(out var messages))
                 {
-                    var batch = ((Endpoint)endpoint).CreateBatch(messages);
+                    var batch = MessageBatchFactory.CreateBatch(_system, _system.Remote().Config, messages);
 
                     try
                     {
@@ -274,7 +274,7 @@ public sealed class EndpointReader : Remoting.RemotingBase
                     var messages = await endpoint.Outgoing.Reader.ReadAsync(cancellationTokenSource.Token)
                         .ConfigureAwait(false);
 
-                    var batch = ((Endpoint)endpoint).CreateBatch(messages);
+                    var batch = MessageBatchFactory.CreateBatch(_system, _system.Remote().Config, messages);
 
                     try
                     {

--- a/src/Proto.Remote/Endpoints/MessageBatchFactory.cs
+++ b/src/Proto.Remote/Endpoints/MessageBatchFactory.cs
@@ -1,0 +1,152 @@
+// -----------------------------------------------------------------------
+//   <copyright file="MessageBatchFactory.cs" company="Asynkron AB">
+//       Copyright (C) 2015-2025 Asynkron AB All rights reserved
+//   </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Google.Protobuf;
+using Microsoft.Extensions.Logging;
+using Proto;
+using Proto.Diagnostics;
+using Proto.Extensions;
+using Proto.Remote.Metrics;
+
+namespace Proto.Remote;
+
+internal static class MessageBatchFactory
+{
+    private static readonly ILogger Logger = Log.CreateLogger("MessageBatchFactory");
+
+    internal static MessageBatch CreateBatch(ActorSystem system, RemoteConfig remoteConfig,
+        IReadOnlyCollection<RemoteDeliver> messages)
+    {
+        var envelopes = new List<MessageEnvelope>(messages.Count);
+        var typeNames = new Dictionary<string, int>();
+        var targets = new Dictionary<(string address, string id), int>();
+        var targetList = new List<string>();
+        var typeNameList = new List<string>();
+        var senders = new Dictionary<(string address, string id), int>();
+        var senderList = new List<PID>();
+
+        foreach (var rd in messages)
+        {
+            var target = rd.Target;
+            var targetKey = (target.Address, target.Id);
+
+            if (!targets.TryGetValue(targetKey, out var targetId))
+            {
+                targetId = targets[targetKey] = targets.Count;
+                targetList.Add(target.Id);
+            }
+
+            var senderId = 0;
+            var sender = rd.Sender;
+
+            if (sender != null)
+            {
+                var senderKey = (sender.Address, sender.Id);
+
+                if (!senders.TryGetValue(senderKey, out senderId))
+                {
+                    senderId = senders[senderKey] = senders.Count + 1;
+
+                    senderList.Add(sender.Address == system.Address
+                        ? PID.FromAddress("", sender.Id)
+                        : PID.FromAddress(sender.Address, sender.Id));
+                }
+            }
+
+            var message = rd.Message;
+
+            //if the message can be translated to a serialization representation, we do this here
+            //this only apply to root level messages and never to nested child objects inside the message
+            if (message is IRootSerializable deserialized)
+            {
+                message = deserialized.Serialize(system);
+            }
+
+            if (message is null)
+            {
+                Logger.LogError("Null message passed to EndpointActor, ignoring message");
+                continue;
+            }
+
+            ByteString bytes;
+            string typeName;
+            int serializerId;
+
+            try
+            {
+                (bytes, typeName, serializerId) = remoteConfig.Serialization.Serialize(message);
+            }
+            catch (CodedOutputStream.OutOfSpaceException oom)
+            {
+                system.Diagnostics.RegisterEvent("Remote",
+                    $"Message is too large {message.GetMessageTypeName()}");
+                Logger.LogError(oom, "Message is too large {MessagePayload}", message.GetMessageTypeName());
+                throw;
+            }
+            catch (Exception x)
+            {
+                system.Diagnostics.RegisterEvent("Remote",
+                    $"Missing serializer for {message.GetMessageTypeName()}");
+                Logger.LogError(x, "Serialization failed for message {MessagePayload}",
+                    message.GetMessageTypeName());
+                throw;
+            }
+
+            if (system.Metrics.Enabled)
+            {
+                RemoteMetrics.RemoteSerializedMessageCount.Add(1,
+                    new KeyValuePair<string, object?>("id", system.Id),
+                    new KeyValuePair<string, object?>("address", system.Address),
+                    new KeyValuePair<string, object?>("messagetype", typeName)
+                );
+            }
+
+            if (!typeNames.TryGetValue(typeName, out var typeId))
+            {
+                typeId = typeNames[typeName] = typeNames.Count;
+                typeNameList.Add(typeName);
+            }
+
+            MessageHeader? header = null;
+
+            if (rd.Header?.Count > 0)
+            {
+                header = new MessageHeader();
+                header.HeaderData.Add(rd.Header.ToDictionary());
+            }
+
+            var envelope = new MessageEnvelope
+            {
+                MessageData = bytes,
+                Sender = senderId,
+                Target = targetId,
+                TypeId = typeId,
+                SerializerId = serializerId,
+                MessageHeader = header,
+                TargetRequestId = rd.Target.RequestId,
+                SenderRequestId = sender?.RequestId ?? default
+            };
+
+            // if (Logger.IsEnabled(LogLevel.Trace))
+            //     Logger.LogTrace("[{SystemAddress}] Endpoint adding Envelope {Envelope}", system.Address, envelope);
+            envelopes.Add(envelope);
+        }
+
+        var batch = new MessageBatch
+        {
+            Targets = { targetList },
+            TypeNames = { typeNameList },
+            Envelopes = { envelopes },
+            Senders = { senderList }
+        };
+
+        // if (Logger.IsEnabled(LogLevel.Trace))
+        //     Logger.LogTrace("[{SystemAddress}] Sending {Count} envelopes for {Address}", system.Address, envelopes.Count, address);
+        return batch;
+    }
+}

--- a/src/Proto.Remote/Endpoints/ServerConnector.cs
+++ b/src/Proto.Remote/Endpoints/ServerConnector.cs
@@ -258,7 +258,7 @@ public sealed class ServerConnector
             {
                 while (_endpoint.OutgoingStash.TryPop(out var messages))
                 {
-                    var batch = ((Endpoint)_endpoint).CreateBatch(messages);
+                    var batch = MessageBatchFactory.CreateBatch(_system, _remoteConfig, messages);
 
                     try
                     {
@@ -279,7 +279,7 @@ public sealed class ServerConnector
                     await foreach (var messages in _endpoint.Outgoing.Reader.ReadAllAsync(combinedToken)
                                        .ConfigureAwait(false))
                     {
-                        var batch = ((Endpoint)_endpoint).CreateBatch(messages);
+                        var batch = MessageBatchFactory.CreateBatch(_system, _remoteConfig, messages);
 
                         try
                         {


### PR DESCRIPTION
## Summary
- extract message batch creation into new MessageBatchFactory
- use MessageBatchFactory in EndpointReader and ServerConnector

## Testing
- `dotnet build ProtoActor.sln`
- `dotnet test ProtoActor.sln` *(fails: Docker is either not running or misconfigured)*

------
https://chatgpt.com/codex/tasks/task_e_6892edc6d21c8328846c4dee677dd4ea