### PR TITLE
Use Thread.Yield for non-blocking MPMCQueue backoff

### DIFF
--- a/src/Proto.Actor/Mailbox/MPMCQueue.cs
+++ b/src/Proto.Actor/Mailbox/MPMCQueue.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Proto.Mailbox;
 
@@ -81,8 +80,7 @@ public class MPMCQueue
                 break;
             }
 
-            Task.Delay(1)
-                .Wait(); // Could be Task.Delay(1) or Thread.SpinWait() if the assembly is not portable lib.
+            Thread.Yield(); // non-blocking backoff under contention
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid blocking in MPMCQueue by replacing Task.Delay(1).Wait with Thread.Yield

## Testing
- `dotnet test tests/Proto.Actor.Tests --nologo`

------
https://chatgpt.com/codex/tasks/task_e_68946755542883288e01466f44ef6bc2