### PR TITLE
Remove explicit System.ValueTuple references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -90,7 +90,6 @@
     <PackageVersion Include="System.Interactive.Async" Version="6.0.1" />
     <PackageVersion Include="System.Text.Json" Version="9.0.3" />
     <PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
-    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Testcontainers" Version="3.10.0" />
     <PackageVersion Include="Testcontainers.CouchDb" Version="3.10.0" />
     <PackageVersion Include="Testcontainers.DynamoDb" Version="3.10.0" />

--- a/benchmarks/RemoteBenchmark/Messages/Messages.csproj
+++ b/benchmarks/RemoteBenchmark/Messages/Messages.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" />
-    <PackageReference Include="System.ValueTuple" />
     <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>

--- a/examples/Persistence/Messages/Messages.csproj
+++ b/examples/Persistence/Messages/Messages.csproj
@@ -4,7 +4,6 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Google.Protobuf" />
-        <PackageReference Include="System.ValueTuple" />
         <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>

--- a/examples/RemoteActivate/Messages/Messages.csproj
+++ b/examples/RemoteActivate/Messages/Messages.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" />
-    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />

--- a/examples/RemoteActivate/Node2/Node2.csproj
+++ b/examples/RemoteActivate/Node2/Node2.csproj
@@ -8,7 +8,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" />
-    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Proto.Actor\Proto.Actor.csproj" />


### PR DESCRIPTION
## Summary
- remove central `System.ValueTuple` package reference and clean up dependent projects

## Testing
- `dotnet restore ProtoActor.sln`
- `dotnet build ProtoActor.sln`


------
https://chatgpt.com/codex/tasks/task_e_6894678560848328aa5318883a620673