### PR TITLE
Use configurable activation timeout

### DIFF
--- a/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
@@ -74,9 +74,9 @@ internal class PartitionPlacementActor : IActor, IDisposable
 
         var cancellationToken = msg.TopologyValidityToken!.Value;
 
-        // TODO: Configurable timeout
-        var activationsCompleted =
-            _cluster.Gossip.WaitUntilInFlightActivationsAreCompleted(TimeSpan.FromSeconds(10), cancellationToken);
+        // Wait for all in-flight activations using the configured timeout
+        var activationsCompleted = _cluster.Gossip
+            .WaitUntilInFlightActivationsAreCompleted(_config.RebalanceActivationsCompletionTimeout, cancellationToken);
 
         // Waits until all members agree on a cluster topology and have no more in-flight activation requests
         context.ReenterAfter(activationsCompleted, async _ =>


### PR DESCRIPTION
## Summary
- use `PartitionConfig.RebalanceActivationsCompletionTimeout` when waiting for in-flight activations in `PartitionPlacementActor`

## Testing
- `dotnet test ProtoActor.sln --no-restore` *(fails: MongoDB collection insert requires Mongo server; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_689357372b748328b7750782700b44bd