### PR TITLE
Add scheduler hook for deterministic scheduler tests

### DIFF
--- a/src/Proto.Actor/Timers/ISchedulerHook.cs
+++ b/src/Proto.Actor/Timers/ISchedulerHook.cs
@@ -1,0 +1,13 @@
+namespace Proto.Timers;
+
+/// <summary>
+/// Hook for tests to observe scheduler behavior.
+/// </summary>
+public interface ISchedulerHook
+{
+    /// <summary>
+    /// Called whenever the scheduler registers an internal timer.
+    /// </summary>
+    void OnTimerRegistered();
+}
+

--- a/src/Proto.Actor/Timers/Scheduler.cs
+++ b/src/Proto.Actor/Timers/Scheduler.cs
@@ -18,15 +18,17 @@ public class Scheduler
 {
     private readonly ISenderContext _context;
     private readonly TimeProvider _timeProvider;
+    private readonly ISchedulerHook? _schedulerHook;
 
     /// <summary>
     ///     Creates a new scheduler.
     /// </summary>
     /// <param name="context">Context to send the scheduled message through</param>
-    public Scheduler(ISenderContext context)
+    public Scheduler(ISenderContext context, ISchedulerHook? schedulerHook = null)
     {
         _context = context;
         _timeProvider = TimeProvider.System;
+        _schedulerHook = schedulerHook;
     }
 
     /// <summary>
@@ -34,10 +36,11 @@ public class Scheduler
     /// </summary>
     /// <param name="context">Context to send the scheduled message through</param>
     /// <param name="timeProvider">TimeProvider to use for scheduling (FakeTimeProvider can be used for testing)</param>
-    public Scheduler(ISenderContext context, TimeProvider timeProvider)
+    public Scheduler(ISenderContext context, TimeProvider timeProvider, ISchedulerHook? schedulerHook = null)
     {
         _context = context;
         _timeProvider = timeProvider;
+        _schedulerHook = schedulerHook;
     }
 
     /// <summary>
@@ -94,7 +97,7 @@ public class Scheduler
                 {
                     _context.Send(target, message);
 
-                    await Task.Delay(interval, token).ConfigureAwait(false);
+                    await Delay(interval, token).ConfigureAwait(false);
                 }
             }, token
         );
@@ -134,6 +137,8 @@ public class Scheduler
 
     private async Task Delay(TimeSpan delay, CancellationToken token)
     {
-        await Task.Delay(delay, _timeProvider, token).ConfigureAwait(false);
+        var delayTask = Task.Delay(delay, _timeProvider, token);
+        _schedulerHook?.OnTimerRegistered();
+        await delayTask.ConfigureAwait(false);
     }
 }

--- a/src/Proto.Actor/Timers/TimerExtensions.cs
+++ b/src/Proto.Actor/Timers/TimerExtensions.cs
@@ -9,7 +9,8 @@ public static class TimerExtensions
     /// </summary>
     /// <param name="context"></param>
     /// <returns></returns>
-    public static Scheduler Scheduler(this ISenderContext context) => new(context);
+    public static Scheduler Scheduler(this ISenderContext context, ISchedulerHook? hook = null) =>
+        new(context, hook);
 
     /// <summary>
     ///     Gets a new scheduler that allows to schedule messages in the future
@@ -17,5 +18,6 @@ public static class TimerExtensions
     /// <param name="context">Context to send the scheduled message through</param>
     /// <param name="timeProvider">TimeProvider to use for scheduling (FakeTimeProvider can be used for testing)</param>
     /// <returns></returns>
-    public static Scheduler Scheduler(this ISenderContext context, TimeProvider timeProvider) => new(context, timeProvider);
+    public static Scheduler Scheduler(this ISenderContext context, TimeProvider timeProvider, ISchedulerHook? hook = null) =>
+        new(context, timeProvider, hook);
 }

