### PR TITLE
Use asynchronous continuations for task completion

### DIFF
--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -232,7 +232,7 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
             return;
         }
 
-        var tcs = new TaskCompletionSource<bool>();
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var registration = token.Register(() => tcs.SetResult(true));
 
         // Ensures registration is disposed with the actor

--- a/src/Proto.Actor/Diagnostics/DiagnosticTools.cs
+++ b/src/Proto.Actor/Diagnostics/DiagnosticTools.cs
@@ -21,7 +21,7 @@ public static class DiagnosticTools
     /// <returns></returns>
     public static async Task<string> GetDiagnosticsString(ActorSystem system, PID pid)
     {
-        var tcs = new TaskCompletionSource<string>();
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         var request = new ProcessDiagnosticsRequest(tcs);
         pid.SendSystemMessage(system, request);
         var res = await tcs.Task.ConfigureAwait(false);

--- a/src/Proto.Cluster.Kubernetes/KubernetesClusterMonitor.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesClusterMonitor.cs
@@ -107,7 +107,7 @@ internal class KubernetesClusterMonitor : IActor
 
     private Task Watch()
     {
-        var tcs = new TaskCompletionSource();
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         _watcherTask = GetListTask(_clusterName, true, _config.WatchTimeoutSeconds);
         _watcher = _watcherTask.Watch<V1Pod, V1PodList>(Watch, Error, Closed);

--- a/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
+++ b/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
@@ -230,7 +230,7 @@ internal class IdentityStoragePlacementActor : IActor
             }
 
             //Do not expose the PID externally before we have persisted the activation
-            var completionCallback = new TaskCompletionSource<PID?>();
+            var completionCallback = new TaskCompletionSource<PID?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             context.ReenterAfter(Task.Run(() => PersistActivation(context, msg, pid)), persistResult =>
                 {

--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -252,7 +252,7 @@ internal class PartitionIdentityActor : IActor
         SetReadyToRebalanceIfNoMoreWaitingSpawns();
         DiscardInvalidatedActivations();
 
-        _rebalanceTcs ??= new TaskCompletionSource<ulong>();
+        _rebalanceTcs ??= new TaskCompletionSource<ulong>(TaskCreationOptions.RunContinuationsAsynchronously);
         _currentHandover = new HandoverSink(msg, TakeOverIdentities(context));
         _rebalanceTimer = Stopwatch.StartNew();
 
@@ -616,7 +616,7 @@ internal class PartitionIdentityActor : IActor
         // Not in progress, spawn actor
 
         var spawnResponse = SpawnRemoteActor(context, msg, activatorAddress);
-        var setResponse = new TaskCompletionSource<ActivationResponse>();
+        var setResponse = new TaskCompletionSource<ActivationResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
         _spawns.Add(msg.ClusterIdentity, (setResponse, activatorAddress));
 
         if (Logger.IsEnabled(LogLevel.Debug))

--- a/src/Proto.Cluster/PubSub/BatchingProducer.cs
+++ b/src/Proto.Cluster/PubSub/BatchingProducer.cs
@@ -309,7 +309,7 @@ public class BatchingProducer : IAsyncDisposable
     /// <exception cref="ProducerQueueFullException">Thrown when producer max queue size is reached.</exception>
     public Task ProduceAsync(object message, CancellationToken ct = default)
     {
-        var tcs = new TaskCompletionSource<bool>();
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         if (!_publisherChannel.Writer.TryWrite(new ProduceMessage(message, tcs, ct)))
         {


### PR DESCRIPTION
## Summary
- ensure TaskCompletionSource continuations run asynchronously across cluster and actor components

## Testing
- `dotnet build ProtoActor.sln`
- `dotnet test ProtoActor.sln -c Debug --no-build` *(fails: Docker not running; Redis/Mongo unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6894609166ec8328bcd38bf8cb5b8e0b