### PR TITLE
feat(testkit): move mailbox stats and simplify probe API

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,33 @@ You should see the output `Hello Alex`.
 
 [https://github.com/asynkron/realtimemap-dotnet](https://github.com/asynkron/realtimemap-dotnet)
 
+## TestKit
+
+Proto.Actor includes a TestKit library for unit testing actors.
+
+- **TestProbe** is an actor that records incoming messages. The API is fully asynchronous:
+
+  ```csharp
+  var probe = new TestProbe();
+  system.Root.Spawn(Props.FromProducer(() => probe));
+  await probe.GetNextMessageAsync<string>();
+  await probe.ExpectNoMessageAsync(TimeSpan.FromMilliseconds(100));
+  ```
+
+- **TestMailboxStats** captures mailbox events such as posted and received messages:
+
+  ```csharp
+  var stats = new TestMailboxStats(msg => msg is MyMessage);
+  var props = Props.FromProducer(() => new MyActor())
+      .WithMailbox(() => UnboundedMailbox.Create(stats));
+  ```
+
+- **Props extensions** help observe actor behavior:
+
+  - `WithReceiveProbe` intercepts messages an actor receives.
+  - `WithSendProbe` observes messages an actor sends.
+  - `WithMailboxProbe` taps into mailbox traffic using `ProbeMailboxStatistics`.
+
 ## Contributors
 
 <a href="https://github.com/asynkron/protoactor-dotnet/graphs/contributors">

--- a/src/Proto.TestKit/ITestProbe.cs
+++ b/src/Proto.TestKit/ITestProbe.cs
@@ -5,8 +5,6 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,7 +16,7 @@ namespace Proto.TestKit;
 public interface ITestProbe
 {
     /// <summary>
-    ///     the sender of the last message retrieved from GetNextMessage or FishForMessage
+    ///     the sender of the last message retrieved from GetNextMessageAsync or FishForMessageAsync
     /// </summary>
     PID? Sender { get; }
 
@@ -28,34 +26,11 @@ public interface ITestProbe
     IContext? Context { get; }
 
     /// <summary>
-    ///     this method will throw an exception if the probe receives a message within the time allowed
+    ///     asynchronously checks that no message arrives within the time allowed
     /// </summary>
     /// <param name="timeAllowed"></param>
-    void ExpectNoMessage(TimeSpan? timeAllowed = null);
-
-    /// <summary>
-    ///     gets the next message from the test probe
-    /// </summary>
-    /// <param name="timeAllowed"></param>
-    /// <returns></returns>
-    object? GetNextMessage(TimeSpan? timeAllowed = null);
-
-    /// <summary>
-    ///     gets the next message from the test probe
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="timeAllowed"></param>
-    /// <returns></returns>
-    T GetNextMessage<T>(TimeSpan? timeAllowed = null);
-
-    /// <summary>
-    ///     gets the next message from the test probe
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="when"></param>
-    /// <param name="timeAllowed"></param>
-    /// <returns></returns>
-    T GetNextMessage<T>(Func<T, bool> when, TimeSpan? timeAllowed = null);
+    /// <param name="cancellationToken"></param>
+    Task ExpectNoMessageAsync(TimeSpan? timeAllowed = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     asynchronously gets the next message from the test probe
@@ -104,47 +79,6 @@ public interface ITestProbe
     /// <returns></returns>
     Task<T> FishForMessageAsync<T>(Func<T, bool> when, TimeSpan? timeAllowed = null,
         CancellationToken cancellationToken = default);
-
-    /// <summary>
-    ///     keeps returning messages until the interval between messages exceeds the time allowed
-    /// </summary>
-    /// <param name="timeAllowed"></param>
-    /// <returns></returns>
-    IEnumerable ProcessMessages(TimeSpan? timeAllowed = null);
-
-    /// <summary>
-    ///     keeps returning messages until the interval between messages exceeds the time allowed
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="timeAllowed"></param>
-    /// <returns></returns>
-    IEnumerable<T> ProcessMessages<T>(TimeSpan? timeAllowed = null);
-
-    /// <summary>
-    ///     keeps returning messages until the interval between messages exceeds the time allowed
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="when"></param>
-    /// <param name="timeAllowed"></param>
-    /// <returns></returns>
-    IEnumerable<T> ProcessMessages<T>(Func<T, bool> when, TimeSpan? timeAllowed = null);
-
-    /// <summary>
-    ///     fishes for the next message of a given type from the test probe
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="timeAllowed"></param>
-    /// <returns></returns>
-    T FishForMessage<T>(TimeSpan? timeAllowed = null);
-
-    /// <summary>
-    ///     fishes for the next message of a given type from the test probe
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="when"></param>
-    /// <param name="timeAllowed"></param>
-    /// <returns></returns>
-    T FishForMessage<T>(Func<T, bool> when, TimeSpan? timeAllowed = null);
 
     /// <summary>
     ///     sends a message from the test probe to the target

--- a/src/Proto.TestKit/PropsTestProbeExtensions.cs
+++ b/src/Proto.TestKit/PropsTestProbeExtensions.cs
@@ -11,7 +11,7 @@ public static class PropsTestProbeExtensions
     /// <summary>
     /// Captures messages received by the actor after they are processed.
     /// </summary>
-    public static Props WithTestReceiveProbe(this Props props, TestProbe probe) =>
+    public static Props WithReceiveProbe(this Props props, TestProbe probe) =>
         props.WithReceiverMiddleware(next => async (ctx, env) =>
         {
             await next(ctx, env);
@@ -21,7 +21,7 @@ public static class PropsTestProbeExtensions
     /// <summary>
     /// Captures messages sent by the actor before they are delivered to the target.
     /// </summary>
-    public static Props WithTestSendProbe(this Props props, TestProbe probe) =>
+    public static Props WithSendProbe(this Props props, TestProbe probe) =>
         props.WithSenderMiddleware(next => async (ctx, target, env) =>
         {
             probe.Context.Send(probe.Context.Self, new MessageEnvelope(env.Message, target));
@@ -32,6 +32,6 @@ public static class PropsTestProbeExtensions
     /// Captures messages processed by the mailbox using <see cref="ProbeMailboxStatistics"/>.
     /// Existing send and receive middleware can still be chained.
     /// </summary>
-    public static Props WithTestMailboxProbe(this Props props, TestProbe probe) =>
+    public static Props WithMailboxProbe(this Props props, TestProbe probe) =>
         props.WithMailbox(() => UnboundedMailbox.Create(new ProbeMailboxStatistics(probe)));
 }

--- a/src/Proto.TestKit/TestMailboxStats.cs
+++ b/src/Proto.TestKit/TestMailboxStats.cs
@@ -3,17 +3,20 @@ using System.Collections.Generic;
 using System.Threading;
 using Proto.Mailbox;
 
-namespace Proto.TestFixtures;
+namespace Proto.TestKit;
 
-public class TestMailboxStatistics : IMailboxStatistics
+/// <summary>
+/// IMailboxStatistics implementation used to collect mailbox events in tests.
+/// </summary>
+public class TestMailboxStats : IMailboxStatistics
 {
-    private readonly Func<object, bool> _waitForReceived;
+    private readonly Func<object, bool>? _waitForReceived;
 
-    public TestMailboxStatistics()
+    public TestMailboxStats()
     {
     }
 
-    public TestMailboxStatistics(Func<object, bool> waitForReceived)
+    public TestMailboxStats(Func<object, bool> waitForReceived)
     {
         _waitForReceived = waitForReceived;
     }

--- a/src/Proto.TestKit/TestProbe.cs
+++ b/src/Proto.TestKit/TestProbe.cs
@@ -5,8 +5,6 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -64,16 +62,15 @@ public class TestProbe : IActor, ITestProbe
     }
 
     /// <inheritdoc />
-    public void ExpectNoMessage(TimeSpan? timeAllowed = null)
+    public async Task ExpectNoMessageAsync(TimeSpan? timeAllowed = null, CancellationToken cancellationToken = default)
     {
-        var time = timeAllowed ?? TimeSpan.FromSeconds(1);
-
-        using var cts = new CancellationTokenSource(time);
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(timeAllowed ?? TimeSpan.FromSeconds(1));
 
         try
         {
-            var item = _channel.Reader.ReadAsync(cts.Token).AsTask().GetAwaiter().GetResult();
-            var seconds = time.TotalSeconds.ToString("0.###");
+            var item = await _channel.Reader.ReadAsync(cts.Token);
+            var seconds = (timeAllowed ?? TimeSpan.FromSeconds(1)).TotalSeconds.ToString("0.###");
             throw new TestKitException($"Waited {seconds} seconds and received a message of type {item.Message.GetType()}");
         }
         catch (OperationCanceledException)
@@ -81,86 +78,6 @@ public class TestProbe : IActor, ITestProbe
             // expected - no message arrived
         }
     }
-
-    /// <inheritdoc />
-    public object? GetNextMessage(TimeSpan? timeAllowed = null) =>
-        GetNextMessageAsync(timeAllowed).GetAwaiter().GetResult();
-
-    /// <inheritdoc />
-    public T GetNextMessage<T>(TimeSpan? timeAllowed = null) =>
-        GetNextMessageAsync<T>(timeAllowed).GetAwaiter().GetResult();
-
-    /// <inheritdoc />
-    public T GetNextMessage<T>(Func<T, bool> when, TimeSpan? timeAllowed = null) =>
-        GetNextMessageAsync(when, timeAllowed).GetAwaiter().GetResult();
-
-    /// <inheritdoc />
-    public IEnumerable ProcessMessages(TimeSpan? timeAllowed = null)
-    {
-        while (true)
-        {
-            object? message;
-
-            try
-            {
-                message = GetNextMessage(timeAllowed);
-            }
-            catch
-            {
-                yield break;
-            }
-
-            yield return message;
-        }
-    }
-
-    /// <inheritdoc />
-    public IEnumerable<T> ProcessMessages<T>(TimeSpan? timeAllowed = null)
-    {
-        while (true)
-        {
-            T message;
-
-            try
-            {
-                message = FishForMessage<T>(timeAllowed);
-            }
-            catch
-            {
-                yield break;
-            }
-
-            yield return message;
-        }
-    }
-
-    /// <inheritdoc />
-    public IEnumerable<T> ProcessMessages<T>(Func<T, bool> when, TimeSpan? timeAllowed = null)
-    {
-        while (true)
-        {
-            T message;
-
-            try
-            {
-                message = FishForMessage(when, timeAllowed);
-            }
-            catch
-            {
-                yield break;
-            }
-
-            yield return message;
-        }
-    }
-
-    /// <inheritdoc />
-    public T FishForMessage<T>(TimeSpan? timeAllowed = null) =>
-        FishForMessageAsync<T>(timeAllowed).GetAwaiter().GetResult();
-
-    /// <inheritdoc />
-    public T FishForMessage<T>(Func<T, bool> when, TimeSpan? timeAllowed = null) =>
-        FishForMessageAsync(when, timeAllowed).GetAwaiter().GetResult();
 
     /// <inheritdoc />
     public async Task<object?> GetNextMessageAsync(TimeSpan? timeAllowed = null,

--- a/src/Proto.TestKit/TestProbeSystemMessageExtensions.cs
+++ b/src/Proto.TestKit/TestProbeSystemMessageExtensions.cs
@@ -11,12 +11,6 @@ namespace Proto.TestKit;
 public static class TestProbeSystemMessageExtensions
 {
     /// <summary>
-    /// Retrieves the next system message of type <typeparamref name="T"/>.
-    /// </summary>
-    public static T ExpectSystemMessage<T>(this ITestProbe probe, TimeSpan? timeAllowed = null)
-        where T : SystemMessage => probe.GetNextMessage<T>(timeAllowed);
-
-    /// <summary>
     /// Asynchronously retrieves the next system message of type <typeparamref name="T"/>.
     /// </summary>
     public static Task<T> ExpectSystemMessageAsync<T>(this ITestProbe probe, TimeSpan? timeAllowed = null,

--- a/tests/Proto.Actor.Tests/DisposableActorTests.cs
+++ b/tests/Proto.Actor.Tests/DisposableActorTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Proto.Mailbox;
-using Proto.TestFixtures;
+using Proto.TestKit;
 using Xunit;
 
 namespace Proto.Tests;
@@ -15,7 +15,7 @@ public class DisposableActorTests
         await using var _ = system;
         var context = system.Root;
 
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var childMailboxStats = new TestMailboxStats(msg => msg is Stopped);
         var disposed = new TaskCompletionSource<bool>();
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 0, null);
 
@@ -39,7 +39,7 @@ public class DisposableActorTests
         await using var _ = system;
         var context = system.Root;
 
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var childMailboxStats = new TestMailboxStats(msg => msg is Stopped);
         var disposed = new TaskCompletionSource<bool>();
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 0, null);
 
@@ -63,7 +63,7 @@ public class DisposableActorTests
         await using var _ = system;
         var context = system.Root;
 
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var childMailboxStats = new TestMailboxStats(msg => msg is Stopped);
         var disposeCalled = false;
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Resume, 0, null);
 
@@ -87,7 +87,7 @@ public class DisposableActorTests
         await using var _ = system;
         var context = system.Root;
 
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var childMailboxStats = new TestMailboxStats(msg => msg is Stopped);
         var disposeCalled = false;
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Resume, 0, null);
 
@@ -145,8 +145,8 @@ public class DisposableActorTests
 
         var child1Disposed = false;
         var child2Disposed = false;
-        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
-        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var child1MailboxStats = new TestMailboxStats(msg => msg is Stopped);
+        var child2MailboxStats = new TestMailboxStats(msg => msg is Stopped);
         var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Stop, 1, null);
 
         var child1Props = Props.FromProducer(() => new DisposableActor(() => child1Disposed = true))

--- a/tests/Proto.Actor.Tests/Mailbox/MailboxStatisticsTests.cs
+++ b/tests/Proto.Actor.Tests/Mailbox/MailboxStatisticsTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Proto.TestFixtures;
+using Proto.TestKit;
 using Xunit;
 
 namespace Proto.Mailbox.Tests;
@@ -9,14 +10,14 @@ public class MailboxStatisticsTests
 {
     private readonly DefaultMailbox _mailbox;
     private readonly TestMailboxHandler _mailboxHandler;
-    private readonly TestMailboxStatistics _mailboxStatistics;
+    private readonly TestMailboxStats _mailboxStatistics;
 
     public MailboxStatisticsTests()
     {
         _mailboxHandler = new TestMailboxHandler();
         var userMailbox = new UnboundedMailboxQueue();
         var systemMessages = new UnboundedMailboxQueue();
-        _mailboxStatistics = new TestMailboxStatistics();
+        _mailboxStatistics = new TestMailboxStats();
         _mailbox = new DefaultMailbox(systemMessages, userMailbox, _mailboxStatistics);
         _mailbox.RegisterHandlers(_mailboxHandler, _mailboxHandler);
     }

--- a/tests/Proto.Actor.Tests/SupervisionTests_AllForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_AllForOne.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Proto.Mailbox;
-using Proto.TestFixtures;
+using Proto.TestKit;
 using Xunit;
 
 namespace Proto.Tests;
@@ -17,8 +17,8 @@ public class SupervisionTestsAllForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var child1MailboxStats = new TestMailboxStatistics(msg => msg is ResumeMailbox);
-        var child2MailboxStats = new TestMailboxStatistics(msg => msg is ResumeMailbox);
+        var child1MailboxStats = new TestMailboxStats(msg => msg is ResumeMailbox);
+        var child2MailboxStats = new TestMailboxStats(msg => msg is ResumeMailbox);
         var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Resume, 1, null);
 
         var child1Props = Props.FromProducer(() => new ChildActor())
@@ -47,8 +47,8 @@ public class SupervisionTestsAllForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Stop);
-        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Stop);
+        var child1MailboxStats = new TestMailboxStats(msg => msg is Stop);
+        var child2MailboxStats = new TestMailboxStats(msg => msg is Stop);
         var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Stop, 1, null);
 
         var child1Props = Props.FromProducer(() => new ChildActor())
