### PR TITLE
docs: clarify testing guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # Agent Instructions
 
-- Ensure we have dotnet 8 already installet. check dotnet --version
-- we can not run docker or 3rd party services. ignore any integration tests that requires such services
+- Verify that .NET 8 is installed by running `dotnet --version`.
+- Do not run Docker or other external services; skip integration tests that require them.
+- When adding or modifying tests:
+  - Prefer Proto.TestKit utilities.
+  - Use probes instead of `TaskCompletionSource` or ad-hoc recording/forwarding actors.
+  - Assert message contents through `probe.ExpectNext*` methods.
+  - Preserve the existing level of assertions; do not reduce coverage.
+  - When suitable, use `ExpectEmptyMailbox` rather than `ExpectNoMessages`.
 


### PR DESCRIPTION
## Summary
- document that tests should use Proto.TestKit probes and ExpectNext helpers
- mention keeping or improving assertion coverage
- note preferring ExpectEmptyMailbox over ExpectNoMessages

## Testing
- `dotnet --version`
- `dotnet test ProtoActor.sln` *(fails: Docker is either not running or misconfigured)*

------
https://chatgpt.com/codex/tasks/task_e_68a85f13644083288af532dffb610e96