### PR TITLE
Track activation requests during partition identity tests

### DIFF
--- a/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ClusterTest.Messages;
 using FluentAssertions;
+using Proto.Cluster;
 using Proto.Cluster.Identity;
 using Proto.Cluster.Partition;
 using Proto.Cluster.Tests;
@@ -91,12 +92,20 @@ public class PartitionIdentityTests
         var actorStates = fixture.Repository.Contents.ToList();
 
         var totalCalls = actorStates.Select(it => it.TotalCount).Sum();
-        var restarts = actorStates.Select(it => it.Events.Count(it => it is ActorStopped) - 1).Sum();
+        var restarts = actorStates.Select(it => it.Events.Count(e => e is ActorStopped) - 1).Sum();
+        var totalActivationRequests =
+            actorStates.Select(it => it.Events.Count(e => e is ActivationRequested)).Sum();
 
-        _output.WriteLine($"{totalCalls} requests, {restarts} restarts against " + actorStates.Count + " identities");
+        _output.WriteLine(
+            $"{totalCalls} requests, {restarts} restarts, {totalActivationRequests} activation requests against " +
+            actorStates.Count + " identities");
 
         foreach (var actorState in actorStates)
         {
+            var activationReqs = actorState.Events.Count(e => e is ActivationRequested);
+            var starts = actorState.Events.Count(e => e is ActorStarted);
+            activationReqs.Should().Be(starts);
+
             if (actorState.Inconsistent)
             {
                 Assert.False(actorState.Inconsistent, actorState.ToString());
@@ -298,12 +307,22 @@ public class PartitionIdentityClusterFixture : BaseInMemoryClusterFixture
         };
 
     protected override IIdentityLookup GetIdentityLookup(string clusterName) =>
-        new PartitionIdentityLookup(new PartitionConfig
-        {
-            GetPidTimeout = TimeSpan.FromSeconds(5),
-            HandoverChunkSize = _chunkSize,
-            RebalanceRequestTimeout = TimeSpan.FromSeconds(3),
-            Mode = _mode,
-            Send = _send
-        });
+        new PartitionIdentityLookup(
+            new PartitionConfig
+            {
+                GetPidTimeout = TimeSpan.FromSeconds(5),
+                HandoverChunkSize = _chunkSize,
+                RebalanceRequestTimeout = TimeSpan.FromSeconds(3),
+                Mode = _mode,
+                Send = _send
+            },
+            props => props.WithReceiverMiddleware(next => async (ctx, env) =>
+            {
+                if (env.Message is ActivationRequest req)
+                {
+                    Repository.Get(req.Identity, this).RecordActivationRequest(ctx.System.Id);
+                }
+
+                await next(ctx, env);
+            }));
 }

--- a/tests/Proto.Cluster.Tests/ConcurrencyVerificationActor.cs
+++ b/tests/Proto.Cluster.Tests/ConcurrencyVerificationActor.cs
@@ -105,6 +105,9 @@ public record ActorStarted(string Member, PID Activation, DateTimeOffset When, i
 public record ActorStopped(string Member, PID Activation, DateTimeOffset When, int StoredCount, long GlobalCount)
     : VerificationEvent(Activation, When);
 
+public record ActivationRequested(string Member, DateTimeOffset When)
+    : VerificationEvent(null!, When);
+
 public record ConsistencyError(
         PID Activation,
         DateTimeOffset When,
@@ -138,6 +141,9 @@ public class ActorState
     public bool Inconsistent { get; private set; }
     public long TotalCount => Interlocked.Read(ref _totalCount);
     public ConcurrentBag<VerificationEvent> Events { get; } = new();
+
+    public void RecordActivationRequest(string member) =>
+        Events.Add(new ActivationRequested(member, DateTimeOffset.Now));
 
     public void RecordStarted(IContext context)
     {
@@ -200,6 +206,7 @@ public class ActorState
                 {
                     ActorStarted started     => $"[{started.When:O}] Actor started on member {started.Member}\n",
                     ActorStopped stopped     => $"[{stopped.When:O}] Actor stopped on member {stopped.Member}\n",
+                    ActivationRequested req => $"[{req.When:O}] Activation requested on member {req.Member}\n",
                     ClusterSnapshot snapshot => $"[{snapshot.When:O}] Cluster snapshot:\n{snapshot.Snapshot}\n",
                     ConsistencyError err =>
                         $"[{err.When:O}] Consistency error, actual: {err.ActualCount}, expected: {err.ExpectedCount}, stored: {err.StoredCount}, global: {err.GlobalCount}",


### PR DESCRIPTION
## Summary
- record activation requests in `ConcurrencyVerificationActor`
- instrument `PartitionIdentityTests` to log and assert activation request counts

## Testing
- `dotnet test tests/Proto.Cluster.PartitionIdentity.Tests/Proto.Cluster.PartitionIdentity.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6894ca5c01e48328a9f670240a77be62