@@ -78,8 +78,8 @@ public class SupervisionTestsAllForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Restart);
-        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Restart);
+        var child1MailboxStats = new TestMailboxStats(msg => msg is Restart);
+        var child2MailboxStats = new TestMailboxStats(msg => msg is Restart);
         var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
 
         var child1Props = Props.FromProducer(() => new ChildActor())
@@ -109,8 +109,8 @@ public class SupervisionTestsAllForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var child1MailboxStats = new TestMailboxStatistics(msg => msg is Restart);
-        var child2MailboxStats = new TestMailboxStatistics(msg => msg is Restart);
+        var child1MailboxStats = new TestMailboxStats(msg => msg is Restart);
+        var child2MailboxStats = new TestMailboxStats(msg => msg is Restart);
         var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
 
         var child1Props = Props.FromProducer(() => new ChildActor())
@@ -140,7 +140,7 @@ public class SupervisionTestsAllForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var parentMailboxStats = new TestMailboxStatistics(msg => msg is Failure);
+        var parentMailboxStats = new TestMailboxStats(msg => msg is Failure);
         var strategy = new AllForOneStrategy((pid, reason) => SupervisorDirective.Escalate, 1, null);
         var childProps = Props.FromProducer(() => new ChildActor());
 

--- a/tests/Proto.Actor.Tests/SupervisionTests_AlwaysRestart.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_AlwaysRestart.cs
@@ -49,7 +49,7 @@ public class SupervisionTestsAlwaysRestart
         await probe.FishForMessageAsync<string>();
 
         var childProps = Props.FromProducer(() => new ChildActor())
