### PR TITLE
Add timer extension tests for scheduler

### DIFF
--- a/tests/Proto.Actor.Tests/TimerExtensionsTests.cs
+++ b/tests/Proto.Actor.Tests/TimerExtensionsTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Threading.Tasks;
+using Proto.Timers;
+using Xunit;
+#if NET8_0_OR_GREATER
+using Microsoft.Extensions.Time.Testing;
+#endif
+
+namespace Proto.Tests;
+
+public class TimerExtensionsTests
+{
+    [Fact]
+    public async Task SchedulerSchedulesMessageAfterDelay()
+    {
+        await using var system = new ActorSystem();
+        var context = system.Root;
+        var tcs = new TaskCompletionSource();
+
+        var pid = context.Spawn(Props.FromFunc(ctx =>
+        {
+            if (ctx.Message is "Wakeup")
+            {
+                tcs.SetResult();
+            }
+
+            return Task.CompletedTask;
+        }));
+
+        var scheduler = context.Scheduler();
+
+        scheduler.SendOnce(TimeSpan.FromMilliseconds(200), pid, "Wakeup");
+
+        // ensure message isn't delivered immediately
+        await Task.Delay(100);
+        Assert.False(tcs.Task.IsCompleted);
+
+        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+#if NET8_0_OR_GREATER
+    [Fact]
+    public async Task SchedulerWithTimeProviderSchedulesMessageAfterDelay()
+    {
+        await using var system = new ActorSystem();
+        var context = system.Root;
+        var tcs = new TaskCompletionSource();
+
+        var pid = context.Spawn(Props.FromFunc(ctx =>
+        {
+            if (ctx.Message is "Wakeup")
+            {
+                tcs.SetResult();
+            }
+
+            return Task.CompletedTask;
+        }));
+
+        var timeProvider = new FakeTimeProvider();
+        var scheduler = context.Scheduler(timeProvider);
+
+        scheduler.SendOnce(TimeSpan.FromSeconds(10), pid, "Wakeup");
+
+        // Give the inner Task.Delay a head start
+        await Task.Delay(50);
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+
+        await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(10));
+    }
+#endif
+}


### PR DESCRIPTION
## Summary
- add tests verifying Scheduler extension schedules messages after delay
- cover Scheduler extension with FakeTimeProvider on .NET 8

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6893b0ddee34832883b4bcfd5720f33b