### PR TITLE
ci: run tests on dev branch manually

### DIFF
--- a/.github/workflows/dev-tests.yml
+++ b/.github/workflows/dev-tests.yml
@@ -7,6 +7,8 @@ env:
   DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
   TERM: xterm
   
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-tests.yml
+++ b/.github/workflows/dev-tests.yml
@@ -1,0 +1,174 @@
+name: Build and test dev branch
+# Manually run the full PR test suite against the dev branch
+on:
+  workflow_dispatch:
+
+env:
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
+  TERM: xterm
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379/tcp
+        options: --entrypoint redis-server
+      mongodb:
+        image: mongo
+        ports:
+          - 27017/tcp
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          ref: dev
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+          cache: true
+          cache-dependency-path: |
+            Directory.Packages.props
+            **/*.csproj
+
+      - name: Restore bin/obj cache
+        id: cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+
+      - name: Restore dependencies
+        run: dotnet restore ProtoActor.sln
+
+      - name: Build
+        run: dotnet build ProtoActor.sln -c Release
+
+      - name: Save bin/obj cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+  test-slow:  # slow tests that should run in parallel
+    runs-on: ubuntu-latest
+    
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379/tcp
+        options: --entrypoint redis-server
+    
+    strategy:
+      matrix:
+        dotnet:
+          - net8.0
+        test:
+          - "tests/Proto.Cluster.Tests/*.csproj"
+          - "tests/Proto.Cluster.PartitionIdentity.Tests/*.csproj"
+          - "tests/Proto.Cluster.RedisIdentity.Tests/*.csproj"
+          - "tests/Proto.Cluster.PubSub.Tests/*.csproj"
+    
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          ref: dev
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+          cache: true
+          cache-dependency-path: |
+            Directory.Packages.props
+            **/*.csproj
+
+      - name: Restore bin/obj cache
+        id: cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+
+      - name: Restore dependencies
+        run: dotnet restore ProtoActor.sln
+
+      - name: Run tests ${{ matrix.test }}
+        timeout-minutes: 15
+        env:
+          ConnectionStrings__Redis: localhost:${{ job.services.redis.ports[6379] }},syncTimeout=10000
+        run: |
+          dotnet test ${{ matrix.test }} -c Release -f ${{ matrix.dotnet }} --logger GitHubActions
+
+      - name: Save bin/obj cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+  test-fast:  # fast tests where setting up a parallel job run is more overhead than just running the tests side by side
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        test:
+          - "tests/Proto.Actor.Tests/*.csproj"
+          - "tests/Proto.Remote.Tests/*.csproj"
+          # "tests/Proto.Persistence.Tests/*.csproj"
+          - "tests/Proto.OpenTelemetry.Tests/*.csproj"
+          - "tests/Proto.Cluster.CodeGen.Tests/*.csproj"
+    
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          ref: dev
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+          cache: true
+          cache-dependency-path: |
+            Directory.Packages.props
+            **/*.csproj
+
+      - name: Restore bin/obj cache
+        id: cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+
+      - name: Restore dependencies
+        run: dotnet restore ProtoActor.sln
+      - name: Run tests ${{ matrix.test }}
+        timeout-minutes: 15
+        run: |
+          dotnet test ${{ matrix.test }} -c Release --logger GitHubActions
+
+      - name: Save bin/obj cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            **/bin
+            **/obj
+          key: ${{ steps.cache.outputs.cache-primary-key }}


### PR DESCRIPTION
## Summary
- allow PR test workflow to be run manually on `dev`

## Testing
- `dotnet --version`
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -c Release`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6894a8625fb8832887710ebfdda47ef9