-            .WithTestMailboxProbe(probe);
+            .WithMailboxProbe(probe);
 
         var parentProps = Props.FromProducer(() => new ParentActor(childProps))
             .WithChildSupervisorStrategy(Supervision.AlwaysRestartStrategy);

--- a/tests/Proto.Actor.Tests/SupervisionTests_ExponentialBackoff.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_ExponentialBackoff.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Proto.Mailbox;
-using Proto.TestFixtures;
+using Proto.TestKit;
 using Xunit;
 
 namespace Proto.Tests;
@@ -34,7 +34,7 @@ public class SupervisionTestsExponentialBackoff
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var childMailboxStats = new TestMailboxStats(msg => msg is Stopped);
         var strategy = new ExponentialBackoffStrategy(TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(50));
 
         var childProps = Props.FromProducer(() => new BackoffChild())

--- a/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Proto.Mailbox;
-using Proto.TestFixtures;
+using Proto.TestKit;
 using Xunit;
 
 namespace Proto.Tests;
@@ -18,7 +18,7 @@ public class SupervisionTestsOneForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is ResumeMailbox);
+        var childMailboxStats = new TestMailboxStats(msg => msg is ResumeMailbox);
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Resume, 1, null);
 
         var childProps = Props.FromProducer(() => new ChildActor())
