### PR TITLE
Expand typed logging across core libraries

### DIFF
--- a/src/Proto.Actor/Utils/TaskFactory.cs
+++ b/src/Proto.Actor/Utils/TaskFactory.cs
@@ -41,7 +41,7 @@ public static class SafeTask
         catch (Exception x)
         {
             x.CheckFailFast();
-            Logger.LogError(x, "Unhandled exception in async job {Job}", name);
+            Logger.UnhandledExceptionInAsyncJob(x, name);
         }
     }
 }

--- a/src/Proto.Actor/Utils/TaskFactoryLogMessages.cs
+++ b/src/Proto.Actor/Utils/TaskFactoryLogMessages.cs
@@ -1,0 +1,11 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Proto;
+
+internal static partial class TaskFactoryLogMessages
+{
+    [LoggerMessage(EventId = 0, Level = LogLevel.Error, Message = "Unhandled exception in async job {Job}")]
+    internal static partial void UnhandledExceptionInAsyncJob(this ILogger logger, Exception exception, string job);
+}
+

--- a/src/Proto.Cluster/Member/MemberList.cs
+++ b/src/Proto.Cluster/Member/MemberList.cs
@@ -107,7 +107,7 @@ public record MemberList
                 //only log if the member is known to us
                 if (TryGetMember(b.MemberId, out _))
                 {
-                    Logger.LogInformation("Blocking member {MemberId} due to {Reason}", b.MemberId, b.Reason);
+                    Logger.BlockingMemberDueToReason(b.MemberId, b.Reason);
                 }
 
                 UpdateClusterTopology(_activeMembers.Members);
@@ -149,7 +149,7 @@ public record MemberList
             return memberStrategy.GetActivator(requestSourceAddress);
         }
 
-        Logger.LogInformation("MemberList did not find any activator for kind '{Kind}'", kind);
+        Logger.DidNotFindActivatorForKind(kind);
 
         return null;
     }
@@ -229,12 +229,12 @@ public record MemberList
 
             if (topology.Joined.Any())
             {
-                Logger.LogInformation("[MemberList] Cluster members joined {MembersJoined}", topology.Joined);
+                Logger.ClusterMembersJoined(topology.Joined);
             }
 
             if (topology.Left.Any())
             {
-                Logger.LogInformation("[MemberList] Cluster members left {MembersLeft}", topology.Left);
+                Logger.ClusterMembersLeft(topology.Left);
             }
 
             BroadcastTopologyChanges(topology);
@@ -320,7 +320,7 @@ public record MemberList
             var youngest = dup.OrderByDescending(m => m.Age).First();
             var rest = dup.Where(m => m.Id != youngest.Id).Select(m => m.Id).ToArray();
 
-            Logger.LogWarning("Duplicate address {Address} found, removing {Rest}", dup.Key, rest);
+            Logger.DuplicateAddressFound(dup.Key, rest);
             activeMembers = activeMembers.Except(rest);
         }
 
@@ -335,7 +335,7 @@ public record MemberList
             return;
         }
 
-        Logger.LogCritical("I have been blocked, exiting {Id}", MemberId);
+        Logger.BlockedExiting(MemberId);
         _ = _cluster.ShutdownAsync(reason: "Blocked by MemberList");
     }
 

--- a/src/Proto.Cluster/Member/MemberListLogMessages.cs
+++ b/src/Proto.Cluster/Member/MemberListLogMessages.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.Logging;
+
+namespace Proto.Cluster;
+
+internal static partial class MemberListLogMessages
+{
+    [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Blocking member {MemberId} due to {Reason}")]
+    internal static partial void BlockingMemberDueToReason(this ILogger logger, string memberId, string reason);
+
+    [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "MemberList did not find any activator for kind '{Kind}'")]
+    internal static partial void DidNotFindActivatorForKind(this ILogger logger, string kind);
+
+    [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "[MemberList] Cluster members joined {MembersJoined}")]
+    internal static partial void ClusterMembersJoined(this ILogger logger, object? membersJoined);
+
+    [LoggerMessage(EventId = 3, Level = LogLevel.Information, Message = "[MemberList] Cluster members left {MembersLeft}")]
+    internal static partial void ClusterMembersLeft(this ILogger logger, object? membersLeft);
+
+    [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "Duplicate address {Address} found, removing {Rest}")]
+    internal static partial void DuplicateAddressFound(this ILogger logger, string address, object? rest);
+
+    [LoggerMessage(EventId = 5, Level = LogLevel.Critical, Message = "I have been blocked, exiting {Id}")]
+    internal static partial void BlockedExiting(this ILogger logger, string id);
+}
+

--- a/src/Proto.Remote/Endpoints/EndpointManager.cs
+++ b/src/Proto.Remote/Endpoints/EndpointManager.cs
@@ -61,7 +61,7 @@ public sealed class EndpointManager : IDiagnosticsProvider
                 return;
             }
 
-            Logger.LogDebug("[{SystemAddress}] Stopping", _system.Address);
+            Logger.Stopping(_system.Address);
 
             _system.EventStream.Unsubscribe(_endpointTerminatedEvnSub);
 
