### PR TITLE
Drain removed routee mailboxes in router tests

### DIFF
--- a/tests/Proto.Actor.Tests/Router/BroadcastGroupTests.cs
+++ b/tests/Proto.Actor.Tests/Router/BroadcastGroupTests.cs
@@ -94,6 +94,7 @@ public class BroadcastGroupTests
         system.Root.Send(router, "first message");
         system.Root.Send(router, new RouterRemoveRoutee(routee1));
         await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
+        await system.Root.RequestAsync<Touched>(routee1, new Touch(), _timeout);
         system.Root.Send(router, "second message");
 
         Assert.Equal("first message", await system.Root.RequestAsync<string>(routee1, "received?", _timeout));

--- a/tests/Proto.Actor.Tests/Router/BroadcastPoolRouterTests.cs
+++ b/tests/Proto.Actor.Tests/Router/BroadcastPoolRouterTests.cs
@@ -29,6 +29,7 @@ public class BroadcastPoolRouterTests
         system.Root.Send(router, "first");
         system.Root.Send(router, new RouterRemoveRoutee(routee1));
         await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
+        await system.Root.RequestAsync<Touched>(routee1, new Touch(), _timeout);
         system.Root.Send(router, "second");
 
         Assert.Equal("first", await system.Root.RequestAsync<string>(routee1, "received?", _timeout));

--- a/tests/Proto.Actor.Tests/Router/ConsistentHashGroupTests.cs
+++ b/tests/Proto.Actor.Tests/Router/ConsistentHashGroupTests.cs
@@ -118,6 +118,7 @@ public class ConsistentHashGroupTests
 
         system.Root.Send(router, new RouterRemoveRoutee(routee1));
         await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
+        await system.Root.RequestAsync<Touched>(routee1, new Touch(), _timeout);
         system.Root.Send(router, new Message("message1"));
         Assert.Equal(0, await system.Root.RequestAsync<int>(routee1, "received?", _timeout));
     }
@@ -148,6 +149,7 @@ public class ConsistentHashGroupTests
         // remove receiver
         system.Root.Send(router, new RouterRemoveRoutee(routee1));
         await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
+        await system.Root.RequestAsync<Touched>(routee1, new Touch(), _timeout);
         // routee2 should now handle "message1"
         system.Root.Send(router, new Message("message1"));
 

--- a/tests/Proto.Actor.Tests/Router/RandomGroupRouterTests.cs
+++ b/tests/Proto.Actor.Tests/Router/RandomGroupRouterTests.cs
@@ -63,6 +63,7 @@ public class RandomGroupRouterTests
 
         // Ensure the router has processed the removal before routing further messages
         await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
+        await system.Root.RequestAsync<Touched>(routee1, new Touch(), _timeout);
 
         for (var i = 0; i < 100; i++)
         {

--- a/tests/Proto.Actor.Tests/Router/RoundRobinGroupTests.cs
+++ b/tests/Proto.Actor.Tests/Router/RoundRobinGroupTests.cs
@@ -89,6 +89,7 @@ public class RoundRobinGroupTests
         system.Root.Send(router, "0");
         system.Root.Send(router, new RouterRemoveRoutee(routee1));
         await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
+        await system.Root.RequestAsync<Touched>(routee1, new Touch(), _timeout);
         // we should have 2 routees, so send 3 messages to ensure round robin happens
         system.Root.Send(router, "3");
         system.Root.Send(router, "3");


### PR DESCRIPTION
## Summary
- ensure router tests flush removed routee mailboxes with a Touch request before sending further messages

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68a71c69b0008328a00c2c34c1484549