### PR TITLE
Use shared or seeded Random

### DIFF
--- a/benchmarks/AutoClusterBenchmark/Program.cs
+++ b/benchmarks/AutoClusterBenchmark/Program.cs
@@ -133,7 +133,7 @@ public static class Program
 
         _ = SafeTask.Run(async () =>
         {
-            var rnd = new Random();
+            var rnd = Random.Shared;
             var semaphore = new AsyncSemaphore(5);
 
             while (!cluster.System.Shutdown.IsCancellationRequested)

--- a/benchmarks/ClusterBenchmark/Program.cs
+++ b/benchmarks/ClusterBenchmark/Program.cs
@@ -360,7 +360,7 @@ public static class Program
         _ = SafeTask.Run(async () =>
         {
             var cluster = await Configuration.SpawnClient();
-            var rnd = new Random();
+            var rnd = Random.Shared;
 
             while (true)
             {
@@ -395,7 +395,7 @@ public static class Program
         _ = SafeTask.Run(async () =>
         {
             var cluster = await Configuration.SpawnClient();
-            var rnd = new Random();
+            var rnd = Random.Shared;
 
             while (true)
             {

--- a/benchmarks/HostedService/ProtoHost.cs
+++ b/benchmarks/HostedService/ProtoHost.cs
@@ -43,7 +43,7 @@ public class ProtoHost : IHostedService
     {
         await Task.Yield();
 
-        var rnd = new Random();
+        var rnd = Random.Shared;
 
         while (!_appLifetime.ApplicationStopping.IsCancellationRequested)
         {

--- a/examples/ActorMetrics/Controllers/WeatherForecastController.cs
+++ b/examples/ActorMetrics/Controllers/WeatherForecastController.cs
@@ -25,7 +25,7 @@ public class WeatherForecastController : ControllerBase
     [HttpGet]
     public IEnumerable<WeatherForecast> Get()
     {
-        var rng = new Random();
+        var rng = Random.Shared;
 
         return Enumerable.Range(1, 5)
             .Select(index => new WeatherForecast

--- a/examples/ActorMetrics/RunDummyCluster.cs
+++ b/examples/ActorMetrics/RunDummyCluster.cs
@@ -85,7 +85,7 @@ public static class RunDummyCluster
 
         _ = SafeTask.Run(async () =>
             {
-                var r = new Random();
+                var r = Random.Shared;
 
                 await Task.Delay(5000);
 

--- a/examples/ClusterPubSub/Program.cs
+++ b/examples/ClusterPubSub/Program.cs
@@ -83,7 +83,7 @@ public class User : UserActorBase
     {
         _schedule = Context.Scheduler()
             .SendRepeatedly(
-                TimeSpan.FromSeconds(new Random().Next(2, 5)),
+                TimeSpan.FromSeconds(Random.Shared.Next(2, 5)),
                 Context.Self,
                 new Tick());
 
@@ -102,7 +102,7 @@ public class User : UserActorBase
         switch (Context.Message)
         {
             case Tick:
-                var message = _messages[new Random().Next(0, _messages.Length)];
+                var message = _messages[Random.Shared.Next(0, _messages.Length)];
                 Console.WriteLine($"{Context.ClusterIdentity()!.Identity} publishes '{message}'");
 
                 _ = Context.Cluster()

--- a/examples/KafkaVirtualActorIngress/Program.cs
+++ b/examples/KafkaVirtualActorIngress/Program.cs
@@ -73,7 +73,7 @@ internal class Program
     {
         //Fake Kafka consumer message generator
         var messages = new List<MyEnvelope>();
-        var rnd = new Random();
+        var rnd = Random.Shared;
 
         for (var i = 0; i < 50; i++)
         {

--- a/examples/Patterns/Saga/Program.cs
+++ b/examples/Patterns/Saga/Program.cs
@@ -16,7 +16,6 @@ internal class Program
     public static void Main(string[] args)
     {
         Console.WriteLine("Starting");
-        var random = new Random();
         var numberOfTransfers = 5;
         var intervalBetweenConsoleUpdates = 1;
         var uptime = 99.99;

--- a/examples/Patterns/Saga/README.md
+++ b/examples/Patterns/Saga/README.md
@@ -741,7 +741,7 @@ internal class Program
     public static void Main(string[] args)
     {
         Console.WriteLine("Starting");
-        var random = new Random();
+        var random = Random.Shared;
         var numberOfTransfers = 1000;
         var uptime = 99.99;
         var retryAttempts = 3;
@@ -781,7 +781,7 @@ scatter-gather pattern to spawn `TransferProcess` actors then reports when they 
     {
         //...
         case Started _:
-            var random = new Random();
+            var random = Random.Shared;
             _inMemoryProvider = new InMemoryProvider();
 
             for (int i = 1; i <= _numberOfIterations; i++)

--- a/examples/Patterns/Saga/Runner.cs
+++ b/examples/Patterns/Saga/Runner.cs
@@ -74,7 +74,7 @@ public class Runner : IActor
 
                 break;
             case Started _:
-                var random = new Random();
+                var random = Random.Shared;
                 _inMemoryProvider = new InMemoryProvider();
 
                 new ForWithProgress(_numberOfIterations, _intervalBetweenConsoleUpdates, true, false).EveryNth(

--- a/examples/Persistence/Persistence/Program.cs
+++ b/examples/Persistence/Persistence/Program.cs
@@ -241,7 +241,7 @@ internal class Program
             const string vowels = "aeiou";
             const string consonants = "bcdfghjklmnpqrstvwxyz";
 
-            var rnd = new Random();
+            var rnd = Random.Shared;
             var name = new StringBuilder();
 
             length = length % 2 == 0 ? length : length + 1;

--- a/src/Proto.Actor/Router/Routers/RandomRouterState.cs
+++ b/src/Proto.Actor/Router/Routers/RandomRouterState.cs
@@ -15,7 +15,8 @@ internal class RandomRouterState : RouterState
 
     public RandomRouterState(ISenderContext senderContext, int? seed)
     {
-        _random = seed.HasValue ? new Random(seed.Value) : new Random();
+        // Use a single random source to avoid identical sequences across router states
+        _random = seed.HasValue ? new Random(seed.Value) : Random.Shared;
         _senderContext = senderContext;
     }
 

--- a/src/Proto.Cluster/Member/LocalAffinityExtensions.cs
+++ b/src/Proto.Cluster/Member/LocalAffinityExtensions.cs
@@ -111,7 +111,8 @@ public static class LocalAffinityExtensions
             return () => true;
         }
 
-        var random = new Random();
+        // Random.Shared ensures thread-safety and avoids reseeding
+        var random = Random.Shared;
 
         return () => random.NextDouble() < relocationFactor;
     }

--- a/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
@@ -56,13 +56,14 @@ public class PartitionIdentityTests
         var stop = new CancellationTokenSource(runtimeSeconds * 1000);
         // ReSharper disable once AccessToDisposedClosure
 
-        foreach (var _ in Enumerable.Range(0, threads))
+        foreach (var i in Enumerable.Range(0, threads))
         {
-            StartBackgroundRequests(fixture, identities, batchSize, stop.Token);
+            // Seed each worker with a different base to ensure deterministic yet distinct sequences
+            StartBackgroundRequests(fixture, identities, batchSize, stop.Token, new Random(i));
         }
 
-        StartKillingRandomVirtualActors(fixture, identities, stop.Token);
-        StartSpawningAndStoppingMembers(fixture, stop.Token);
+        StartKillingRandomVirtualActors(fixture, identities, stop.Token, new Random(threads));
+        StartSpawningAndStoppingMembers(fixture, stop.Token, new Random(threads + 1));
 
         var timer = Stopwatch.StartNew();
         var prev = Interlocked.Read(ref _requests);
@@ -107,11 +108,11 @@ public class PartitionIdentityTests
         IClusterFixture clusterFixture,
         List<string> identities,
         int batchSize,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        Random rnd
     ) =>
         _ = Task.Run(async () =>
             {
-                var rnd = new Random();
                 var identityIndex = rnd.Next(identities.Count);
                 var tasks = new List<Task>();
 
@@ -159,12 +160,11 @@ public class PartitionIdentityTests
     private void StartKillingRandomVirtualActors(
         IClusterFixture clusterFixture,
         List<string> identities,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        Random rnd
     ) =>
         _ = Task.Run(async () =>
             {
-                var rnd = new Random();
-
                 while (!cancellationToken.IsCancellationRequested)
                 {
                     await Task.Delay(rnd.Next(50), cancellationToken);
@@ -189,13 +189,13 @@ public class PartitionIdentityTests
 
     private void StartSpawningAndStoppingMembers(
         IClusterFixture clusterFixture,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        Random rnd
     ) =>
         _ = Task.Run(async () =>
             {
                 const int maxMembers = 10;
                 const int minMembers = 2;
-                var rnd = new Random();
 
                 try
                 {

--- a/tests/Proto.Cluster.Tests/ConcurrencyVerificationActor.cs
+++ b/tests/Proto.Cluster.Tests/ConcurrencyVerificationActor.cs
@@ -82,7 +82,7 @@ public class ConcurrencyVerificationActor : IActor
     private async Task OnStopping(IContext context)
     {
         _state!.RecordStopping(context);
-        await Task.Delay(new Random().Next(50));
+        await Task.Delay(Random.Shared.Next(50));
     }
 
     private async Task OnStarted(IContext context)
@@ -93,7 +93,7 @@ public class ConcurrencyVerificationActor : IActor
         _count = _state.StoredCount;
 
         // Simulate network hop
-        await Task.Delay(new Random().Next(50));
+        await Task.Delay(Random.Shared.Next(50));
     }
 }
 

--- a/tests/Proto.Remote.Tests/RemoteTests.cs
+++ b/tests/Proto.Remote.Tests/RemoteTests.cs
@@ -332,7 +332,8 @@ public abstract class RemoteTests
             return;
         }
 
-        var rnd = new Random();
+        // Seeded for deterministic message payloads
+        var rnd = new Random(0);
         var tcs = new TaskCompletionSource<bool>();
         long responseCount = 0;
 


### PR DESCRIPTION
## Summary
- avoid repeatedly allocating Random by using Random.Shared or a seeded instance
- inject seeded Randoms into concurrency and routing tests for deterministic behavior
- switch relocation logic to thread-safe shared randomness

## Testing
- `dotnet test ProtoActor.sln` *(fails: System.Lazy`1.ViaFactory, Many tests fail requiring external services)*

------
https://chatgpt.com/codex/tasks/task_e_6894678753e48328b73d64a97af7d2b2