### PR TITLE
Add mailbox probe and system message support to TestKit

### DIFF
--- a/src/Proto.TestKit/ProbeMailboxStatistics.cs
+++ b/src/Proto.TestKit/ProbeMailboxStatistics.cs
@@ -1,0 +1,28 @@
+using Proto.Mailbox;
+
+namespace Proto.TestKit;
+
+/// <summary>
+/// IMailboxStatistics implementation that forwards processed messages to a <see cref="TestProbe"/>.
+/// </summary>
+public class ProbeMailboxStatistics : IMailboxStatistics
+{
+    private readonly TestProbe _probe;
+
+    public ProbeMailboxStatistics(TestProbe probe) => _probe = probe;
+
+    public void MailboxStarted()
+    {
+    }
+
+    public void MessagePosted(object message)
+    {
+    }
+
+    public void MessageReceived(object message) =>
+        _probe.Context.Send(_probe.Context.Self, message);
+
+    public void MailboxEmpty()
+    {
+    }
+}

--- a/src/Proto.TestKit/PropsTestProbeExtensions.cs
+++ b/src/Proto.TestKit/PropsTestProbeExtensions.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Proto.Mailbox;
 
 namespace Proto.TestKit;
 
@@ -26,4 +27,11 @@ public static class PropsTestProbeExtensions
             probe.Context.Send(probe.Context.Self, new MessageEnvelope(env.Message, target));
             await next(ctx, target, env);
         });
+
+    /// <summary>
+    /// Captures messages processed by the mailbox using <see cref="ProbeMailboxStatistics"/>.
+    /// Existing send and receive middleware can still be chained.
+    /// </summary>
+    public static Props WithTestMailboxProbe(this Props props, TestProbe probe) =>
+        props.WithMailbox(() => UnboundedMailbox.Create(new ProbeMailboxStatistics(probe)));
 }

--- a/src/Proto.TestKit/TestProbe.cs
+++ b/src/Proto.TestKit/TestProbe.cs
@@ -35,7 +35,7 @@ public class TestProbe : IActor, ITestProbe
                 _channel.Writer.TryWrite(new MessageAndSender(context));
 
                 break;
-            case SystemMessage _: return Task.CompletedTask;
+            case SystemMessage _:
             default:
                 _channel.Writer.TryWrite(new MessageAndSender(context));
 

--- a/src/Proto.TestKit/TestProbeSystemMessageExtensions.cs
+++ b/src/Proto.TestKit/TestProbeSystemMessageExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Proto.Mailbox;
+
+namespace Proto.TestKit;
+
+/// <summary>
+/// Convenience methods for expecting <see cref="Proto.SystemMessage"/> instances.
+/// </summary>
+public static class TestProbeSystemMessageExtensions
+{
+    /// <summary>
+    /// Retrieves the next system message of type <typeparamref name="T"/>.
+    /// </summary>
+    public static T ExpectSystemMessage<T>(this ITestProbe probe, TimeSpan? timeAllowed = null)
+        where T : SystemMessage => probe.GetNextMessage<T>(timeAllowed);
+
+    /// <summary>
+    /// Asynchronously retrieves the next system message of type <typeparamref name="T"/>.
+    /// </summary>
+    public static Task<T> ExpectSystemMessageAsync<T>(this ITestProbe probe, TimeSpan? timeAllowed = null,
+        CancellationToken cancellationToken = default)
+        where T : SystemMessage => probe.GetNextMessageAsync<T>(timeAllowed, cancellationToken);
+}

--- a/tests/Proto.TestKit.Tests/ProbeMiddlewareTests.cs
+++ b/tests/Proto.TestKit.Tests/ProbeMiddlewareTests.cs
@@ -37,6 +37,23 @@ public class ProbeMiddlewareTests
         probe.Sender.Should().Be(target);
     }
 
+    [Fact]
+    public void Mailbox_probe_captures_messages_and_system_messages()
+    {
+        var system = new ActorSystem();
+        var probe = new TestProbe();
+        system.Root.Spawn(Props.FromProducer(() => probe));
+
+        var props = Props.FromProducer(() => new EmptyActor()).WithTestMailboxProbe(probe);
+        var pid = system.Root.Spawn(props);
+
+        system.Root.Send(pid, "hello");
+        probe.GetNextMessage<string>().Should().Be("hello");
+
+        system.Root.Stop(pid);
+        probe.ExpectSystemMessage<Stop>();
+    }
+
     private class EmptyActor : IActor
     {
         public Task ReceiveAsync(IContext context) => Task.CompletedTask;


### PR DESCRIPTION
## Summary
- forward processed messages to probes via new `ProbeMailboxStatistics`
- expose `WithTestMailboxProbe` to attach mailbox probes
- record and assert system messages with `ExpectSystemMessage` helpers

## Testing
- `dotnet test tests/Proto.TestKit.Tests/Proto.TestKit.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a6de9084a083289a27a65dc5c6b246