@@ -43,7 +43,7 @@ public class SupervisionTestsOneForOne
         var context = system.Root;
 
         // wait specifically for the Stop system message to ensure assertions run
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is Stop);
+        var childMailboxStats = new TestMailboxStats(msg => msg is Stop);
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Stop, 1, null);
 
         var childProps = Props.FromProducer(() => new ChildActor())
@@ -67,7 +67,7 @@ public class SupervisionTestsOneForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is Restart);
+        var childMailboxStats = new TestMailboxStats(msg => msg is Restart);
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
 
         var childProps = Props.FromProducer(() => new ChildActor())
@@ -92,7 +92,7 @@ public class SupervisionTestsOneForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is Stop);
+        var childMailboxStats = new TestMailboxStats(msg => msg is Stop);
 
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 3,
             TimeSpan.FromSeconds(1)
@@ -129,7 +129,7 @@ public class SupervisionTestsOneForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is Restart r && r.Reason == Exception);
+        var childMailboxStats = new TestMailboxStats(msg => msg is Restart r && r.Reason == Exception);
 
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 3,
             TimeSpan.FromMilliseconds(100)
@@ -160,7 +160,7 @@ public class SupervisionTestsOneForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is Restart r && r.Reason == Exception);
+        var childMailboxStats = new TestMailboxStats(msg => msg is Restart r && r.Reason == Exception);
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
 
         var childProps = Props.FromProducer(() => new ChildActor())
