### PR TITLE
Add stress test for shared future token reuse

### DIFF
--- a/tests/Proto.Actor.Tests/Futures/SharedFutureTokenReuseTests.cs
+++ b/tests/Proto.Actor.Tests/Futures/SharedFutureTokenReuseTests.cs
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="SharedFutureTokenReuseTests.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Proto.Tests;
+
+public class SharedFutureTokenReuseTests : ActorTestBase
+{
+    [Fact]
+    public async Task Should_not_reuse_cancelled_tokens_in_shared_futures()
+    {
+        // actor that simply echoes back the incoming message
+        var pid = Context.Spawn(Props.FromFunc(ctx =>
+            {
+                if (ctx.Sender is not null)
+                {
+                    ctx.Respond(ctx.Message!);
+                }
+
+                return Task.CompletedTask;
+            }));
+
+        const int iterations = 2_000_000;
+
+        var options = new ParallelOptions
+        {
+            // allow many concurrent futures to overlap
+            MaxDegreeOfParallelism = Environment.ProcessorCount * 4
+        };
+
+        await Parallel.ForEachAsync(Enumerable.Range(0, iterations), options, async (i, _) =>
+        {
+            using var future = System.Future.Get();
+
+            if ((i & 1) == 0)
+            {
+                // successful path, request should complete before timeout
+                Context.Request(pid, i, future.Pid);
+                var token = CancellationTokens.FromSeconds(5);
+                token.IsCancellationRequested.Should().BeFalse();
+                var res = await future.GetTask(token);
+                res.Should().Be(i);
+            }
+            else
+            {
+                // timeout path, no message is sent and token is cancelled immediately
+                using var cts = new CancellationTokenSource();
+                cts.Cancel();
+                await Assert.ThrowsAsync<TimeoutException>(() => future.GetTask(cts.Token));
+            }
+        });
+    }
+}
+

--- a/tests/Proto.Actor.Tests/Futures/SharedFutureTokenReuseTests.cs
+++ b/tests/Proto.Actor.Tests/Futures/SharedFutureTokenReuseTests.cs
@@ -29,12 +29,13 @@ public class SharedFutureTokenReuseTests : ActorTestBase
                 return Task.CompletedTask;
             }));
 
-        const int iterations = 2_000_000;
+        // crank up the load to really stress shared futures
+        const int iterations = 20_000_000;
 
         var options = new ParallelOptions
         {
-            // allow many concurrent futures to overlap
-            MaxDegreeOfParallelism = Environment.ProcessorCount * 4
+            // fixed degree of parallelism to keep pressure constant
+            MaxDegreeOfParallelism = 20
         };
 
         await Parallel.ForEachAsync(Enumerable.Range(0, iterations), options, async (i, _) =>


### PR DESCRIPTION
## Summary
- run shared future token reuse stress test in parallel using Parallel.ForEachAsync to create millions of overlapping futures

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj --filter SharedFutureTokenReuseTests --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_689a01ac381c832892841c15712f8035