### PR TITLE
Include activation stats in PartitionIdentity test failures

### DIFF
--- a/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
@@ -136,6 +136,8 @@ public class PartitionIdentityTests
         var sentActivationRequests = activationRequestsSent;
         var receivedActivationRequests = activationRequestsReceived;
         var forwardedActivationRequests = activationRequestsForwarded;
+        var activationStats =
+            $"sent {sentActivationRequests}, received {receivedActivationRequests}, forwarded {forwardedActivationRequests}";
 
         _output.WriteLine(
             $"{totalCalls} requests, {restarts} restarts, {receivedActivationRequests} activation requests against " +
@@ -146,21 +148,22 @@ public class PartitionIdentityTests
         // Ensure every activation request sent by lookups was handled by an activator
         sentActivationRequests.Should().Be(
             receivedActivationRequests,
-            $"sent {sentActivationRequests}, received {receivedActivationRequests}, forwarded {forwardedActivationRequests}"
+            activationStats
         );
 
         // Some activation requests may target actors that are already running
         // so the number of received requests can exceed actual actor starts
         receivedActivationRequests.Should().BeGreaterOrEqualTo(
             totalStarts,
-            $"received {receivedActivationRequests}, actor starts {totalStarts}, forwarded {forwardedActivationRequests}"
+            activationStats
         );
 
         foreach (var actorState in actorStates)
         {
             if (actorState.Inconsistent)
             {
-                Assert.False(actorState.Inconsistent, actorState.ToString());
+                // Include activation counts in the failure message for easier debugging
+                Assert.False(actorState.Inconsistent, $"{activationStats}\n{actorState}");
             }
         }
     }


### PR DESCRIPTION
## Summary
- log activation request counts in PartitionIdentity tests
- include activation metrics when reporting inconsistent actor state

## Testing
- `dotnet test tests/Proto.Cluster.PartitionIdentity.Tests/Proto.Cluster.PartitionIdentity.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6895e3d163588328bfdf2bb42002fe49