### PR TITLE
refactor: unify ReenterAfter with generic helpers

### DIFF
--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -221,7 +221,13 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
     {
         if (token.IsCancellationRequested)
         {
-            ReenterAfter(Task.CompletedTask, onCancelled);
+            ReenterAfter(Task.CompletedTask, _ =>
+                {
+                    onCancelled();
+
+                    return Task.CompletedTask;
+                }
+            );
 
             return;
         }
@@ -238,84 +244,35 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
         // Ensures registration is disposed with the actor
         var inceptionRegistration = CancellationToken.Register(() => registration.Dispose());
 
-        ReenterAfter(tcs.Task, () =>
+        ReenterAfter(tcs.Task, _ =>
             {
                 inceptionRegistration.Dispose();
                 onCancelled();
+
+                return Task.CompletedTask;
             }
         );
     }
 
-    public void ReenterAfter<T>(Task<T> target, Func<Task<T>, Task> action)
+    private void ContinueReenter<T>(Task<T> target, Func<Task<T>, Task> action)
     {
         var msg = _messageOrEnvelope;
         var cont = new Continuation(() => action(target), msg, Actor);
-
         ScheduleContinuation(target, cont);
     }
 
-    public void ReenterAfter(Task target, Action action)
+    private void ContinueReenter(Task target, Func<Task, Task> action)
     {
         var msg = _messageOrEnvelope;
-
-        var cont = new Continuation(
-            () =>
-            {
-                action();
-
-                return Task.CompletedTask;
-            },
-            msg,
-            Actor);
-
+        var cont = new Continuation(() => action(target), msg, Actor);
         ScheduleContinuation(target, cont);
     }
 
-    public void ReenterAfter(Task target, Action<Task> action)
-    {
-        var msg = _messageOrEnvelope;
+    public void ReenterAfter<T>(Task<T> target, Func<Task<T>, Task> action) =>
+        ContinueReenter(target, action);
 
-        var cont = new Continuation(
-            () =>
-            {
-                action(target);
-
-                return Task.CompletedTask;
-            },
-            msg,
-            Actor);
-
-        ScheduleContinuation(target, cont);
-    }
-
-    public void ReenterAfter<T>(Task<T> target, Action<Task<T>> action)
-    {
-        var msg = _messageOrEnvelope;
-
-        var cont = new Continuation(
-            () =>
-            {
-                action(target);
-
-                return Task.CompletedTask;
-            },
-            msg,
-            Actor);
-
-        ScheduleContinuation(target, cont);
-    }
-
-    public void ReenterAfter(Task target, Func<Task, Task> action)
-    {
-        var msg = _messageOrEnvelope;
-
-        var cont = new Continuation(
-            () => action(target),
-            msg,
-            Actor);
-
-        ScheduleContinuation(target, cont);
-    }
+    public void ReenterAfter(Task target, Func<Task, Task> action) =>
+        ContinueReenter(target, action);
 
     public Task Receive(MessageEnvelope envelope)
     {

--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -221,13 +221,10 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
     {
         if (token.IsCancellationRequested)
         {
-            ReenterAfter(Task.CompletedTask, _ =>
-                {
-                    onCancelled();
-
-                    return Task.CompletedTask;
-                }
-            );
+            ((IContext)this).ReenterAfter(Task.CompletedTask, () =>
+            {
+                onCancelled();
+            });
 
             return;
         }
@@ -244,14 +241,11 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
         // Ensures registration is disposed with the actor
         var inceptionRegistration = CancellationToken.Register(() => registration.Dispose());
 
-        ReenterAfter(tcs.Task, _ =>
-            {
-                inceptionRegistration.Dispose();
-                onCancelled();
-
-                return Task.CompletedTask;
-            }
-        );
+        ((IContext)this).ReenterAfter(tcs.Task, () =>
+        {
+            inceptionRegistration.Dispose();
+            onCancelled();
+        });
     }
 
     private void ContinueReenter<T>(Task<T> target, Func<Task<T>, Task> action)

--- a/src/Proto.Actor/Context/ActorContextDecorator.cs
+++ b/src/Proto.Actor/Context/ActorContextDecorator.cs
@@ -63,13 +63,8 @@ public abstract class ActorContextDecorator : IContext
     public virtual void ReenterAfter<T>(Task<T> target, Func<Task<T>, Task> action) =>
         _context.ReenterAfter(target, action);
 
-    public virtual void ReenterAfter(Task target, Action action) => _context.ReenterAfter(target, action);
-
-    public virtual void ReenterAfter(Task target, Action<Task> action) => _context.ReenterAfter(target, action);
-
-    public virtual void ReenterAfter<T>(Task<T> target, Action<Task<T>> action) => _context.ReenterAfter(target, action);
-
-    public virtual void ReenterAfter(Task target, Func<Task, Task> action) => _context.ReenterAfter(target, action);
+    public virtual void ReenterAfter(Task target, Func<Task, Task> action) =>
+        _context.ReenterAfter(target, action);
 
     public CapturedContext Capture() => _context.Capture();
 

--- a/src/Proto.Actor/Context/ActorLoggingContext.cs
+++ b/src/Proto.Actor/Context/ActorLoggingContext.cs
@@ -95,7 +95,7 @@ public class ActorLoggingContext : ActorContextDecorator
         base.ReenterAfter(target, action);
     }
 
-    public override void ReenterAfter(Task target, Action action)
+    public override void ReenterAfter(Task target, Func<Task, Task> action)
     {
         if (_logLevel != LogLevel.None && _logger.IsEnabled(_logLevel))
         {

--- a/src/Proto.Actor/Context/IContext.cs
+++ b/src/Proto.Actor/Context/IContext.cs
@@ -93,39 +93,8 @@ public interface IContext : ISenderContext, IReceiverContext, ISpawnerContext, I
 
     /// <summary>
     ///     Awaits the given target task and once completed, the given action is then completed within the actors concurrency
-    ///     constraint.
-    ///     The concept is called Reentrancy, where an actor can continue to process messages while also awaiting that some
-    ///     asynchronous operation completes.
-    /// </summary>
-    /// <param name="target">The Task to await</param>
-    /// <param name="action">The continuation to call once the task is completed</param>
-    void ReenterAfter(Task target, Action action);
-
-    /// <summary>
-    ///     Awaits the given target task and once completed, the given action is then completed within the actors concurrency
-    ///     constraint.
-    ///     The concept is called Reentrancy, where an actor can continue to process messages while also awaiting that some
-    ///     asynchronous operation completes.
-    /// </summary>
-    /// <param name="target">The Task to await</param>
-    /// <param name="action">The continuation to call once the task is completed. The awaited task is passed in as a parameter.</param>
-    void ReenterAfter(Task target, Action<Task> action);
-
-    /// <summary>
-    ///     Awaits the given target task and once completed, the given action is then completed within the actors concurrency
-    ///     constraint.
-    ///     The concept is called Reentrancy, where an actor can continue to process messages while also awaiting that some
-    ///     asynchronous operation completes.
-    /// </summary>
-    /// <param name="target">The Task to await</param>
-    /// <param name="action">The continuation to call once the task is completed. The awaited task is passed in as a parameter.</param>
-    void ReenterAfter<T>(Task<T> target, Action<Task<T>> action);
-
-    /// <summary>
-    ///     Awaits the given target task and once completed, the given action is then completed within the actors concurrency
-    ///     constraint.
-    ///     The concept is called Reentrancy, where an actor can continue to process messages while also awaiting that some
-    ///     asynchronous operation completes.
+    ///     constraint. The concept is called Reentrancy, where an actor can continue to process messages while also awaiting
+    ///     that some asynchronous operation completes.
     /// </summary>
     /// <param name="target">The Task to await</param>
     /// <param name="action">The continuation to call once the task is completed. The awaited task is passed in as a parameter.</param>

--- a/src/Proto.Actor/Context/ReenterAfterExtensions.cs
+++ b/src/Proto.Actor/Context/ReenterAfterExtensions.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+
+// ReSharper disable once CheckNamespace
+namespace Proto;
+
+/// <summary>
+/// Convenience overloads for <see cref="IContext.ReenterAfter"/> to avoid boilerplate when the
+/// continuation does not require the completed task or when it is synchronous.
+/// </summary>
+[PublicAPI]
+public static class ReenterAfterExtensions
+{
+    public static void ReenterAfter(this IContext context, Task target, Action action)
+        => context.ReenterAfter(target, _ =>
+        {
+            action();
+            return Task.CompletedTask;
+        });
+
+    public static void ReenterAfter(this IContext context, Task target, Func<Task> action)
+        => context.ReenterAfter(target, _ => action());
+
+    public static void ReenterAfter(this IContext context, Task target, Action<Task> action)
+        => context.ReenterAfter(target, t =>
+        {
+            action(t);
+            return Task.CompletedTask;
+        });
+
+    public static void ReenterAfter<T>(this IContext context, Task<T> target, Action action)
+        => context.ReenterAfter(target, _ =>
+        {
+            action();
+            return Task.CompletedTask;
+        });
+
+    public static void ReenterAfter<T>(this IContext context, Task<T> target, Func<Task> action)
+        => context.ReenterAfter(target, _ => action());
+
+    public static void ReenterAfter<T>(this IContext context, Task<T> target, Action<Task<T>> action)
+        => context.ReenterAfter(target, t =>
+        {
+            action(t);
+            return Task.CompletedTask;
+        });
+
+    public static void ReenterAfter<T>(this IContext context, Task<T> target, Action<T> action)
+        => context.ReenterAfter(target, async t =>
+        {
+            action(await t.ConfigureAwait(false));
+        });
+
+    public static void ReenterAfter<T>(this IContext context, Task<T> target, Func<T, Task> action)
+        => context.ReenterAfter(target, async t =>
+        {
+            var res = await t.ConfigureAwait(false);
+            await action(res).ConfigureAwait(false);
+        });
+}

--- a/src/Proto.Cluster.AzureContainerApps/Actors/AzureContainerAppsClusterMonitor.cs
+++ b/src/Proto.Cluster.AzureContainerApps/Actors/AzureContainerAppsClusterMonitor.cs
@@ -98,12 +98,10 @@ public class AzureContainerAppsClusterMonitor : IActor
         var registerMemberTask = RegisterMemberInternal();
 
         // Reenter after the member has been registered.
-        context.ReenterAfter(registerMemberTask, _ =>
+        context.ReenterAfter(registerMemberTask, () =>
         {
             // Schedule the first update.
             ScheduleUpdate(context);
-
-            return Task.CompletedTask;
         });
 
         return Task.CompletedTask;
@@ -122,12 +120,10 @@ public class AzureContainerAppsClusterMonitor : IActor
             return Task.CompletedTask;
 
         var updateMembersTask = UpdateMembersAsync();
-        context.ReenterAfter(updateMembersTask, _ =>
+        context.ReenterAfter(updateMembersTask, () =>
         {
             // Schedule the next update.
             ScheduleUpdate(context);
-
-            return Task.CompletedTask;
         });
 
         return Task.CompletedTask;

--- a/src/Proto.Cluster.AzureContainerApps/Actors/AzureContainerAppsClusterMonitor.cs
+++ b/src/Proto.Cluster.AzureContainerApps/Actors/AzureContainerAppsClusterMonitor.cs
@@ -102,6 +102,8 @@ public class AzureContainerAppsClusterMonitor : IActor
         {
             // Schedule the first update.
             ScheduleUpdate(context);
+
+            return Task.CompletedTask;
         });
 
         return Task.CompletedTask;
@@ -124,6 +126,8 @@ public class AzureContainerAppsClusterMonitor : IActor
         {
             // Schedule the next update.
             ScheduleUpdate(context);
+
+            return Task.CompletedTask;
         });
 
         return Task.CompletedTask;

--- a/src/Proto.Cluster/Identity/IdentityActivatorProxy.cs
+++ b/src/Proto.Cluster/Identity/IdentityActivatorProxy.cs
@@ -123,7 +123,7 @@ internal class IdentityActivatorProxy : IActor
                         }
 
                         context.ReenterAfter(Task.Delay(50 * attempt),
-                            () => ReplaceActivation(identity, replacedPid, context, attempt + 1));
+                            _ => ReplaceActivation(identity, replacedPid, context, attempt + 1));
 
                         return;
                     }

