### PR TITLE
chore: simplify supervision log messages

### DIFF
--- a/src/Proto.Actor/Supervision/AllForOneStrategyLogMessages.cs
+++ b/src/Proto.Actor/Supervision/AllForOneStrategyLogMessages.cs
@@ -5,6 +5,7 @@ namespace Proto;
 
 internal static partial class AllForOneStrategyLogMessages
 {
-    [LoggerMessage(0, LogLevel.Information, "{Action} {Actor} because of {Reason}")]
+    // `reason` is kept so the logger captures the exception automatically
+    [LoggerMessage(0, LogLevel.Information, "{Action} {Actor}")]
     internal static partial void AllForOneStrategyAction(this ILogger logger, string action, PID actor, Exception reason);
 }

--- a/src/Proto.Actor/Supervision/OneForOneStrategyLogMessages.cs
+++ b/src/Proto.Actor/Supervision/OneForOneStrategyLogMessages.cs
@@ -5,6 +5,7 @@ namespace Proto;
 
 internal static partial class OneForOneStrategyLogMessages
 {
-    [LoggerMessage(0, LogLevel.Information, "{Action} {Actor} because of {Reason}")]
+    // `reason` is kept so the logger captures the exception automatically
+    [LoggerMessage(0, LogLevel.Information, "{Action} {Actor}")]
     internal static partial void OneForOneStrategyAction(this ILogger logger, string action, PID actor, Exception reason);
 }


### PR DESCRIPTION
## Summary
- remove unused `{Reason}` placeholder from supervision log templates
- allow logger to capture exception automatically

## Testing
- `dotnet build ProtoActor.sln`


------
https://chatgpt.com/codex/tasks/task_e_6896553670748328994ce87b316d4f9e