### PR TITLE
Fix nullability warnings in Proto.Actor

### DIFF
--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -205,7 +205,7 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
 
     public void Request(PID target, object message, PID? sender)
     {
-        var messageEnvelope = MessageEnvelope.WithSender(message, sender!);
+        var messageEnvelope = MessageEnvelope.WithSender(message, sender);
         SendUserMessage(target, messageEnvelope);
     }
 

--- a/src/Proto.Actor/EventStream/EventProbeLogMessages.cs
+++ b/src/Proto.Actor/EventStream/EventProbeLogMessages.cs
@@ -8,8 +8,8 @@ internal static partial class EventProbeLogMessages
     internal static partial void SettingExpectation(this ILogger logger);
 
     [LoggerMessage(1, LogLevel.Debug, "Got expected event {Event}")]
-    internal static partial void GotExpectedEvent(this ILogger logger, object @event);
+    internal static partial void GotExpectedEvent(this ILogger logger, object? @event);
 
     [LoggerMessage(2, LogLevel.Debug, "Got unexpected {Event}, ignoring")]
-    internal static partial void GotUnexpectedEvent(this ILogger logger, object @event);
+    internal static partial void GotUnexpectedEvent(this ILogger logger, object? @event);
 }

--- a/src/Proto.Actor/Messages/MessageEnvelope.cs
+++ b/src/Proto.Actor/Messages/MessageEnvelope.cs
@@ -67,17 +67,17 @@ public record MessageEnvelope : IDiagnosticsTypeName
     /// <summary>
     ///     Adds a sender <see cref="PID" /> to the message envelope.
     /// </summary>
-    /// <param name="sender"></param>
+    /// <param name="sender">Sender <see cref="PID" /> or <c>null</c></param>
     /// <returns>New envelope</returns>
-    public MessageEnvelope WithSender(PID sender) => this with { Sender = sender };
+    public MessageEnvelope WithSender(PID? sender) => this with { Sender = sender };
 
     /// <summary>
     ///     Adds a sender <see cref="PID" /> if the message is an envelope, otherwise creates a new envelope with the given sender.
     /// </summary>
     /// <param name="message"></param>
-    /// <param name="sender"></param>
+    /// <param name="sender">Sender <see cref="PID" /> or <c>null</c></param>
     /// <returns>New envelope</returns>
-    public static MessageEnvelope WithSender(object message, PID sender) => message is MessageEnvelope env
+    public static MessageEnvelope WithSender(object message, PID? sender) => message is MessageEnvelope env
         ? env.WithSender(sender)
         : new MessageEnvelope(message, sender);
 

--- a/src/Proto.Actor/Supervision/AllForOneStrategyLogMessages.cs
+++ b/src/Proto.Actor/Supervision/AllForOneStrategyLogMessages.cs
@@ -5,7 +5,7 @@ namespace Proto;
 
 internal static partial class AllForOneStrategyLogMessages
 {
-    // `reason` is kept so the logger captures the exception automatically
+    // "exception" parameter ensures the exception is logged automatically
     [LoggerMessage(0, LogLevel.Information, "{Action} {Actor}")]
-    internal static partial void AllForOneStrategyAction(this ILogger logger, string action, PID actor, Exception reason);
+    internal static partial void AllForOneStrategyAction(this ILogger logger, string action, PID actor, Exception exception);
 }

--- a/src/Proto.Actor/Supervision/OneForOneStrategyLogMessages.cs
+++ b/src/Proto.Actor/Supervision/OneForOneStrategyLogMessages.cs
@@ -5,7 +5,7 @@ namespace Proto;
 
 internal static partial class OneForOneStrategyLogMessages
 {
-    // `reason` is kept so the logger captures the exception automatically
+    // "exception" parameter ensures the exception is logged automatically
     [LoggerMessage(0, LogLevel.Information, "{Action} {Actor}")]
-    internal static partial void OneForOneStrategyAction(this ILogger logger, string action, PID actor, Exception reason);
+    internal static partial void OneForOneStrategyAction(this ILogger logger, string action, PID actor, Exception exception);
 }


### PR DESCRIPTION
## Summary
- rename exception parameters in supervision log helpers
- avoid null sender when wrapping Request messages
- allow nullable events in probe logging
- allow nullable sender in MessageEnvelope.WithSender and simplify Request

## Testing
- `dotnet build src/Proto.Actor/Proto.Actor.csproj`
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68965d0c105483288def0e2201bf967d