### PR TITLE
fix: tighten consensus check nullability

### DIFF
--- a/src/Proto.Cluster/Gossip/Consensus.cs
+++ b/src/Proto.Cluster/Gossip/Consensus.cs
@@ -11,14 +11,14 @@ using Proto.Utils;
 
 namespace Proto.Cluster.Gossip;
 
-public interface IConsensusHandle<T> : IDisposable
+public interface IConsensusHandle<T> : IDisposable where T : notnull
 {
     Task<(bool consensus, T value)> TryGetConsensus(CancellationToken ct);
 
     Task<(bool consensus, T value)> TryGetConsensus(TimeSpan maxWait, CancellationToken cancellationToken);
 }
 
-internal class GossipConsensusHandle<T> : IConsensusHandle<T>
+internal class GossipConsensusHandle<T> : IConsensusHandle<T> where T : notnull
 {
     private readonly Action _deregister;
     private TaskCompletionSource<T> _consensusTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -42,7 +42,7 @@ internal class GossipConsensusHandle<T> : IConsensusHandle<T>
             }
         }
 
-        return (false, default);
+        return (false, default!);
     }
 
     public Task<(bool consensus, T value)> TryGetConsensus(TimeSpan maxWait, CancellationToken cancellationToken) =>

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -20,7 +20,7 @@ using Proto.Remote;
 
 namespace Proto.Cluster.Gossip;
 
-public delegate (bool, T) ConsensusCheck<T>(GossipState state, IImmutableSet<string> memberIds);
+public delegate (bool, T) ConsensusCheck<T>(GossipState state, IImmutableSet<string> memberIds) where T : notnull;
 
 public record GossipUpdate(string MemberId, string Key, Any Value, long SequenceNumber);
 
@@ -324,6 +324,7 @@ public class Gossiper
     }
 
     public class ConsensusCheckBuilder<T> : IConsensusCheckDefinition<T>
+        where T : notnull
     {
         private readonly Lazy<ConsensusCheck<T>> _check;
         private readonly ImmutableList<(string, Func<Any, T?>)> _getConsensusValues;
@@ -445,7 +446,8 @@ public class Gossiper
     }
 
     public IConsensusHandle<TV> RegisterConsensusCheck<T, TV>(string key, Func<T, TV?> getValue)
-        where T : notnull, IMessage, new() =>
+        where T : notnull, IMessage, new()
+        where TV : notnull =>
         RegisterConsensusCheck(ConsensusCheckBuilder<TV>.Create(key, getValue));
 
     public IConsensusHandle<T> RegisterConsensusCheck<T>(IConsensusCheckDefinition<T> consensusDefinition)

--- a/src/Proto.Cluster/Partition/Extensions.cs
+++ b/src/Proto.Cluster/Partition/Extensions.cs
@@ -30,7 +30,7 @@ internal static class Extensions
         this Gossiper gossip, Gossiper.ConsensusCheckBuilder<T> check,
         TimeSpan maxWait,
         CancellationToken cancellationToken
-    )
+    ) where T : notnull
     {
         using var consensusCheck = gossip.RegisterConsensusCheck(check);
 


### PR DESCRIPTION
## Summary
- enforce non-null constraints for cluster consensus checks and delegates
- allow consensus handle default values without nullable warnings
- require non-null types when waiting for gossip consensus

## Testing
- `dotnet build src/Proto.Cluster/Proto.Cluster.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689329865ec48328bda47aa6cfa9dd6b