@@ -186,7 +186,7 @@ public class SupervisionTestsOneForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var childMailboxStats = new TestMailboxStats(msg => msg is Stopped);
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Restart, 1, null);
 
         var childProps = Props.FromProducer(() => new ChildActor())
@@ -211,7 +211,7 @@ public class SupervisionTestsOneForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var parentMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var parentMailboxStats = new TestMailboxStats(msg => msg is Stopped);
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Escalate, 1, null);
         var childProps = Props.FromProducer(() => new ThrowOnStartedChildActor());
 
@@ -248,7 +248,7 @@ public class SupervisionTestsOneForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var parentMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var parentMailboxStats = new TestMailboxStats(msg => msg is Stopped);
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Escalate, 1, null);
         var childProps = Props.FromProducer(() => new ChildActor());
 
@@ -271,7 +271,7 @@ public class SupervisionTestsOneForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var childMailboxStats = new TestMailboxStatistics(msg => msg is Stopped);
+        var childMailboxStats = new TestMailboxStats(msg => msg is Stopped);
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Stop, 1, null);
 
         var childProps = Props.FromProducer(() => new ThrowOnStartedChildActor())
@@ -293,7 +293,7 @@ public class SupervisionTestsOneForOne
         await using var system = new ActorSystem();
         var context = system.Root;
 