--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -548,7 +548,7 @@ internal class PartitionIdentityActor : IActor
                     msg.ClusterIdentity);
             }
 
-            context.ReenterAfter(_rebalanceTcs.Task, _ => OnActivationRequest(msg, context));
+            context.ReenterAfter(_rebalanceTcs.Task, () => OnActivationRequest(msg, context));
 
             return Task.CompletedTask;
         }

--- a/src/Proto.Cluster/Partition/PartitionIdentityRebalanceWorker.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityRebalanceWorker.cs
@@ -125,14 +125,10 @@ internal class PartitionIdentityRebalanceWorker : IActor, IDisposable
             default:
                 Logger.LogWarning("[PartitionIdentity] Partition {Member} unreachable", response.MemberAddress);
 
-                context.ReenterAfter(Task.Delay(200, _cancellationToken),
-                    _ =>
-                    {
-                        StartRebalanceFromMember(_request!, context, response.MemberAddress);
-
-                        return Task.CompletedTask;
-                    }
-                );
+                context.ReenterAfter(Task.Delay(200, _cancellationToken), () =>
+                {
+                    StartRebalanceFromMember(_request!, context, response.MemberAddress);
+                });
 
                 break;
         }
@@ -201,14 +197,11 @@ internal class PartitionIdentityRebalanceWorker : IActor, IDisposable
             context.Request(_targetMember, msg);
             context.SetReceiveTimeout(_timeout);
 
