### PR TITLE
chore: rely on default compile items

### DIFF
--- a/src/Proto.TestKit/Proto.TestKit.csproj
+++ b/src/Proto.TestKit/Proto.TestKit.csproj
@@ -9,7 +9,4 @@
     <ItemGroup>
         <ProjectReference Include="..\Proto.Actor\Proto.Actor.csproj" />
     </ItemGroup>
-
-    <ItemGroup>
-    </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- remove manual Compile `ItemGroup` from Proto.TestKit project to rely on SDK defaults

## Testing
- `dotnet test tests/Proto.TestKit.Tests/Proto.TestKit.Tests.csproj`
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a871d13b0883288689005b5bdf0733