### PR TITLE
Use structured logging for remaining raw messages

### DIFF
--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -149,7 +149,8 @@ public class Gossiper
 
         if (_pid == null)
         {
-            Logger.LogError("Gossiper is not started, cannot set state");
+            // Use generated logging for attempts to set state before startup
+            Logger.GossiperNotStartedCannotSetState(key);
             return;
         }
 

--- a/src/Proto.Cluster/Gossip/GossiperLogMessages.cs
+++ b/src/Proto.Cluster/Gossip/GossiperLogMessages.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.Logging;
+
+namespace Proto.Cluster.Gossip;
+
+internal static partial class GossiperLogMessages
+{
+    [LoggerMessage(EventId = 0, Level = LogLevel.Error, Message = "Gossiper is not started, cannot set state for key {Key}")]
+    internal static partial void GossiperNotStartedCannotSetState(this ILogger logger, string key);
+}
+

--- a/src/Proto.Remote/Endpoints/MessageBatchFactory.cs
+++ b/src/Proto.Remote/Endpoints/MessageBatchFactory.cs
@@ -69,7 +69,8 @@ internal static class MessageBatchFactory
 
             if (message is null)
             {
-                Logger.LogError("Null message passed to EndpointActor, ignoring message");
+                // Use generated structured logging to note the null message and target
+                Logger.EndpointActorReceivedNullMessage(target);
                 continue;
             }
 

--- a/src/Proto.Remote/Endpoints/MessageBatchFactoryLogMessages.cs
+++ b/src/Proto.Remote/Endpoints/MessageBatchFactoryLogMessages.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Logging;
+using Proto;
+
+namespace Proto.Remote;
+
+internal static partial class MessageBatchFactoryLogMessages
+{
+    [LoggerMessage(EventId = 0, Level = LogLevel.Error, Message = "Null message passed to EndpointActor for target {Target}, ignoring message")]
+    internal static partial void EndpointActorReceivedNullMessage(this ILogger logger, PID target);
+}
+


### PR DESCRIPTION
## Summary
- replace raw log strings in MessageBatchFactory and Gossiper with structured logging templates
- generate strongly typed logging extensions for null message and uninitialized gossip state scenarios

## Testing
- `dotnet test ProtoActor.sln` *(fails: many tests failing due to missing MongoDB/Redis infrastructure)*

------
https://chatgpt.com/codex/tasks/task_e_689385eaca888328bcfada820b5b644b