### PR TITLE
Avoid channel closed exception when stopping batching producer

### DIFF
--- a/src/Proto.Cluster/PubSub/BatchingProducer.cs
+++ b/src/Proto.Cluster/PubSub/BatchingProducer.cs
@@ -214,10 +214,9 @@ public class BatchingProducer : IAsyncDisposable
 
     private void StopAcceptingNewMessages()
     {
-        if (!_publisherChannel.Reader.Completion.IsCompleted)
-        {
-            _publisherChannel.Writer.Complete();
-        }
+        // Attempt to complete the channel without throwing if it has already been closed
+        // The publisher loop and publish error handling might both call this concurrently
+        _publisherChannel.Writer.TryComplete();
     }
 
     private async Task PublishBatch(PubSubBatchWithReceipts batchWrapper)


### PR DESCRIPTION
## Summary
- prevent ChannelClosedException when shutting down BatchingProducer by using TryComplete

## Testing
- `dotnet test tests/Proto.Cluster.PubSub.Tests/Proto.Cluster.PubSub.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68946c27105483288b0b1da0edbd860e