--- a/src/Proto.TestKit/README.md
+++ b/src/Proto.TestKit/README.md
@@ -14,3 +14,22 @@ await AwaitConditionAsync(() => value == expected, TimeSpan.FromSeconds(5), "val
 
 The helper evaluates the condition every 20ms and throws a `TimeoutException`—including the optional
 message—if the condition is not met within the supplied timeout.
+
+## Deterministic Scheduler Tests
+
+`Proto.Timers` exposes a test hook, `ISchedulerHook`, that signals when a
+`Scheduler` has registered its internal `Task.Delay` timer. When testing with
+`FakeTimeProvider`, await this hook before advancing time to avoid flakiness:
+
+```csharp
+var hook = new TestSchedulerHook();
+var scheduler = ctx.Scheduler(fakeTimeProvider, hook);
+
+scheduler.SendOnce(TimeSpan.FromSeconds(5), target, "Wakeup");
+await hook.WaitAsync();
+fakeTimeProvider.Advance(TimeSpan.FromSeconds(5));
+```
+
+Implement `ISchedulerHook` with a `TaskCompletionSource` to observe timer
+registration. This allows tests to deterministically control when scheduled
+messages are delivered.

--- a/tests/Proto.Actor.Tests/SchedulerTests.cs
+++ b/tests/Proto.Actor.Tests/SchedulerTests.cs
@@ -25,11 +25,11 @@ public class SchedulerTests
             return Task.CompletedTask;
         }));
         var timeProvider = new FakeTimeProvider();
-        var scheduler = context.Scheduler(timeProvider);
+        var hook = new TestSchedulerHook();
+        var scheduler = context.Scheduler(timeProvider, hook);
 
         scheduler.SendOnce(TimeSpan.FromSeconds(10), pid, "Wakeup");
-        // Give SendOnce's inner call to Task.Delay a head start, so it won't miss the call to Advance.
-        await Task.Delay(50);
+        await hook.WaitAsync();
         timeProvider.Advance(TimeSpan.FromMinutes(10));
         await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(10));
     }
@@ -63,12 +63,12 @@ public class SchedulerTests
         }));
 
         var timeProvider = new FakeTimeProvider();
-        var scheduler = context.Scheduler(timeProvider);
+        var hook = new TestSchedulerHook();
+        var scheduler = context.Scheduler(timeProvider, hook);
 
         var cts = scheduler.SendRepeatedly(TimeSpan.FromSeconds(5), pid, "Tick");
 
-        // Give SendRepeatedly's inner call to Task.Delay a head start
-        await Task.Delay(50);
+        await hook.WaitAsync();
         timeProvider.Advance(TimeSpan.FromMinutes(1));
         await firstMessage.Task.WaitAsync(TimeSpan.FromMilliseconds(10));
 
@@ -99,12 +99,12 @@ public class SchedulerTests
         }));
 
         var timeProvider = new FakeTimeProvider();
-        var scheduler = context.Scheduler(timeProvider);
+        var hook = new TestSchedulerHook();
+        var scheduler = context.Scheduler(timeProvider, hook);
 
         var cts = scheduler.SendOnce(TimeSpan.FromSeconds(5), pid, "Wakeup");
 
-        // Give SendOnce's inner call to Task.Delay a head start
-        await Task.Delay(50);
+        await hook.WaitAsync();
         cts.Cancel();
 
         timeProvider.Advance(TimeSpan.FromMinutes(1));
@@ -133,6 +133,7 @@ public class SchedulerTests
         var extraResponse = new TaskCompletionSource();
 
         var timeProvider = new FakeTimeProvider();
+        var hook = new TestSchedulerHook();
 
         CancellationTokenSource? cts = null;
         var requester = context.Spawn(Props.FromFunc(ctx =>
@@ -140,7 +141,7 @@ public class SchedulerTests
             switch (ctx.Message)
             {
                 case Started:
-                    var scheduler = ctx.Scheduler(timeProvider);
+                    var scheduler = ctx.Scheduler(timeProvider, hook);
                     cts = scheduler.RequestRepeatedly(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5), responder, "Ping");
                     break;
                 case string msg when msg == "Pong":
@@ -161,8 +162,7 @@ public class SchedulerTests
             return Task.CompletedTask;
         }));
 
-        // Give RequestRepeatedly's inner call to Task.Delay a head start
-        await Task.Delay(50);
+        await hook.WaitAsync();
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         await firstResponse.Task.WaitAsync(TimeSpan.FromMilliseconds(10));
 
@@ -175,6 +175,15 @@ public class SchedulerTests
         await Task.Delay(50);
 
         Assert.False(extraResponse.Task.IsCompleted);
+    }
+
+    private sealed class TestSchedulerHook : ISchedulerHook
+    {
+        private readonly TaskCompletionSource _tcs = new();
+
+        public Task WaitAsync() => _tcs.Task;
+
+        public void OnTimerRegistered() => _tcs.TrySetResult();
     }
 }
 


### PR DESCRIPTION
## Summary
- expose ISchedulerHook for Proto.Timers to notify when timers register
- allow injecting hooks into Scheduler and TimerExtensions
- use hook in SchedulerTests and document deterministic scheduler testing

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a715e65d288328a7af0399f1db7740