### PR TITLE
Use mailbox stats to await stop in reenter test

### DIFF
--- a/src/Proto.TestKit/PropsTestMailboxStatsExtensions.cs
+++ b/src/Proto.TestKit/PropsTestMailboxStatsExtensions.cs
@@ -1,0 +1,15 @@
+using Proto.Mailbox;
+
+namespace Proto.TestKit;
+
+/// <summary>
+/// Extension methods to attach <see cref="TestMailboxStats"/> to actor props.
+/// </summary>
+public static class PropsTestMailboxStatsExtensions
+{
+    /// <summary>
+    /// Configures the actor to use an <see cref="UnboundedMailbox"/> instrumented with the provided <paramref name="stats"/>.
+    /// </summary>
+    public static Props WithTestMailboxStats(this Props props, TestMailboxStats stats) =>
+        props.WithMailbox(() => UnboundedMailbox.Create(stats));
+}

--- a/src/Proto.TestKit/TestMailboxStats.cs
+++ b/src/Proto.TestKit/TestMailboxStats.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Proto.Mailbox;
 
 namespace Proto.TestKit;
@@ -46,4 +47,10 @@ public class TestMailboxStats : IMailboxStatistics
     }
 
     public void MailboxEmpty() => Stats.Add("Empty");
+
+    /// <summary>
+    /// Asynchronously waits until <see cref="Reset"/> is signaled or the <paramref name="timeout"/> elapses.
+    /// </summary>
+    public Task WaitForResetAsync(TimeSpan timeout) =>
+        TestKit.AwaitConditionAsync(() => Reset.IsSet, timeout);
 }

--- a/tests/Proto.Actor.Tests/ReenterTests.cs
+++ b/tests/Proto.Actor.Tests/ReenterTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Proto.TestKit;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -312,8 +313,8 @@ public class ReenterTests : ActorTestBase
     [Fact]
     public async Task DropReenterContinuationAfterStop()
     {
-        var stopped = false;
         var completionExecuted = false;
+        var stats = new TestMailboxStats(msg => msg is Stop); // track when the stop message is received
         CancellationTokenSource cts = new();
 
         var props = Props.FromFunc(async ctx =>
@@ -328,30 +329,28 @@ public class ReenterTests : ActorTestBase
                             {
                                 completionExecuted = true;
                             });
-                        
+
                         ctx.Stop(ctx.Self);
-                        
-                        // Release the cancellation token after stop gets processed.
-                        cts.Cancel();
 
                         ctx.Respond(true);
 
                         break;
                     case Stopped:
-                        stopped = true;
-                        
+                        // Release the cancellation token after stop gets processed.
+                        cts.Cancel();
+
                         break;
                 }
             }
-        );
+        ).WithTestMailboxStats(stats);
 
         var pid = Context.Spawn(props);
 
         await Context.RequestAsync<bool>(pid, "start", TimeSpan.FromSeconds(5));
-        
-        await Task.Delay(500);
-        await Task.Yield();
-        
+
+        // Wait for the actor to process the stop sequence
+        await stats.WaitForResetAsync(TimeSpan.FromSeconds(5));
+
         Assert.True(!completionExecuted);
     }
 

--- a/tests/Proto.Actor.Tests/ReenterTests.cs
+++ b/tests/Proto.Actor.Tests/ReenterTests.cs
@@ -335,11 +335,6 @@ public class ReenterTests : ActorTestBase
                         ctx.Respond(true);
 
                         break;
-                    case Stopped:
-                        // Release the cancellation token after stop gets processed.
-                        cts.Cancel();
-
-                        break;
                 }
             }
         ).WithTestMailboxStats(stats);
@@ -351,7 +346,10 @@ public class ReenterTests : ActorTestBase
         // Wait for the actor to process the stop sequence
         await stats.WaitForResetAsync(TimeSpan.FromSeconds(5));
 
-        Assert.True(!completionExecuted);
+        // Trigger the reenter continuation after the actor has stopped
+        cts.Cancel();
+
+        Assert.False(completionExecuted);
     }
 
     private class ReenterAfterCancellationActor : IActor


### PR DESCRIPTION
## Summary
- add `WithTestMailboxStats` extension to simplify wiring test stats
- wait on `TestMailboxStats` asynchronously via `WaitForResetAsync`
- use `Stop` mailbox stats and async wait in `DropReenterContinuationAfterStop`

## Testing
- `dotnet test tests/Proto.Actor.Tests -c Release`
- `dotnet test tests/Proto.Actor.Tests -c Release --filter "FullyQualifiedName=Proto.Tests.ReenterTests.DropReenterContinuationAfterStop"`


------
https://chatgpt.com/codex/tasks/task_e_68a804da9bf88328878d00d02a8141ff