-            context.ReenterAfter(_completionSource.Task, _ =>
-                {
-                    context.Send(context.Parent!, _completionSource.Task.Result);
-                    context.Stop(context.Self);
-
-                    return Task.CompletedTask;
-                }
-            );
+            context.ReenterAfter(_completionSource.Task, () =>
+            {
+                context.Send(context.Parent!, _completionSource.Task.Result);
+                context.Stop(context.Self);
+            });
         }
 
         private void OnIdentityHandover(IdentityHandover response, IContext context)

--- a/src/Proto.Cluster/Partition/PartitionIdentityRebalanceWorker.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityRebalanceWorker.cs
@@ -126,7 +126,12 @@ internal class PartitionIdentityRebalanceWorker : IActor, IDisposable
                 Logger.LogWarning("[PartitionIdentity] Partition {Member} unreachable", response.MemberAddress);
 
                 context.ReenterAfter(Task.Delay(200, _cancellationToken),
-                    () => StartRebalanceFromMember(_request!, context, response.MemberAddress)
+                    _ =>
+                    {
+                        StartRebalanceFromMember(_request!, context, response.MemberAddress);
+
+                        return Task.CompletedTask;
+                    }
                 );
 
                 break;
@@ -196,10 +201,12 @@ internal class PartitionIdentityRebalanceWorker : IActor, IDisposable
             context.Request(_targetMember, msg);
             context.SetReceiveTimeout(_timeout);
 
