### PR TITLE
Ensure RandomGroup router test waits for routee removal

### DIFF
--- a/tests/Proto.Actor.Tests/Router/RandomGroupRouterTests.cs
+++ b/tests/Proto.Actor.Tests/Router/RandomGroupRouterTests.cs
@@ -61,6 +61,9 @@ public class RandomGroupRouterTests
 
         system.Root.Send(router, new RouterRemoveRoutee(routee1));
 
+        // Ensure the router has processed the removal before routing further messages
+        await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
+
         for (var i = 0; i < 100; i++)
         {
             system.Root.Send(router, i.ToString());


### PR DESCRIPTION
## Summary
- wait for router to process removal before sending messages in `RandomGroupRouter_RemovedRouteesDoNotReceiveMessages`

## Testing
- `dotnet test tests/Proto.Actor.Tests --filter "RandomGroupRouter_RemovedRouteesDoNotReceiveMessages" -c Release`
- `dotnet test tests/Proto.Actor.Tests -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68a7178f28e8832899f3074135038d32