### PR TITLE
Avoid blocking Result usage in cluster activation flows

### DIFF
--- a/src/Proto.Cluster/DefaultClusterContext.cs
+++ b/src/Proto.Cluster/DefaultClusterContext.cs
@@ -131,7 +131,8 @@ public class DefaultClusterContext : IClusterContext
 
                     if (task.IsCompleted)
                     {
-                        var untypedResult = MessageEnvelope.UnwrapMessage(task.Result);
+                        var result = await task.ConfigureAwait(false);
+                        var untypedResult = MessageEnvelope.UnwrapMessage(result);
                         
                         if (untypedResult is DeadLetterResponse)
                         {
@@ -158,7 +159,7 @@ public class DefaultClusterContext : IClusterContext
                         
                         if (typeof(T) == typeof(MessageEnvelope))
                         {
-                            return (T)(object)MessageEnvelope.Wrap(task.Result);
+                            return (T)(object)MessageEnvelope.Wrap(result);
                         }
 
                         Logger.LogError("Unexpected message. Was type {Type} but expected {ExpectedType}",

--- a/src/Proto.Cluster/Identity/IdentityActivatorProxy.cs
+++ b/src/Proto.Cluster/Identity/IdentityActivatorProxy.cs
@@ -52,12 +52,15 @@ internal class IdentityActivatorProxy : IActor
         if (context.Sender is not null)
         {
             context.ReenterAfter(target,
-                task =>
+                async task =>
                 {
-                    var pid = task.IsCompletedSuccessfully ? task.Result : null;
-                    Respond(context, pid);
+                    PID? pid = null;
+                    if (task.IsCompletedSuccessfully)
+                    {
+                        pid = await task.ConfigureAwait(false);
+                    }
 
-                    return Task.CompletedTask;
+                    Respond(context, pid);
                 }
             );
         }
@@ -98,9 +101,13 @@ internal class IdentityActivatorProxy : IActor
         }
 
         context.ReenterAfter(GetPid(identity, context.CancellationToken),
-            task =>
+            async task =>
             {
-                var activation = task.IsCompletedSuccessfully ? task.Result : null;
+                PID? activation = null;
+                if (task.IsCompletedSuccessfully)
+                {
+                    activation = await task.ConfigureAwait(false);
+                }
 
                 // Check if retrieved PID is stale. Replace should be called after the original activation has been stopped,
                 // but the identity might not have been purged from IdentityLookup yet.
@@ -118,7 +125,7 @@ internal class IdentityActivatorProxy : IActor
                         context.ReenterAfter(Task.Delay(50 * attempt),
                             () => ReplaceActivation(identity, replacedPid, context, attempt + 1));
 
-                        return Task.CompletedTask;
+                        return;
                     }
 
                     Logger.LogWarning(
@@ -127,8 +134,6 @@ internal class IdentityActivatorProxy : IActor
                 }
 
                 Respond(context, activation);
-
-                return Task.CompletedTask;
             }
         );
 

--- a/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
+++ b/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
@@ -104,14 +104,14 @@ internal class IdentityStoragePlacementActor : IActor
         }
     }
 
-    private Task OnActivationRequest(IContext context, ActivationRequest msg)
+    private async Task OnActivationRequest(IContext context, ActivationRequest msg)
     {
         if (_actors.TryGetValue(msg.ClusterIdentity, out var existing))
         {
             //this identity already exists
             context.Respond(new ActivationResponse { Pid = existing });
 
-            return Task.CompletedTask;
+            return;
         }
 
         var clusterKind = _cluster.TryGetClusterKind(msg.Kind);
@@ -121,23 +121,21 @@ internal class IdentityStoragePlacementActor : IActor
             Logger.LogError("Failed to spawn {Kind}/{Identity}, kind not found for member", msg.Kind, msg.Identity);
             context.Respond(new ActivationResponse { Failed = true });
 
-            return Task.CompletedTask;
+            return;
         }
 
         if (clusterKind.CanSpawnIdentity is not null)
         {
             // Needs to check if the identity is allowed to spawn
-            VerifyAndSpawn(msg, context, clusterKind);
+            await VerifyAndSpawn(msg, context, clusterKind).ConfigureAwait(false);
         }
         else
         {
             Spawn(msg, context, clusterKind);
         }