-            context.ReenterAfter(_completionSource.Task, () =>
+            context.ReenterAfter(_completionSource.Task, _ =>
                 {
                     context.Send(context.Parent!, _completionSource.Task.Result);
                     context.Stop(context.Self);
+
+                    return Task.CompletedTask;
                 }
             );
         }

--- a/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionPlacementActor.cs
@@ -80,14 +80,13 @@ internal class PartitionPlacementActor : IActor, IDisposable
             .WaitUntilInFlightActivationsAreCompleted(_config.RebalanceActivationsCompletionTimeout, cancellationToken);
 
         // Waits until all members agree on a cluster topology and have no more in-flight activation requests
-        context.ReenterAfter(activationsCompleted, async _ =>
+        context.ReenterAfter(activationsCompleted, async () =>
+        {
+            if (!cancellationToken.IsCancellationRequested)
             {
-                if (!cancellationToken.IsCancellationRequested)
-                {
-                    await Rebalance(context, msg).ConfigureAwait(false);
-                }
+                await Rebalance(context, msg).ConfigureAwait(false);
             }
-        );
+        });
 
         return Task.CompletedTask;
     }

--- a/src/Proto.Cluster/PubSub/PubSubMemberDeliveryActor.cs
+++ b/src/Proto.Cluster/PubSub/PubSubMemberDeliveryActor.cs
@@ -39,11 +39,9 @@ public class PubSubMemberDeliveryActor : IActor
                     .Select(sub => DeliverBatch(context, topicBatch, sub))
                     .ToArray();
 
-            context.ReenterAfter(Task.WhenAll(tasks), _ =>
+            context.ReenterAfter(Task.WhenAll(tasks), () =>
             {
                 NotifyAboutInvalidDeliveries(tasks, deliveryBatch.Topic, context);
-
-                return Task.CompletedTask;
             });
         }
 

--- a/src/Proto.Cluster/PubSub/PubSubMemberDeliveryActor.cs
+++ b/src/Proto.Cluster/PubSub/PubSubMemberDeliveryActor.cs
@@ -39,8 +39,12 @@ public class PubSubMemberDeliveryActor : IActor
                     .Select(sub => DeliverBatch(context, topicBatch, sub))
                     .ToArray();
 
