### PR TITLE
Use TotalSeconds in TestProbe messages

### DIFF
--- a/src/Proto.TestKit/TestProbe.cs
+++ b/src/Proto.TestKit/TestProbe.cs
@@ -77,7 +77,8 @@ public class TestProbe : IActor, ITestProbe
 
         if (_messageQueue.TryTake(out var o, time))
         {
-            throw new TestKitException($"Waited {time.Seconds} seconds and received a message of type {o.GetType()}");
+            var seconds = time.TotalSeconds.ToString("0.###");
+            throw new TestKitException($"Waited {seconds} seconds and received a message of type {o.GetType()}");
         }
     }
 
@@ -88,7 +89,8 @@ public class TestProbe : IActor, ITestProbe
 
         if (!_messageQueue.TryTake(out var output, time))
         {
-            throw new TestKitException($"Waited {time.Seconds} seconds but failed to receive a message");
+            var seconds = time.TotalSeconds.ToString("0.###");
+            throw new TestKitException($"Waited {seconds} seconds but failed to receive a message");
         }
 
         Sender = output?.Sender;

--- a/tests/Proto.TestKit.Tests/MessageFiltering.cs
+++ b/tests/Proto.TestKit.Tests/MessageFiltering.cs
@@ -97,8 +97,12 @@ namespace Proto.TestKit.Tests
         }
 
         [Fact]
-        public void GetFailsNoMessage() => this.Invoking(_ => GetNextMessage<DateTime>())
-            .Should().Throw<TestKitException>().WithMessage("Waited 1 seconds but failed to receive a message");
+        public void GetFailsNoMessage()
+        {
+            var seconds = TimeSpan.FromSeconds(1).TotalSeconds.ToString("0.###");
+            this.Invoking(_ => GetNextMessage<DateTime>())
+                .Should().Throw<TestKitException>().WithMessage($"Waited {seconds} seconds but failed to receive a message");
+        }
 
         [Fact]
         public void GetFailsCondition()
@@ -112,8 +116,9 @@ namespace Proto.TestKit.Tests
         public void ExpectNoMessageFails()
         {
             Send(Probe, "hi");
+            var seconds = TimeSpan.FromSeconds(1).TotalSeconds.ToString("0.###");
             this.Invoking(_ => ExpectNoMessage())
-                .Should().Throw<TestKitException>().WithMessage("Waited 1 seconds and received a message of type Proto.TestKit.MessageAndSender");
+                .Should().Throw<TestKitException>().WithMessage($"Waited {seconds} seconds and received a message of type Proto.TestKit.MessageAndSender");
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- report full wait time when TestProbe times out or receives unexpected messages
- update unit tests for new timeout text

## Testing
- `dotnet test tests/Proto.TestKit.Tests/Proto.TestKit.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a6c4e368208328882d4596ccc3c516