### PR TITLE
refactor: use TestProbe for system message assertions

### DIFF
--- a/tests/Proto.Actor.Tests/SupervisionTests_AlwaysRestart.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_AlwaysRestart.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Proto.Mailbox;
-using Proto.TestFixtures;
+using Proto.TestKit;
 using Xunit;
 
 namespace Proto.Tests;
@@ -43,20 +42,14 @@ public class SupervisionTestsAlwaysRestart
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var restartCount = 0;
-        var childMailboxStats = new TestMailboxStatistics(msg =>
-        {
-            if (msg is Restart)
-            {
-                restartCount++;
-                return restartCount == 3;
-            }
-
-            return false;
-        });
+        // probe child mailbox to observe Restart system messages
+        var probe = new TestProbe();
+        var probePid = system.Root.Spawn(Props.FromProducer(() => probe));
+        context.Send(probePid, "start");
+        await probe.FishForMessageAsync<string>();
 
         var childProps = Props.FromProducer(() => new ChildActor())
-            .WithMailbox(() => UnboundedMailbox.Create(childMailboxStats));
+            .WithTestMailboxProbe(probe);
 
         var parentProps = Props.FromProducer(() => new ParentActor(childProps))
             .WithChildSupervisorStrategy(Supervision.AlwaysRestartStrategy);
@@ -67,9 +60,15 @@ public class SupervisionTestsAlwaysRestart
         context.Send(parent, "2");
         context.Send(parent, "3");
 
-        Assert.True(childMailboxStats.Reset.Wait(TimeSpan.FromSeconds(2)));
-        Assert.Equal(3, childMailboxStats.Received.OfType<Restart>().Count());
-        Assert.DoesNotContain(childMailboxStats.Posted, msg => msg is Stop);
+        for (var i = 0; i < 3; i++)
+        {
+            var restart = await probe.FishForMessageAsync<Restart>();
+            Assert.Equal(Exception, restart.Reason);
+        }
+
+        // Ensure no Stop message was processed
+        await Assert.ThrowsAsync<TestKitException>(
+            async () => await probe.FishForMessageAsync<Stop>(TimeSpan.FromMilliseconds(100)));
     }
 
     private class ParentActor : IActor

--- a/tests/Proto.Actor.Tests/UnknownSystemMessageTests.cs
+++ b/tests/Proto.Actor.Tests/UnknownSystemMessageTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Proto.Mailbox;
-using Proto.TestFixtures;
+using Proto.TestKit;
 using Xunit;
 
 namespace Proto.Tests;
@@ -46,19 +46,25 @@ public class UnknownSystemMessageTests
     public async Task Unknown_system_message_should_escalate_to_parent()
     {
         await using var system = new ActorSystem();
-        var parentStats = new TestMailboxStatistics(m => m is Failure);
+
+        // Attach a probe to the parent mailbox to observe system messages such as Failure
+        var probe = new TestProbe();
+        var probePid = system.Root.Spawn(Props.FromProducer(() => probe));
+        // ensure the probe is fully started before it is used
+        system.Root.Send(probePid, "init");
+        await probe.FishForMessageAsync<string>();
 
         var childProps = Props.FromFunc(ctx => Task.CompletedTask);
         var parentProps = Props.FromProducer(() => new ParentActor(childProps))
-            .WithMailbox(() => UnboundedMailbox.Create(parentStats));
+            .WithTestMailboxProbe(probe);
 
         var parent = system.Root.Spawn(parentProps);
         var child = await system.Root.RequestAsync<PID>(parent, new GetChild());
 
         child.SendSystemMessage(system, new UnknownSystemMessage());
 
-        Assert.True(parentStats.Reset.Wait(TimeSpan.FromSeconds(5)));
-        var failure = Assert.Single(parentStats.Received.OfType<Failure>());
+        // The parent should receive a Failure describing the child and exception
+        var failure = await probe.FishForMessageAsync<Failure>();
         Assert.Equal(child, failure.Who);
         Assert.IsType<InvalidOperationException>(failure.Reason);
     }


### PR DESCRIPTION
## Summary
- ensure TestProbe is fully started before observing system messages
- replace TestMailboxStatistics with TestProbe in AlwaysRestart supervision tests

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj --filter "FullyQualifiedName~UnknownSystemMessageTests"`
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj --filter "FullyQualifiedName~SupervisionTestsAlwaysRestart"`


------
https://chatgpt.com/codex/tasks/task_e_68a6e4cd258083288e267d6649bb9d10