-            context.ReenterAfter(Task.WhenAll(tasks),
-                () => NotifyAboutInvalidDeliveries(tasks, deliveryBatch.Topic, context));
+            context.ReenterAfter(Task.WhenAll(tasks), _ =>
+            {
+                NotifyAboutInvalidDeliveries(tasks, deliveryBatch.Topic, context);
+
+                return Task.CompletedTask;
+            });
         }
 
         return Task.CompletedTask;

--- a/src/Proto.OpenTelemetry/OpenTelemetryActorContextDecorator.cs
+++ b/src/Proto.OpenTelemetry/OpenTelemetryActorContextDecorator.cs
@@ -77,20 +77,6 @@ internal class OpenTelemetryActorContextDecorator : ActorContextDecorator
         OpenTelemetryMethodsDecorators.Respond(message,
             () => base.Respond(message));
 
-    public override void ReenterAfter(Task target, Action action)
-    {
-        var current = Activity.Current?.Context ?? default;
-        var message = base.Message!;
-        var a2 = () =>
-        {
-            using var x = OpenTelemetryHelpers.BuildStartedActivity(current, Source, nameof(ReenterAfter), message,
-                _sendActivitySetup);
-            x?.SetTag(ProtoTags.ActionType, nameof(ReenterAfter));
-            action();
-        };
-        base.ReenterAfter(target, a2);
-    }
-
     public override void ReenterAfter<T>(Task<T> target, Func<Task<T>, Task> action)
     {
         var current = Activity.Current?.Context ?? default;
@@ -101,34 +87,6 @@ internal class OpenTelemetryActorContextDecorator : ActorContextDecorator
                 _sendActivitySetup);
             x?.SetTag(ProtoTags.ActionType, nameof(ReenterAfter));
             await action(t).ConfigureAwait(false);
-        };
-        base.ReenterAfter(target, a2);
-    }
-
-    public override void ReenterAfter(Task target, Action<Task> action)
-    {
-        var current = Activity.Current?.Context ?? default;
-        var message = base.Message!;
-        Action<Task> a2 = t =>
-        {
-            using var x = OpenTelemetryHelpers.BuildStartedActivity(current, Source, nameof(ReenterAfter), message,
-                _sendActivitySetup);
-            x?.SetTag(ProtoTags.ActionType, nameof(ReenterAfter));
-            action(t);
-        };
-        base.ReenterAfter(target, a2);
-    }
-
-    public override void ReenterAfter<T>(Task<T> target, Action<Task<T>> action)
-    {
-        var current = Activity.Current?.Context ?? default;
-        var message = base.Message!;
-        Action<Task<T>> a2 = t =>
-        {
-            using var x = OpenTelemetryHelpers.BuildStartedActivity(current, Source, nameof(ReenterAfter), message,
-                _sendActivitySetup);
-            x?.SetTag(ProtoTags.ActionType, nameof(ReenterAfter));
-            action(t);
         };
         base.ReenterAfter(target, a2);
     }