-
-        return Task.CompletedTask;
     }
 
-    private void VerifyAndSpawn(ActivationRequest msg, IContext context, ActivatedClusterKind clusterKind)
+    private async Task VerifyAndSpawn(ActivationRequest msg, IContext context, ActivatedClusterKind clusterKind)
     {
         var clusterIdentity = msg.ClusterIdentity;
 
@@ -159,20 +157,22 @@ internal class IdentityStoragePlacementActor : IActor
 
         if (canSpawn.IsCompleted)
         {
-            OnSpawnDecided(msg, context, clusterKind, canSpawn.Result);
+            var canSpawnIdentity = await canSpawn.AsTask().ConfigureAwait(false);
+            OnSpawnDecided(msg, context, clusterKind, canSpawnIdentity);
 
             return;
         }
 
         _inFlightIdentityChecks.Add(clusterIdentity);
 
-        context.ReenterAfter(canSpawn.AsTask(), task =>
+        context.ReenterAfter(canSpawn.AsTask(), async task =>
             {
                 _inFlightIdentityChecks.Remove(clusterIdentity);
 
                 if (task.IsCompletedSuccessfully)
                 {
-                    OnSpawnDecided(msg, context, clusterKind, task.Result);
+                    var canSpawnIdentity = await task.ConfigureAwait(false);
+                    OnSpawnDecided(msg, context, clusterKind, canSpawnIdentity);
                 }
                 else
                 {
@@ -184,8 +184,6 @@ internal class IdentityStoragePlacementActor : IActor
                         }
                     );
                 }
-
-                return Task.CompletedTask;
             }
         );
     }

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -71,15 +71,13 @@ internal class IdentityStorageWorker : IActor
         {
             _inProgress.Add(clusterIdentity);
 
-            context.ReenterAfter(GetWithGlobalLock(context.Sender!, clusterIdentity), task =>
+            context.ReenterAfter(GetWithGlobalLock(context.Sender!, clusterIdentity), async task =>
                 {
                     try
                     {
-                        var response = task.Result;
+                        var response = await task.ConfigureAwait(false);
                         context.Respond(response);
                         RespondToWaitingRequests(context, clusterIdentity, response);
-
-                        return Task.CompletedTask;
                     }
                     finally
                     {

--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -602,11 +602,9 @@ internal class PartitionIdentityActor : IActor
                     res, msg.ClusterIdentity);
             }
             // Just waits for the already in-progress activation to complete (or fail)
-            context.ReenterAfter(res.Response.Task, task =>
+            context.ReenterAfter(res.Response.Task, async task =>
                 {
-                    context.Respond(task.Result);
-
-                    return Task.CompletedTask;
+                    context.Respond(await task.ConfigureAwait(false));
                 }
             );
 

--- a/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
@@ -131,10 +131,26 @@ internal class PartitionPlacementActor : IActor, IDisposable
             }
 
             // Ensure that we only update last rebalanced topology when all members have received the current activations
-            if (waitingRequests.All(task
-                    => task.IsCompletedSuccessfully &&
-                       task.Result?.ProcessingState == IdentityHandoverAck.Types.State.Processed
-                ))
+            var allProcessed = true;
+
+            foreach (var task in waitingRequests)
+            {
+                if (!task.IsCompletedSuccessfully)
+                {
+                    allProcessed = false;
+                    break;
+                }
+
+                var ack = await task.ConfigureAwait(false);
+
+                if (ack?.ProcessingState != IdentityHandoverAck.Types.State.Processed)
+                {
+                    allProcessed = false;
+                    break;
+                }
+            }
+
+            if (allProcessed)
             {
                 Logger.LogInformation("[PartitionPlacementActor] Completed rebalance publish for topology {TopologyHash}",
                     msg.TopologyHash);
@@ -318,7 +334,7 @@ internal class PartitionPlacementActor : IActor, IDisposable
             }
         );
 
-    private Task OnActivationRequest(IContext context, ActivationRequest msg)
+    private async Task OnActivationRequest(IContext context, ActivationRequest msg)
     {
         if (_actors.TryGetValue(msg.ClusterIdentity, out var existing))
         {
@@ -336,7 +352,7 @@ internal class PartitionPlacementActor : IActor, IDisposable
 
             context.Respond(response);
 
-            return Task.CompletedTask;
+            return;
         }
 
         var clusterKind = _cluster.TryGetClusterKind(msg.Kind);
@@ -350,23 +366,21 @@ internal class PartitionPlacementActor : IActor, IDisposable
                 TopologyHash = msg.TopologyHash
             });
 
-            return Task.CompletedTask;
+            return;
         }
 
         if (clusterKind.CanSpawnIdentity is not null)
         {
             // Needs to check if the identity is allowed to spawn
-            VerifyAndSpawn(msg, context, clusterKind);
+            await VerifyAndSpawn(msg, context, clusterKind).ConfigureAwait(false);
         }
         else
         {
             Spawn(msg, context, clusterKind);
         }
