### PR TITLE
Add Proto.TestKit example with probes and fixture

### DIFF
--- a/examples/actor.testkit/Actor.TestKit.csproj
+++ b/examples/actor.testkit/Actor.TestKit.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Proto.Actor\Proto.Actor.csproj" />
+    <ProjectReference Include="..\..\src\Proto.TestKit\Proto.TestKit.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+</Project>

--- a/examples/actor.testkit/EchoActor.cs
+++ b/examples/actor.testkit/EchoActor.cs
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------
+// <copyright file="EchoActor.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Proto;
+
+namespace ActorTestKit;
+
+public record Ping(string Who);
+public record Pong(string Who);
+
+// A simple actor that responds to Ping with Pong.
+public class EchoActor : IActor
+{
+    public Task ReceiveAsync(IContext context)
+    {
+        if (context.Message is Ping ping)
+        {
+            context.Respond(new Pong(ping.Who));
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/examples/actor.testkit/EchoActorTests.cs
+++ b/examples/actor.testkit/EchoActorTests.cs
@@ -1,0 +1,45 @@
+// -----------------------------------------------------------------------
+// <copyright file="EchoActorTests.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using FluentAssertions;
+using Proto.TestKit;
+using Xunit;
+
+namespace ActorTestKit;
+
+public class EchoActorTests : IClassFixture<TestKitFixture>
+{
+    private readonly TestKitFixture _fixture;
+
+    public EchoActorTests(TestKitFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public void Actor_replies_using_fixture_probe()
+    {
+        // Spawn the actor under test
+        var pid = _fixture.Spawn<EchoActor>();
+
+        // Send a message via the fixture's probe
+        _fixture.Request(pid, new Ping("Proto"));
+
+        // Probes capture messages and allow typed assertions
+        var reply = _fixture.GetNextMessage<Pong>();
+        reply.Who.Should().Be("Proto");
+    }
+
+    [Fact]
+    public void Dedicated_probe_captures_messages()
+    {
+        // Create a separate probe
+        TestProbe probe = _fixture.CreateTestProbe();
+
+        // Send a message directly to the probe
+        _fixture.Context.Send(probe, "hello");
+
+        probe.GetNextMessage<string>().Should().Be("hello");
+        probe.ExpectNoMessage();
+    }
+}

--- a/examples/actor.testkit/README.md
+++ b/examples/actor.testkit/README.md
@@ -1,0 +1,26 @@
+# Actor TestKit Example
+
+This example shows how to test actors using [`Proto.TestKit`](https://github.com/asynkron/protoactor-dotnet).
+
+`TestKitFixture` sets up an `ActorSystem` and a default `TestProbe`.  A probe is an actor that stores
+incoming messages, allowing tests to inspect them later.
+
+```csharp
+var pid = _fixture.Spawn<EchoActor>();
+_fixture.Request(pid, new Ping("Proto"));
+var reply = _fixture.GetNextMessage<Pong>();
+```
+
+`GetNextMessage<T>` dequeues the next message of the specified type. If the type does not match or no
+message arrives within the default timeout, a `TestKitException` is thrown. `ExpectNoMessage` asserts
+that the probe did not receive anything during the interval.
+
+Additional probes can be created when isolation between tests is needed:
+
+```csharp
+var probe = _fixture.CreateTestProbe();
+_fixture.Context.Send(probe, "hello");
+probe.GetNextMessage<string>();
+```
+
+Probes capture messages in FIFO order, so assertions reflect the sequence of events in the actor under test.

--- a/examples/actor.testkit/TestKitFixture.cs
+++ b/examples/actor.testkit/TestKitFixture.cs
@@ -1,0 +1,18 @@
+// -----------------------------------------------------------------------
+// <copyright file="TestKitFixture.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Proto.TestKit;
+
+namespace ActorTestKit;
+
+// xUnit fixture that sets up and tears down the TestKit probe and system.
+public class TestKitFixture : TestKitBase, IDisposable
+{
+    public TestKitFixture() => SetUp();
+
+    public void Dispose() => TearDown();
+}


### PR DESCRIPTION
## Summary
- add actor.testkit example with EchoActor and xUnit tests
- explain TestKit probes and assertions in README

## Testing
- `dotnet test examples/actor.testkit/Actor.TestKit.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a636a72bc083288505d3a736c55546