--- a/tests/Proto.Actor.Tests/ReenterAfterExtensionsDecoratorTests.cs
+++ b/tests/Proto.Actor.Tests/ReenterAfterExtensionsDecoratorTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Proto.Tests;
+
+public class ReenterAfterExtensionsDecoratorTests : ActorTestBase
+{
+    private sealed class CountingReenterDecorator : ActorContextDecorator
+    {
+        public int TaskCalls { get; private set; }
+        public int GenericTaskCalls { get; private set; }
+
+        public CountingReenterDecorator(IContext context) : base(context) { }
+
+        public override void ReenterAfter(Task target, Func<Task, Task> action)
+        {
+            TaskCalls++;
+            base.ReenterAfter(target, action);
+        }
+
+        public override void ReenterAfter<T>(Task<T> target, Func<Task<T>, Task> action)
+        {
+            GenericTaskCalls++;
+            base.ReenterAfter(target, action);
+        }
+    }
+
+    private async Task Verify(Func<IContext, TaskCompletionSource<bool>, Task> invoke,
+        int expectedTaskCalls, int expectedGenericTaskCalls)
+    {
+        CountingReenterDecorator? decorator = null;
+
+        var props = Props.FromFunc(ctx =>
+        {
+            if (ctx.Message is TaskCompletionSource<bool> tcs)
+            {
+                invoke(ctx, tcs);
+            }
+
+            return Task.CompletedTask;
+        }).WithContextDecorator(c => decorator = new CountingReenterDecorator(c));
+
+        var pid = Context.Spawn(props);
+
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Context.Send(pid, tcs);
+        await tcs.Task.ConfigureAwait(false);
+
+        decorator!.TaskCalls.Should().Be(expectedTaskCalls);
+        decorator.GenericTaskCalls.Should().Be(expectedGenericTaskCalls);
+    }
+
+    [Fact]
+    public Task Task_Action_Should_Call_Decorator() =>
+        Verify((ctx, tcs) =>
+        {
+            ctx.ReenterAfter(Task.CompletedTask, () => tcs.SetResult(true));
+            return Task.CompletedTask;
+        }, 1, 0);
+
+    [Fact]
+    public Task Task_Func_Should_Call_Decorator() =>
+        Verify((ctx, tcs) =>
+        {
+            ctx.ReenterAfter(Task.CompletedTask, async () =>
+            {
+                tcs.SetResult(true);
+                await Task.CompletedTask;
+            });
+            return Task.CompletedTask;
+        }, 1, 0);
+
+    [Fact]
+    public Task Task_ActionTask_Should_Call_Decorator() =>
+        Verify((ctx, tcs) =>
+        {
+            var task = Task.CompletedTask;
+            ctx.ReenterAfter(task, completed =>
+            {
+                tcs.SetResult(completed.IsCompleted);
+            });
+            return Task.CompletedTask;
+        }, 1, 0);
+
+    [Fact]
+    public Task Generic_Action_Should_Call_Decorator() =>
+        Verify((ctx, tcs) =>
+        {
+            ctx.ReenterAfter(Task.FromResult(1), () => tcs.SetResult(true));
+            return Task.CompletedTask;
+        }, 0, 1);
+
+    [Fact]
+    public Task Generic_Func_Should_Call_Decorator() =>
+        Verify((ctx, tcs) =>
+        {
+            ctx.ReenterAfter(Task.FromResult(1), async () =>
+            {
+                tcs.SetResult(true);
+                await Task.CompletedTask;
+            });
+            return Task.CompletedTask;
+        }, 0, 1);
+
+    [Fact]
+    public Task Generic_ActionTask_Should_Call_Decorator() =>
+        Verify((ctx, tcs) =>
+        {
+            ctx.ReenterAfter(Task.FromResult(1), task =>
+            {
+                tcs.SetResult(task.IsCompleted);
+            });
+            return Task.CompletedTask;
+        }, 0, 1);
+
+    [Fact]
+    public Task Generic_ActionResult_Should_Call_Decorator() =>
+        Verify((ctx, tcs) =>
+        {
+            ctx.ReenterAfter(Task.FromResult(1), result =>
+            {
+                tcs.SetResult(result == 1);
+            });
+            return Task.CompletedTask;
+        }, 0, 1);
+
+    [Fact]
+    public Task Generic_FuncResult_Should_Call_Decorator() =>
+        Verify((ctx, tcs) =>
+        {
+            ctx.ReenterAfter(Task.FromResult(1), async result =>
+            {
+                tcs.SetResult(result == 1);
+                await Task.CompletedTask;
+            });
+            return Task.CompletedTask;
+        }, 0, 1);
+}

