### PR TITLE
Track activation requests in partition identity lookup

### DIFF
--- a/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
@@ -95,6 +95,10 @@ public class PartitionIdentityTests
 
         _output.WriteLine($"{totalCalls} requests, {restarts} restarts against " + actorStates.Count + " identities");
 
+        var activationRequests = actorStates.Sum(it => it.Events.Count(e => e is ActivationRequested));
+        var actorStarts = actorStates.Sum(it => it.Events.Count(e => e is ActorStarted));
+        _output.WriteLine($"Activation requests: {activationRequests}, actors started: {actorStarts}");
+
         foreach (var actorState in actorStates)
         {
             if (actorState.Inconsistent)
@@ -298,12 +302,15 @@ public class PartitionIdentityClusterFixture : BaseInMemoryClusterFixture
         };
 
     protected override IIdentityLookup GetIdentityLookup(string clusterName) =>
-        new PartitionIdentityLookup(new PartitionConfig
-        {
-            GetPidTimeout = TimeSpan.FromSeconds(5),
-            HandoverChunkSize = _chunkSize,
-            RebalanceRequestTimeout = TimeSpan.FromSeconds(3),
-            Mode = _mode,
-            Send = _send
-        });
+        new RecordingPartitionIdentityLookup(
+            new PartitionIdentityLookup(new PartitionConfig
+            {
+                GetPidTimeout = TimeSpan.FromSeconds(5),
+                HandoverChunkSize = _chunkSize,
+                RebalanceRequestTimeout = TimeSpan.FromSeconds(3),
+                Mode = _mode,
+                Send = _send
+            }),
+            Repository,
+            this);
 }

--- a/tests/Proto.Cluster.PartitionIdentity.Tests/RecordingPartitionIdentityLookup.cs
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/RecordingPartitionIdentityLookup.cs
@@ -1,0 +1,50 @@
+// -----------------------------------------------------------------------
+// <copyright file="RecordingPartitionIdentityLookup.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using Proto;
+using Proto.Cluster.Identity;
+using Proto.Cluster.Partition;
+using Proto.Cluster.Tests;
+using Proto.Diagnostics;
+
+namespace Proto.Cluster.PartitionIdentity.Tests;
+
+/// <summary>
+/// Identity lookup wrapper that records activation requests before delegating
+/// to the underlying <see cref="PartitionIdentityLookup"/>.
+/// </summary>
+public class RecordingPartitionIdentityLookup : IIdentityLookup
+{
+    private readonly PartitionIdentityLookup _inner;
+    private readonly ActorStateRepo _repo;
+    private readonly IClusterFixture _fixture;
+
+    public RecordingPartitionIdentityLookup(PartitionIdentityLookup inner, ActorStateRepo repo, IClusterFixture fixture)
+    {
+        _inner = inner;
+        _repo = repo;
+        _fixture = fixture;
+    }
+
+    public Task<PID?> GetAsync(ClusterIdentity clusterIdentity, CancellationToken ct)
+    {
+        _repo.Get(clusterIdentity.Identity, _fixture).RecordActivationRequest();
+        return _inner.GetAsync(clusterIdentity, ct);
+    }
+
+    public Task RemovePidAsync(ClusterIdentity clusterIdentity, PID pid, CancellationToken ct)
+        => _inner.RemovePidAsync(clusterIdentity, pid, ct);
+
+    public Task SetupAsync(Cluster cluster, string[] kinds, bool isClient)
+        => _inner.SetupAsync(cluster, kinds, isClient);
+
+    public Task ShutdownAsync() => _inner.ShutdownAsync();
+
+    public Task<DiagnosticsEntry[]> GetDiagnostics()
+        => (_inner as IDiagnosticsProvider).GetDiagnostics();
+}

--- a/tests/Proto.Cluster.Tests/ConcurrencyVerificationActor.cs
+++ b/tests/Proto.Cluster.Tests/ConcurrencyVerificationActor.cs
@@ -105,6 +105,9 @@ public record ActorStarted(string Member, PID Activation, DateTimeOffset When, i
 public record ActorStopped(string Member, PID Activation, DateTimeOffset When, int StoredCount, long GlobalCount)
     : VerificationEvent(Activation, When);
 
+public record ActivationRequested(DateTimeOffset When)
+    : VerificationEvent(new PID(string.Empty, string.Empty), When);
+
 public record ConsistencyError(
         PID Activation,
         DateTimeOffset When,
@@ -173,6 +176,9 @@ public class ActorState
             _currentlyOnMembers.Remove(context.System.Id);
         }
     }
+
+    public void RecordActivationRequest()
+        => Events.Add(new ActivationRequested(DateTimeOffset.Now));
 
     // do not verify consistency if any of the current members is blocked (which means they are shutting down)
     // in this case we may see duplicated activation, but this is by design and we don't want to report it


### PR DESCRIPTION
## Summary
- add `ActivationRequested` event and state tracker
- wrap `PartitionIdentityLookup` to record activation requests
- report activation request vs start counts in partition identity tests

## Testing
- `dotnet test tests/Proto.Cluster.PartitionIdentity.Tests/Proto.Cluster.PartitionIdentity.Tests.csproj --filter "ClusterMaintainsSingleConcurrentVirtualActorPerIdentity" -c Release --logger "console;verbosity=detailed"`


------
https://chatgpt.com/codex/tasks/task_e_6894ccf4d30c8328a7381baf9b90397c