@@ -84,16 +84,12 @@ public sealed class EndpointManager : IDiagnosticsProvider
 
         StopActivator();
 
-        Logger.LogDebug("[{SystemAddress}] Stopped", _system.Address);
+        Logger.Stopped(_system.Address);
     }
 
     private async Task OnEndpointTerminated(EndpointTerminatedEvent evt)
     {
-        if (Logger.IsEnabled(LogLevel.Debug))
-        {
-            Logger.LogDebug("[{SystemAddress}] Endpoint {Address} terminating", _system.Address,
-                evt.Address ?? evt.ActorSystemId);
-        }
+        Logger.EndpointTerminating(_system.Address, evt.Address ?? evt.ActorSystemId);
 
         Action? unblock = null;
         try
@@ -124,8 +120,7 @@ public sealed class EndpointManager : IDiagnosticsProvider
                 // the address will always be blocked while we dispose, at a minimum
                 await endpoint.DisposeAsync().ConfigureAwait(false);
 
-                Logger.LogInformation("[{SystemAddress}] Endpoint {Address} terminated", _system.Address,
-                    evt.Address ?? evt.ActorSystemId);
+                Logger.EndpointTerminated(_system.Address, evt.Address ?? evt.ActorSystemId);
 
                 if (evt.ShouldBlock && _remoteConfig.WaitAfterEndpointTerminationTimeSpan.HasValue)
                 {
@@ -135,16 +130,14 @@ public sealed class EndpointManager : IDiagnosticsProvider
             }
             else
             {
-                Logger.LogDebug("[{SystemAddress}] Endpoint {Address} already removed.", _system.Address,
-                    evt.Address ?? evt.ActorSystemId);
+                Logger.EndpointAlreadyRemoved(_system.Address, evt.Address ?? evt.ActorSystemId);
             }
         }
         catch (Exception ex)
         {
             // since these async EventStream subscription handlers are fire and forget, we need to
             // log if something goes wrong, or we'll never know
-            Logger.LogError(ex, "[{SystemAddress}] Error during endpoint {Address} termination", _system.Address,
-                evt.Address ?? evt.ActorSystemId);
+            Logger.ErrorDuringEndpointTermination(ex, _system.Address, evt.Address ?? evt.ActorSystemId);
         }
         finally
         {
@@ -158,7 +151,7 @@ public sealed class EndpointManager : IDiagnosticsProvider
     {
         if (address is null)
         {
-            Logger.LogError("[{SystemAddress}] Tried to get endpoint for null address", _system.Address);
+            Logger.TriedGetEndpointForNullAddress(_system.Address);
 
             return _blockedEndpoint;
         }

--- a/src/Proto.Remote/Endpoints/EndpointManagerLogMessages.cs
+++ b/src/Proto.Remote/Endpoints/EndpointManagerLogMessages.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Proto.Remote;
+
+internal static partial class EndpointManagerLogMessages
+{
+    [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = "[{SystemAddress}] Stopping")]
+    internal static partial void Stopping(this ILogger logger, string systemAddress);
+
+    [LoggerMessage(EventId = 1, Level = LogLevel.Debug, Message = "[{SystemAddress}] Stopped")]
+    internal static partial void Stopped(this ILogger logger, string systemAddress);
+
+    [LoggerMessage(EventId = 2, Level = LogLevel.Debug, Message = "[{SystemAddress}] Endpoint {Address} terminating")]
+    internal static partial void EndpointTerminating(this ILogger logger, string systemAddress, string? address);
+
+    [LoggerMessage(EventId = 3, Level = LogLevel.Information, Message = "[{SystemAddress}] Endpoint {Address} terminated")]
+    internal static partial void EndpointTerminated(this ILogger logger, string systemAddress, string? address);
+
+    [LoggerMessage(EventId = 4, Level = LogLevel.Debug, Message = "[{SystemAddress}] Endpoint {Address} already removed.")]
+    internal static partial void EndpointAlreadyRemoved(this ILogger logger, string systemAddress, string? address);
+
+    [LoggerMessage(EventId = 5, Level = LogLevel.Error, Message = "[{SystemAddress}] Error during endpoint {Address} termination")]
+    internal static partial void ErrorDuringEndpointTermination(this ILogger logger, Exception ex, string systemAddress, string? address);
+
+    [LoggerMessage(EventId = 6, Level = LogLevel.Error, Message = "[{SystemAddress}] Tried to get endpoint for null address")]
+    internal static partial void TriedGetEndpointForNullAddress(this ILogger logger, string systemAddress);
+}
+


### PR DESCRIPTION
## Summary
- use source-generated `LoggerMessage` patterns for `SafeTask`
- replace string-based logs in `EndpointManager` with typed log methods
- add typed logging helpers to `MemberList` for common events

## Testing
- `dotnet build ProtoActor.sln`
- `dotnet test ProtoActor.sln` *(fails: RequestRepeatedlyCanBeCancelled, TaskMessageAnalyzerTests.ShouldFindTaskAsMessageWhenSending, ExamplePersistentActorTests...)*

------
https://chatgpt.com/codex/tasks/task_e_689365cb7c948328a974137c6183e8f7