--- a/tests/Proto.Actor.Tests/ReenterTests.cs
+++ b/tests/Proto.Actor.Tests/ReenterTests.cs
@@ -56,11 +56,9 @@ public class ReenterTests : ActorTestBase
                 if (ctx.Message is "reenter")
                 {
                     var delay = Task.Delay(500);
-                    ctx.ReenterAfter(delay, _ =>
+                    ctx.ReenterAfter(delay, () =>
                     {
                         ctx.Respond("response");
-
-                        return Task.CompletedTask;
                     });
                 }
 
@@ -84,11 +82,9 @@ public class ReenterTests : ActorTestBase
                 if (ctx.Message is "reenter")
                 {
                     var task = Task.FromResult(expectedResult);
-                    ctx.ReenterAfter(task, completedTask =>
+                    ctx.ReenterAfter(task, (int result) =>
                     {
-                        ctx.Respond(completedTask.Result);
-
-                        return Task.CompletedTask;
+                        ctx.Respond(result);
                     });
                 }
 
@@ -160,18 +156,15 @@ public class ReenterTests : ActorTestBase
                 if (ctx.Message is "reenter")
                 {
                     var task = Task.Run(async () =>
-                        {
-                            await Task.Delay(100);
+                    {
+                        await Task.Delay(100);
 
-                            throw new Exception("Failed!");
-                        }
-                    );
+                        throw new Exception("Failed!");
+                    });
 
-                    ctx.ReenterAfter(task, _ =>
+                    ctx.ReenterAfter(task, () =>
                     {
                         ctx.Respond("response");
-
-                        return Task.CompletedTask;
                     });
                 }
 
@@ -194,13 +187,10 @@ public class ReenterTests : ActorTestBase
                 {
                     var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                    ctx.ReenterAfter(tcs.Task, _ =>
-                        {
-                            ctx.Respond("response");
-
-                            return Task.CompletedTask;
-                        }
-                    );
+                    ctx.ReenterAfter(tcs.Task, () =>
+                    {
+                        ctx.Respond("response");
+                    });
 
                     tcs.TrySetCanceled();
                 }
@@ -231,20 +221,17 @@ public class ReenterTests : ActorTestBase
 
                     var task = Task.Delay(0);
 
-                    ctx.ReenterAfter(task, _ =>
+                    ctx.ReenterAfter(task, () =>
+                    {
+                        var res = Interlocked.Increment(ref activeCount);
+
+                        if (res != 1)
                         {
-                            var res = Interlocked.Increment(ref activeCount);
-
-                            if (res != 1)
-                            {
-                                correct = false;
-                            }
-
-                            Interlocked.Decrement(ref activeCount);
-
-                            return Task.CompletedTask;
+                            correct = false;
                         }
-                    );
+
+                        Interlocked.Decrement(ref activeCount);
+                    });
                 }
 
                 return Task.CompletedTask;
@@ -279,11 +266,9 @@ public class ReenterTests : ActorTestBase
 
                         ctx.ReenterAfter(
                             Task.Delay(-1, cts.Token),
-                            _ =>
+                            () =>
                             {
                                 completionExecuted = true;
-
-                                return Task.CompletedTask;
                             });
 
                         ctx.Self.SendSystemMessage(ctx.System, new Restart(new Exception()));
@@ -339,11 +324,9 @@ public class ReenterTests : ActorTestBase
 
                         ctx.ReenterAfter(
                             Task.Delay(-1, cts.Token),
-                            _ =>
+                            () =>
                             {
                                 completionExecuted = true;
-
-                                return Task.CompletedTask;
                             });
                         
                         ctx.Stop(ctx.Self);

--- a/tests/Proto.Actor.Tests/ReenterTests.cs
+++ b/tests/Proto.Actor.Tests/ReenterTests.cs
@@ -56,7 +56,12 @@ public class ReenterTests : ActorTestBase
                 if (ctx.Message is "reenter")
                 {
                     var delay = Task.Delay(500);
-                    ctx.ReenterAfter(delay, () => { ctx.Respond("response"); });
+                    ctx.ReenterAfter(delay, _ =>
+                    {
+                        ctx.Respond("response");
+
+                        return Task.CompletedTask;
+                    });
                 }
 
                 return Task.CompletedTask;
@@ -79,7 +84,12 @@ public class ReenterTests : ActorTestBase
                 if (ctx.Message is "reenter")
                 {
                     var task = Task.FromResult(expectedResult);
-                    ctx.ReenterAfter(task, completedTask => { ctx.Respond(completedTask.Result); });
+                    ctx.ReenterAfter(task, completedTask =>
+                    {
+                        ctx.Respond(completedTask.Result);
+
+                        return Task.CompletedTask;
+                    });
                 }
 
                 return Task.CompletedTask;
@@ -157,7 +167,12 @@ public class ReenterTests : ActorTestBase
                         }
                     );
 
-                    ctx.ReenterAfter(task, () => { ctx.Respond("response"); });
+                    ctx.ReenterAfter(task, _ =>
+                    {
+                        ctx.Respond("response");
+
+                        return Task.CompletedTask;
+                    });
                 }
 
                 return Task.CompletedTask;
@@ -216,7 +231,7 @@ public class ReenterTests : ActorTestBase
 
                     var task = Task.Delay(0);
 
-                    ctx.ReenterAfter(task, () =>
+                    ctx.ReenterAfter(task, _ =>
                         {
                             var res = Interlocked.Increment(ref activeCount);
 
@@ -226,6 +241,8 @@ public class ReenterTests : ActorTestBase
                             }
 
                             Interlocked.Decrement(ref activeCount);
+
+                            return Task.CompletedTask;
                         }
                     );
                 }
