### PR TITLE
Use TestProbe in repeated request cancellation test

### DIFF
--- a/tests/Proto.Actor.Tests/SchedulerTests.cs
+++ b/tests/Proto.Actor.Tests/SchedulerTests.cs
@@ -90,8 +90,8 @@ public class SchedulerTests
             return Task.CompletedTask;
         }));
 
-        var firstResponse = new TaskCompletionSource();
-        var extraResponse = new TaskCompletionSource();
+        var probe = new TestProbe();
+        var probePid = context.Spawn(Props.FromProducer(() => probe));
 
         var timeProvider = new FakeTimeProvider();
         var hook = new TestSchedulerHook();
@@ -106,14 +106,7 @@ public class SchedulerTests
                     cts = scheduler.RequestRepeatedly(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5), responder, "Ping");
                     break;
                 case string msg when msg == "Pong":
-                    if (!firstResponse.Task.IsCompleted)
-                    {
-                        firstResponse.SetResult();
-                    }
-                    else
-                    {
-                        extraResponse.SetResult();
-                    }
+                    ctx.Send(probePid, msg);
                     break;
                 case "Cancel":
                     cts?.Cancel();
@@ -125,7 +118,7 @@ public class SchedulerTests
 
         await hook.WaitAsync();
         timeProvider.Advance(TimeSpan.FromSeconds(5));
-        await firstResponse.Task.WaitAsync(TimeSpan.FromMilliseconds(10));
+        await probe.GetNextMessageAsync<string>(TimeSpan.FromMilliseconds(10));
 
         context.Send(requester, "Cancel");
 
@@ -135,7 +128,7 @@ public class SchedulerTests
         timeProvider.Advance(TimeSpan.FromSeconds(10));
         await Task.Delay(50);
 
-        Assert.False(extraResponse.Task.IsCompleted);
+        await probe.ExpectNoMessageAsync(TimeSpan.FromMilliseconds(50));
     }
 
     private sealed class TestSchedulerHook : ISchedulerHook


### PR DESCRIPTION
## Summary
- refactor `RequestRepeatedlyCanBeCancelled` to use a single `TestProbe`
- forward `Pong` responses to the probe and assert no extra messages after cancellation

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a804cf8e1483288cd9dec0d00d853d