-
-        return Task.CompletedTask;
     }
 
-    private void VerifyAndSpawn(ActivationRequest msg, IContext context, ActivatedClusterKind clusterKind)
+    private async Task VerifyAndSpawn(ActivationRequest msg, IContext context, ActivatedClusterKind clusterKind)
     {
         var clusterIdentity = msg.ClusterIdentity;
 
@@ -389,20 +403,22 @@ internal class PartitionPlacementActor : IActor, IDisposable
 
         if (canSpawn.IsCompleted)
         {
-            OnSpawnDecided(msg, context, clusterKind, canSpawn.Result);
+            var canSpawnIdentity = await canSpawn.AsTask().ConfigureAwait(false);
+            OnSpawnDecided(msg, context, clusterKind, canSpawnIdentity);
 
             return;
         }
 
         _inFlightIdentityChecks.Add(clusterIdentity);
 
-        context.ReenterAfter(canSpawn.AsTask(), task =>
+        context.ReenterAfter(canSpawn.AsTask(), async task =>
             {
                 _inFlightIdentityChecks.Remove(clusterIdentity);
 
                 if (task.IsCompletedSuccessfully)
                 {
-                    OnSpawnDecided(msg, context, clusterKind, task.Result);
+                    var canSpawnIdentity = await task.ConfigureAwait(false);
+                    OnSpawnDecided(msg, context, clusterKind, canSpawnIdentity);
                 }
                 else
                 {
@@ -415,8 +431,6 @@ internal class PartitionPlacementActor : IActor, IDisposable
                         }
                     );
                 }
-
-                return Task.CompletedTask;
             }
         );
     }

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
@@ -149,7 +149,7 @@ public class PartitionActivatorActor : IActor
         return Task.CompletedTask;
     }
 
-    private Task OnActivationRequest(ActivationRequest msg, IContext context)
+    private async Task OnActivationRequest(ActivationRequest msg, IContext context)
     {
         //who owns this?
         var ownerAddress = _manager.Selector.GetOwnerAddress(msg.ClusterIdentity);
@@ -167,7 +167,7 @@ public class PartitionActivatorActor : IActor
 
             context.Forward(ownerPid);
 
-            return Task.CompletedTask;
+            return;
         }
 
         if (_actors.TryGetValue(msg.ClusterIdentity, out var existing))
@@ -185,18 +185,16 @@ public class PartitionActivatorActor : IActor
             if (clusterKind.CanSpawnIdentity is not null)
             {
                 // Needs to check if the identity is allowed to spawn
-                VerifyAndSpawn(msg, context, clusterKind);
+                await VerifyAndSpawn(msg, context, clusterKind).ConfigureAwait(false);
             }
             else
             {
                 Spawn(msg, context, clusterKind);
             }
         }
-
-        return Task.CompletedTask;
     }
 