@@ -262,7 +279,12 @@ public class ReenterTests : ActorTestBase
 
                         ctx.ReenterAfter(
                             Task.Delay(-1, cts.Token),
-                            () => { completionExecuted = true; });
+                            _ =>
+                            {
+                                completionExecuted = true;
+
+                                return Task.CompletedTask;
+                            });
 
                         ctx.Self.SendSystemMessage(ctx.System, new Restart(new Exception()));
                         // Release the cancellation token after restart gets processed.
@@ -317,7 +339,12 @@ public class ReenterTests : ActorTestBase
 
                         ctx.ReenterAfter(
                             Task.Delay(-1, cts.Token),
-                            () => { completionExecuted = true; });
+                            _ =>
+                            {
+                                completionExecuted = true;
+
+                                return Task.CompletedTask;
+                            });
                         
                         ctx.Stop(ctx.Self);
                         

--- a/tests/Proto.OpenTelemetry.Tests/OpenTelemetryTracingTests.cs
+++ b/tests/Proto.OpenTelemetry.Tests/OpenTelemetryTracingTests.cs
@@ -149,9 +149,6 @@ public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
     [Theory]
     [InlineData(SendAs.ReEnterAfter1)]
     [InlineData(SendAs.ReEnterAfter2)]
-    [InlineData(SendAs.ReEnterAfter3)]
-    [InlineData(SendAs.ReEnterAfter4)]
-    [InlineData(SendAs.ReEnterAfter5)]
     public async Task TracesPropagateCorrectlyWithBaggageForReEnterAfter(SendAs reEnterType) =>
         await VerifyTrace(async (rootContext, target) =>
             {
@@ -263,10 +260,7 @@ public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
         Forward,
         Invalid,
         ReEnterAfter1, // void ReenterAfter<T>(Task<T> target, Func<Task<T>, Task> action);
-        ReEnterAfter2, // void ReenterAfter(Task target, Action action);
-        ReEnterAfter3, // void ReenterAfter(Task target, Action<Task> action);
-        ReEnterAfter4, // void ReenterAfter<T>(Task<T> target, Action<Task<T>> action);
-        ReEnterAfter5, // void ReenterAfter(Task target, Func<Task, Task> action);
+        ReEnterAfter2, // void ReenterAfter(Task target, Func<Task, Task> action);
     }
 
     private record TraceMe(SendAs Method);
@@ -320,18 +314,6 @@ public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
 
                     break;
                 case SendAs.ReEnterAfter2:
-                    context.ReenterAfter(Task.CompletedTask, () => context.Forward(target));
-
-                    break;
-                case SendAs.ReEnterAfter3:
-                    context.ReenterAfter(Task.CompletedTask, _ => context.Forward(target));
-
-                    break;
-                case SendAs.ReEnterAfter4:
-                    context.ReenterAfter(Task.FromResult(1), _ => context.Forward(target));
-
-                    break;
-                case SendAs.ReEnterAfter5:
                     context.ReenterAfter(Task.CompletedTask, _ =>
                     {
                         context.Forward(target);

--- a/tests/Proto.OpenTelemetry.Tests/OpenTelemetryTracingTests.cs
+++ b/tests/Proto.OpenTelemetry.Tests/OpenTelemetryTracingTests.cs
@@ -306,18 +306,16 @@ public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
 
                     break;
                 case SendAs.ReEnterAfter1:
-                    context.ReenterAfter(Task.FromResult(1), _ =>
+                    context.ReenterAfter(Task.FromResult(1), () =>
                     {
                         context.Forward(target);
-                        return Task.CompletedTask;
                     });
 
                     break;
                 case SendAs.ReEnterAfter2:
-                    context.ReenterAfter(Task.CompletedTask, _ =>
+                    context.ReenterAfter(Task.CompletedTask, () =>
                     {
                         context.Forward(target);
-                        return Task.CompletedTask;
                     });
 
                     break;


### PR DESCRIPTION
## Summary
- centralize actor reentrancy logic via generic `ContinueReenter`
- simplify `IContext` to two `ReenterAfter` overloads
- update contexts, decorators, and tests to use new unified form

## Testing
- `dotnet build ProtoActor.sln`
- `dotnet test ProtoActor.sln` *(fails: Docker is either not running or misconfigured)*

------
https://chatgpt.com/codex/tasks/task_e_68a316af5b108328bf9ad9a0e9c6e12b