-        var parentMailboxStats = new TestMailboxStatistics(msg => msg is Restart);
+        var parentMailboxStats = new TestMailboxStats(msg => msg is Restart);
         var strategy = new OneForOneStrategy((pid, reason) => SupervisorDirective.Escalate, 0, null);
         var childProps = Props.FromProducer(() => new ThrowOnStartedChildActor());
 

--- a/tests/Proto.Actor.Tests/UnknownSystemMessageTests.cs
+++ b/tests/Proto.Actor.Tests/UnknownSystemMessageTests.cs
@@ -56,7 +56,7 @@ public class UnknownSystemMessageTests
 
         var childProps = Props.FromFunc(ctx => Task.CompletedTask);
         var parentProps = Props.FromProducer(() => new ParentActor(childProps))
-            .WithTestMailboxProbe(probe);
+            .WithMailboxProbe(probe);
 
         var parent = system.Root.Spawn(parentProps);
         var child = await system.Root.RequestAsync<PID>(parent, new GetChild());

--- a/tests/Proto.TestKit.Tests/ProbeMiddlewareTests.cs
+++ b/tests/Proto.TestKit.Tests/ProbeMiddlewareTests.cs
@@ -8,50 +8,50 @@ namespace Proto.TestKit.Tests
 public class ProbeMiddlewareTests
 {
     [Fact]
-    public void Receive_probe_captures_messages()
+    public async Task Receive_probe_captures_messages()
     {
         var system = new ActorSystem();
         var probe = new TestProbe();
         system.Root.Spawn(Props.FromProducer(() => probe));
 
-        var props = Props.FromProducer(() => new EmptyActor()).WithTestReceiveProbe(probe);
+        var props = Props.FromProducer(() => new EmptyActor()).WithReceiveProbe(probe);
         var pid = system.Root.Spawn(props);
 
         system.Root.Send(pid, "hello");
-        probe.GetNextMessage<string>().Should().Be("hello");
+        (await probe.GetNextMessageAsync<string>()).Should().Be("hello");
     }
 
     [Fact]
-    public void Send_probe_captures_outgoing_messages()
+    public async Task Send_probe_captures_outgoing_messages()
     {
         var system = new ActorSystem();
         var probe = new TestProbe();
         system.Root.Spawn(Props.FromProducer(() => probe));
 
         var target = system.Root.Spawn(Props.FromFunc(ctx => Task.CompletedTask));
-        var props = Props.FromProducer(() => new ForwardActor(target)).WithTestSendProbe(probe);
+        var props = Props.FromProducer(() => new ForwardActor(target)).WithSendProbe(probe);
         var pid = system.Root.Spawn(props);
 
         system.Root.Send(pid, "hi");
-        probe.GetNextMessage<string>().Should().Be("hi");
+        (await probe.GetNextMessageAsync<string>()).Should().Be("hi");
         probe.Sender.Should().Be(target);
     }
 
     [Fact]
-    public void Mailbox_probe_captures_messages_and_system_messages()
+    public async Task Mailbox_probe_captures_messages_and_system_messages()
     {
         var system = new ActorSystem();
         var probe = new TestProbe();
         system.Root.Spawn(Props.FromProducer(() => probe));
 
-        var props = Props.FromProducer(() => new EmptyActor()).WithTestMailboxProbe(probe);
+        var props = Props.FromProducer(() => new EmptyActor()).WithMailboxProbe(probe);
         var pid = system.Root.Spawn(props);
 
         system.Root.Send(pid, "hello");
-        probe.GetNextMessage<string>().Should().Be("hello");
+        (await probe.GetNextMessageAsync<string>()).Should().Be("hello");
 
         system.Root.Stop(pid);
-        probe.ExpectSystemMessage<Stop>();
+        await probe.ExpectSystemMessageAsync<Stop>();
     }
 
     private class EmptyActor : IActor


### PR DESCRIPTION
## Summary
- move TestMailboxStats into the testkit library and document testkit usage
- drop blocking methods from TestProbe, keeping async-only API
- rename Props test probe extensions for clearer, consistent naming

## Testing
- `dotnet test tests/Proto.TestKit.Tests/Proto.TestKit.Tests.csproj`
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj` *(failing: RequestRepeatedlyCanBeCancelled, RandomGroupRouter_RemovedRouteesDoNotReceiveMessages)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f15c03f083289f9f2a37490cdc83