### PR TITLE
Remove obsolete .NET version directives

### DIFF
--- a/benchmarks/ClusterBenchmark/Program.cs
+++ b/benchmarks/ClusterBenchmark/Program.cs
@@ -31,7 +31,6 @@ public static class Program
 
     public static async Task Main(string[] args)
     {
-        //AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
         //    ThreadPool.SetMinThreads(500, 500);
         Request = new HelloRequest();
         Configuration.SetupLogger(LogLevel.Error);

--- a/benchmarks/GossipBenchmark/Node1/Program.cs
+++ b/benchmarks/GossipBenchmark/Node1/Program.cs
@@ -30,8 +30,6 @@ class Program
         );
         var logger = Log.CreateLogger("benchmark");
 
-        // Required to allow unencrypted GrpcNet connections
-        AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
         var system = new ActorSystem(
             new ActorSystemConfig()
                 .WithDeveloperSupervisionLogging(true)

--- a/benchmarks/GossipBenchmark/Node2/Program.cs
+++ b/benchmarks/GossipBenchmark/Node2/Program.cs
@@ -49,8 +49,6 @@ class Program
 
         var logger = Log.CreateLogger("benchmark");
 
-        // Required to allow unencrypted GrpcNet connections
-        AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
         var system = new ActorSystem(
             new ActorSystemConfig()
                 .WithDeveloperSupervisionLogging(true)

--- a/benchmarks/RemoteBenchmark/Node1/Program.cs
+++ b/benchmarks/RemoteBenchmark/Node1/Program.cs
@@ -33,9 +33,6 @@ class Program
         );
 
         var logger = Log.CreateLogger<Program>();
-#if NETCOREAPP3_1
-        AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-#endif
 
         var serverRemote = 0;
 

--- a/examples/ClusterGrainHelloWorld/Node1/Program.cs
+++ b/examples/ClusterGrainHelloWorld/Node1/Program.cs
@@ -20,9 +20,6 @@ using ProtosReflection = ClusterHelloWorld.Messages.ProtosReflection;
 Log.SetLoggerFactory(
     LoggerFactory.Create(l => l.AddConsole().SetMinimumLevel(LogLevel.Information)));
 
-// Required to allow unencrypted GrpcNet connections
-// AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-
 var system = new ActorSystem()
     .WithRemote(RemoteConfig.BindToLocalhost().WithProtoMessages(ProtosReflection.Descriptor))
     .WithCluster(ClusterConfig

--- a/examples/ClusterGrainHelloWorld/Node2/Program.cs
+++ b/examples/ClusterGrainHelloWorld/Node2/Program.cs
@@ -21,9 +21,6 @@ using ProtosReflection = ClusterHelloWorld.Messages.ProtosReflection;
 Log.SetLoggerFactory(
     LoggerFactory.Create(l => l.AddConsole().SetMinimumLevel(LogLevel.Information)));
 
-// Required to allow unencrypted GrpcNet connections
-// AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-
 var system = new ActorSystem(new ActorSystemConfig().WithDeveloperSupervisionLogging(true))
     .WithRemote(RemoteConfig.BindToLocalhost(8090).WithProtoMessages(ProtosReflection.Descriptor))
     .WithCluster(ClusterConfig

--- a/examples/ClusterK8sGrains/Node1/Program.cs
+++ b/examples/ClusterK8sGrains/Node1/Program.cs
@@ -33,9 +33,6 @@ Log.SetLoggerFactory(
         .AddFilter("Proto.Cluster.Gossip", LogLevel.Information)
         .AddFilter("Proto.Context.ActorContext", LogLevel.Information)));
 
-// Required to allow unencrypted GrpcNet connections
-AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-
 var kubernetesProvider = new KubernetesProvider();
 var advertisedHost = await kubernetesProvider.GetPodFqdn();
 

--- a/examples/ClusterK8sGrains/Node2/Program.cs
+++ b/examples/ClusterK8sGrains/Node2/Program.cs
@@ -34,9 +34,6 @@ Log.SetLoggerFactory(
         .AddFilter("Proto.Cluster.Gossip", LogLevel.Information)
         .AddFilter("Proto.Context.ActorContext", LogLevel.Information)));
 
-// Required to allow unencrypted GrpcNet connections
-AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-
 var kubernetesProvider = new KubernetesProvider();
 var advertisedHost = await kubernetesProvider.GetPodFqdn();
 

--- a/src/Proto.Actor/Timers/Scheduler.cs
+++ b/src/Proto.Actor/Timers/Scheduler.cs
@@ -17,9 +17,7 @@ namespace Proto.Timers;
 public class Scheduler
 {
     private readonly ISenderContext _context;
-#if NET8_0_OR_GREATER
     private readonly TimeProvider _timeProvider;
-#endif
 
     /// <summary>
     ///     Creates a new scheduler.
@@ -28,13 +26,9 @@ public class Scheduler
     public Scheduler(ISenderContext context)
     {
         _context = context;
-
-#if NET8_0_OR_GREATER
         _timeProvider = TimeProvider.System;
-#endif
     }
 
-#if NET8_0_OR_GREATER
     /// <summary>
     ///     Creates a new scheduler.
     /// </summary>
@@ -45,7 +39,6 @@ public class Scheduler
         _context = context;
         _timeProvider = timeProvider;
     }
-#endif
 
     /// <summary>
     ///     Schedules a single message to be sent in the future.
@@ -141,10 +134,6 @@ public class Scheduler
 
     private async Task Delay(TimeSpan delay, CancellationToken token)
     {
-#if NET8_0_OR_GREATER
-    await Task.Delay(delay, _timeProvider, token).ConfigureAwait(false);
-#else
-        await Task.Delay(delay, token).ConfigureAwait(false);
-#endif
+        await Task.Delay(delay, _timeProvider, token).ConfigureAwait(false);
     }
 }

