### PR TITLE
fix: address nullability warnings

### DIFF
--- a/src/Proto.Actor/Context/RootContext.cs
+++ b/src/Proto.Actor/Context/RootContext.cs
@@ -102,7 +102,10 @@ public sealed record RootContext : IRootContext
 
     public void Request(PID target, object message, PID? sender)
     {
-        var envelope = MessageEnvelope.WithSender(message, sender);
+        var envelope = sender is null
+            ? MessageEnvelope.Wrap(message)
+            : MessageEnvelope.WithSender(message, sender);
+
         Send(target, envelope);
     }
 

--- a/src/Proto.Cluster.CodeGen/ProtoGenTask.cs
+++ b/src/Proto.Cluster.CodeGen/ProtoGenTask.cs
@@ -52,7 +52,7 @@ public class ProtoGenTask : Task
         return true;
     }
 
-    private static void EnsureDirExistsAndIsEmpty(string? potatoDirectory)
+    private static void EnsureDirExistsAndIsEmpty(string potatoDirectory)
     {
         Directory.CreateDirectory(potatoDirectory);
         var di = new DirectoryInfo(potatoDirectory);

--- a/src/Proto.Cluster.CodeGen/model/ProtoHack.cs
+++ b/src/Proto.Cluster.CodeGen/model/ProtoHack.cs
@@ -20,8 +20,8 @@ public static class ProtoHack
         }
 
         var parentProp = typeof(DescriptorProto).GetProperty("Parent", BindingFlags.NonPublic | BindingFlags.Instance);
-        var parent = (FileDescriptorProto)parentProp!.GetValue(self);
+        var parent = parentProp?.GetValue(self) as FileDescriptorProto;
 
-        return parent;
+        return parent ?? throw new InvalidOperationException("Descriptor has no parent");
     }
 }

--- a/tests/Proto.OpenTelemetry.Tests/OpenTelemetryTracingTests.cs
+++ b/tests/Proto.OpenTelemetry.Tests/OpenTelemetryTracingTests.cs
@@ -13,7 +13,7 @@ namespace Proto.OpenTelemetry.Tests;
 
 public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
 {
-    private static readonly Baggage TestBaggage = Baggage.Create(new Dictionary<string, string?>
+    private static readonly Baggage TestBaggage = Baggage.Create(new Dictionary<string, string>
     {
         {"baggageKey", "baggageValue"}
     });


### PR DESCRIPTION
## Summary
- ensure RootContext.Request wraps messages when sender is null
- guard against missing descriptor parents in codegen helpers
- clean up nullability in OpenTelemetry test setup

## Testing
- `dotnet build ProtoActor.sln`
- `dotnet test tests/Proto.OpenTelemetry.Tests/Proto.OpenTelemetry.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6893206d1cf48328bb5a6398cb2222c2