### PR TITLE
Use ExpectNextUserMessageAsync in UnknownSystemMessageTests

### DIFF
--- a/tests/Proto.Actor.Tests/UnknownSystemMessageTests.cs
+++ b/tests/Proto.Actor.Tests/UnknownSystemMessageTests.cs
@@ -49,9 +49,9 @@ public class UnknownSystemMessageTests
 
         // Attach a probe to the parent mailbox to observe system messages such as Failure
         var (probe, probePid) = system.CreateTestProbe();
-        // ensure the probe is fully started before it is used
+        // ensure the probe is fully started before it is used by awaiting the init message
         system.Root.Send(probePid, "init");
-        await probe.FishForMessageAsync<string>();
+        await probe.ExpectNextUserMessageAsync<string>();
 
         var childProps = Props.FromFunc(ctx => Task.CompletedTask);
         var parentProps = Props.FromProducer(() => new ParentActor(childProps))


### PR DESCRIPTION
## Summary
- ensure test probe mailbox readiness by awaiting `ExpectNextUserMessageAsync` after sending init

## Testing
- `dotnet test tests/Proto.Actor.Tests --filter Unknown_system_message_should_escalate_to_parent`

------
https://chatgpt.com/codex/tasks/task_e_68a84d2d016483288999d01369065213