-    private void VerifyAndSpawn(ActivationRequest msg, IContext context, ActivatedClusterKind clusterKind)
+    private async Task VerifyAndSpawn(ActivationRequest msg, IContext context, ActivatedClusterKind clusterKind)
     {
         var clusterIdentity = msg.ClusterIdentity;
 
@@ -219,20 +217,22 @@ public class PartitionActivatorActor : IActor
 
         if (canSpawn.IsCompleted)
         {
-            OnSpawnDecided(msg, context, clusterKind, canSpawn.Result);
+            var canSpawnIdentity = await canSpawn.AsTask().ConfigureAwait(false);
+            OnSpawnDecided(msg, context, clusterKind, canSpawnIdentity);
 
             return;
         }
 
         _inFlightIdentityChecks.Add(clusterIdentity);
 
-        context.ReenterAfter(canSpawn.AsTask(), task =>
+        context.ReenterAfter(canSpawn.AsTask(), async task =>
             {
                 _inFlightIdentityChecks.Remove(clusterIdentity);
 
                 if (task.IsCompletedSuccessfully)
                 {
-                    OnSpawnDecided(msg, context, clusterKind, task.Result);
+                    var canSpawnIdentity = await task.ConfigureAwait(false);
+                    OnSpawnDecided(msg, context, clusterKind, canSpawnIdentity);
                 }
                 else
                 {
@@ -244,8 +244,6 @@ public class PartitionActivatorActor : IActor
                         }
                     );
                 }
-
-                return Task.CompletedTask;
             }
         );
     }

--- a/src/Proto.Cluster/SingleNode/SingleNodeActivatorActor.cs
+++ b/src/Proto.Cluster/SingleNode/SingleNodeActivatorActor.cs
@@ -114,7 +114,7 @@ internal class SingleNodeActivatorActor : IActor
         return Task.CompletedTask;
     }
 
-    private Task OnActivationRequest(ActivationRequest msg, IContext context)
+    private async Task OnActivationRequest(ActivationRequest msg, IContext context)
     {
         if (_actors.TryGetValue(msg.ClusterIdentity, out var existing))
         {
@@ -131,18 +131,16 @@ internal class SingleNodeActivatorActor : IActor
             if (clusterKind.CanSpawnIdentity is not null)
             {
                 // Needs to check if the identity is allowed to spawn
-                VerifyAndSpawn(msg, context, clusterKind);
+                await VerifyAndSpawn(msg, context, clusterKind).ConfigureAwait(false);
             }
             else
             {
                 Spawn(msg, context, clusterKind);
             }
         }
-
-        return Task.CompletedTask;
     }
 
-    private void VerifyAndSpawn(ActivationRequest msg, IContext context, ActivatedClusterKind clusterKind)
+    private async Task VerifyAndSpawn(ActivationRequest msg, IContext context, ActivatedClusterKind clusterKind)
     {
         var clusterIdentity = msg.ClusterIdentity;
 
@@ -164,20 +162,22 @@ internal class SingleNodeActivatorActor : IActor
 
         if (canSpawn.IsCompleted)
         {
-            OnSpawnDecided(msg, context, clusterKind, canSpawn.Result);
+            var canSpawnIdentity = await canSpawn.AsTask().ConfigureAwait(false);
+            OnSpawnDecided(msg, context, clusterKind, canSpawnIdentity);
 
             return;
         }
 
         _inFlightIdentityChecks.Add(clusterIdentity);
 
-        context.ReenterAfter(canSpawn.AsTask(), task =>
+        context.ReenterAfter(canSpawn.AsTask(), async task =>
             {
                 _inFlightIdentityChecks.Remove(clusterIdentity);
 
                 if (task.IsCompletedSuccessfully)
                 {
-                    OnSpawnDecided(msg, context, clusterKind, task.Result);
+                    var canSpawnIdentity = await task.ConfigureAwait(false);
+                    OnSpawnDecided(msg, context, clusterKind, canSpawnIdentity);
                 }
                 else
                 {
@@ -189,8 +189,6 @@ internal class SingleNodeActivatorActor : IActor
                         }
                     );
                 }
-
-                return Task.CompletedTask;
             }
         );
     }


### PR DESCRIPTION
## Summary
- replace direct `Result` access with awaited tasks in cluster activation actors and identity plumbing
- propagate asynchronous CanSpawnIdentity checks to calling methods
- adjust rebalance consensus check to await per-node acknowledgements

## Testing
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj --nologo` *(fails: GossipCoreTests.Large_cluster_should_get_topology_consensus)*
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj --filter "FullyQualifiedName=Proto.Cluster.Tests.GossipCoreTests.Large_cluster_should_get_topology_consensus" --nologo`


------
https://chatgpt.com/codex/tasks/task_e_689467f25ba08328a9926359cd27e104