### PR TITLE
Memoize Rendezvous member filtering

### DIFF
--- a/src/Proto.Cluster/Partition/Rendezvous.cs
+++ b/src/Proto.Cluster/Partition/Rendezvous.cs
@@ -17,6 +17,7 @@ namespace Proto.Cluster.Partition;
 public class Rendezvous
 {
     private MemberData[] _members = Array.Empty<MemberData>();
+    private Dictionary<string, MemberData[]> _membersByKind = new();
 
     public string GetOwnerMemberByIdentity(string identity)
     {
@@ -51,11 +52,19 @@ public class Rendezvous
     }
 
     // ReSharper disable once ParameterTypeCanBeEnumerable.Global
-    public void UpdateMembers(IEnumerable<Member> members) =>
+    public void UpdateMembers(IEnumerable<Member> members)
+    {
         _members = members
             .OrderBy(m => m.Address)
             .Select(x => new MemberData(x))
             .ToArray();
+
+        // cache members by kind to avoid repeated filtering at lookup time
+        _membersByKind = _members
+            .SelectMany(m => m.Info.Kinds.Select(k => (Kind: k, Member: m)))
+            .GroupBy(x => x.Kind)
+            .ToDictionary(g => g.Key, g => g.Select(x => x.Member).ToArray());
+    }
 
     private static uint RdvHash(byte[] node, byte[] key)
     {
@@ -83,8 +92,10 @@ public class Rendezvous
 
     public string GetOwnerMemberByIdentity(ClusterIdentity ci)
     {
-        //TODO: memoize
-        var members = _members.Where(m => m.Info.Kinds.Contains(ci.Kind));
+        if (!_membersByKind.TryGetValue(ci.Kind, out var members))
+        {
+            return "";
+        }
 
         var keyBytes = Encoding.UTF8.GetBytes(ci.Identity);
 


### PR DESCRIPTION
## Summary
- cache members by kind in Rendezvous to avoid repeated filtering

## Testing
- `dotnet format src/Proto.Cluster/Partition/Rendezvous.cs` *(fails: The file 'Rendezvous.cs' does not appear to be a valid project or solution file.)*
- `dotnet test ProtoActor.sln` *(fails: several tests failed, then build canceled)*


------
https://chatgpt.com/codex/tasks/task_e_6893329815e48328b399713900fb15bd