--- a/src/Proto.Actor/Timers/TimerExtensions.cs
+++ b/src/Proto.Actor/Timers/TimerExtensions.cs
@@ -10,8 +10,7 @@ public static class TimerExtensions
     /// <param name="context"></param>
     /// <returns></returns>
     public static Scheduler Scheduler(this ISenderContext context) => new(context);
-    
-#if NET8_0_OR_GREATER
+
     /// <summary>
     ///     Gets a new scheduler that allows to schedule messages in the future
     /// </summary>
@@ -19,5 +18,4 @@ public static class TimerExtensions
     /// <param name="timeProvider">TimeProvider to use for scheduling (FakeTimeProvider can be used for testing)</param>
     /// <returns></returns>
     public static Scheduler Scheduler(this ISenderContext context, TimeProvider timeProvider) => new(context, timeProvider);
-#endif
 }

--- a/tests/Proto.Actor.Tests/SchedulerTests.cs
+++ b/tests/Proto.Actor.Tests/SchedulerTests.cs
@@ -1,4 +1,3 @@
-#if NET8_0_OR_GREATER
 using System;
 using System.Threading.Tasks;
 using System.Threading;
@@ -178,4 +177,4 @@ public class SchedulerTests
         Assert.False(extraResponse.Task.IsCompleted);
     }
 }
-#endif
+

--- a/tests/Proto.Actor.Tests/TimerExtensionsTests.cs
+++ b/tests/Proto.Actor.Tests/TimerExtensionsTests.cs
@@ -2,9 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Proto.Timers;
 using Xunit;
-#if NET8_0_OR_GREATER
 using Microsoft.Extensions.Time.Testing;
-#endif
 
 namespace Proto.Tests;
 
@@ -38,7 +36,6 @@ public class TimerExtensionsTests
         await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
-#if NET8_0_OR_GREATER
     [Fact]
     public async Task SchedulerWithTimeProviderSchedulesMessageAfterDelay()
     {
@@ -67,5 +64,5 @@ public class TimerExtensionsTests
 
         await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(10));
     }
-#endif
 }
+

--- a/tests/Proto.Cluster.MongoIdentity.Tests/MongoIdentityTests.cs
+++ b/tests/Proto.Cluster.MongoIdentity.Tests/MongoIdentityTests.cs
@@ -18,9 +18,6 @@ public class MongoIdentityClusterFixture : BaseInMemoryClusterFixture
     public MongoIdentityClusterFixture() : base(3,
         config => config with { ActorActivationTimeout = TimeSpan.FromSeconds(10) })
     {
-#if NETCOREAPP3_1
-            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-#endif
     }
 
     protected override IIdentityLookup GetIdentityLookup(string clusterName)
@@ -96,3 +93,4 @@ public class MongoStorageTests : IdentityStorageTests
     private static IIdentityStorage Init(string clusterName) => new MongoIdentityStorage(clusterName,
         MongoFixture.Database.GetCollection<PidLookupEntity>("pids"));
 }
+

--- a/tests/Proto.Cluster.RedisIdentity.Tests/RedisIdentityTests.cs
+++ b/tests/Proto.Cluster.RedisIdentity.Tests/RedisIdentityTests.cs
@@ -19,9 +19,6 @@ public class RedisIdentityClusterFixture : BaseInMemoryClusterFixture
 {
     public RedisIdentityClusterFixture() : base(3)
     {
-#if NETCOREAPP3_1
-            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-#endif
     }
 
     protected override IIdentityLookup GetIdentityLookup(string clusterName)
@@ -95,3 +92,4 @@ public class RedisStorageTests : IdentityStorageTests
             TimeSpan.FromMilliseconds(1500)
         );
 }
+

--- a/tests/Proto.Remote.Tests/RemoteFixture.cs
+++ b/tests/Proto.Remote.Tests/RemoteFixture.cs
@@ -72,9 +72,6 @@ public abstract class RemoteFixture : IRemoteFixture
 
     protected static (IHost, HostedGrpcNetRemote) GetHostedGrpcNetRemote(RemoteConfig config)
     {
-#if NETCOREAPP3_1
-            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-#endif
         var hostBuilder = Host.CreateDefaultBuilder(Array.Empty<string>())
             .ConfigureServices(services =>
                 {
@@ -120,17 +117,12 @@ public abstract class RemoteFixture : IRemoteFixture
 
     protected static GrpcNetRemote GetGrpcNetRemote(RemoteConfig config)
     {
-#if NETCOREAPP3_1
-            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-#endif
         return new GrpcNetRemote(new ActorSystem(), config);
     }
 
     protected static GrpcNetClientRemote GetGrpcNetClientRemote(RemoteConfig config)
     {
-#if NETCOREAPP3_1
-            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-#endif
         return new GrpcNetClientRemote(new ActorSystem(), config);
     }
 }
+


### PR DESCRIPTION
## Summary
- remove `NET8_0_OR_GREATER` and `NETCOREAPP3_1` preprocessor directives
- always use `TimeProvider`-based scheduling
- drop conditional HTTP/2 switches in tests, benchmarks, and samples, removing outdated `AppContext.SetSwitch` calls

## Testing
- `dotnet build ProtoActor.sln`
- `dotnet test ProtoActor.sln` *(fails: Proto.Analyzers, Proto.Cluster.MongoIdentity, Proto.Cluster.RedisIdentity, Proto.Persistence)*

------
https://chatgpt.com/codex/tasks/task_e_6893b67420b083289dca5d841f85f17b