### PR TITLE
Use snapshot flag in persistence recovery

### DIFF
--- a/src/Proto.Persistence/Persistence.cs
+++ b/src/Proto.Persistence/Persistence.cs
@@ -45,7 +45,7 @@ public class Persistence
     /// </summary>
     public long Index { get; private set; } = -1;
 
-    private bool UsingSnapshotting => _applySnapshot is not null; //TODO: why not used?
+    private bool UsingSnapshotting => _applySnapshot is not null;
     private bool UsingEventSourcing => _applyEvent is not null;
 
     /// <summary>
@@ -218,10 +218,10 @@ public class Persistence
     {
         var (snapshot, lastSnapshotIndex) = await _snapshotStore.GetSnapshotAsync(_actorId).ConfigureAwait(false);
 
-        if (snapshot is not null && _applySnapshot is not null)
+        if (snapshot is not null && UsingSnapshotting)
         {
             Index = lastSnapshotIndex;
-            _applySnapshot(new RecoverSnapshot(snapshot, lastSnapshotIndex));
+            _applySnapshot!(new RecoverSnapshot(snapshot, lastSnapshotIndex));
         }
 
         var fromEventIndex = Index + 1;


### PR DESCRIPTION
## Summary
- use `UsingSnapshotting` flag during state recovery
- remove stale TODO comment

## Testing
- `dotnet test ProtoActor.sln` *(fails: Proto.Analyzers.Tests.Diagnostics.TaskMessageAnalyzerTests.ShouldNotFindAnyProblems, Proto.Persistence.Tests.ExamplePersistentActorTests.*)*

------
https://chatgpt.com/codex/tasks/task_e_68932fe0e200832884c08b265aa8a3e8