### PR TITLE
refactor: use TestProbe in FunctionActor test

### DIFF
--- a/logs/log1755870784.md
+++ b/logs/log1755870784.md
@@ -1,0 +1,2 @@
+# Change Log
+- Updated `tests/Proto.Actor.Tests/FunctionActorTests.cs` to replace manual message tracking with `TestProbe` and added `Proto.TestKit` usage. This improves test reliability and follows project guidelines to use probes instead of custom flags.

--- a/tests/Proto.Actor.Tests/FunctionActorTests.cs
+++ b/tests/Proto.Actor.Tests/FunctionActorTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Proto.TestKit;
 using Xunit;
 
 namespace Proto.Tests;
@@ -10,21 +11,19 @@ public class FunctionActorTests
     {
         await using var system = new ActorSystem();
         var context = system.Root;
-        var received = false;
+        var (probe, probePid) = system.CreateTestProbe();
 
         var props = Props.FromFunc(ctx =>
         {
             if (ctx.Message is string)
             {
-                received = true;
+                ctx.Forward(probePid);
             }
             return Task.CompletedTask;
         });
 
         var pid = context.Spawn(props);
         context.Send(pid, "hello");
-        await Task.Delay(50);
-
-        Assert.True(received);
+        await probe.ExpectNextUserMessageAsync<string>(msg => msg == "hello");
     }
 }


### PR DESCRIPTION
## Summary
- use Proto.TestKit's TestProbe in FunctionActor test
- document change in logs

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a875e039dc832891aa127d4fa5f358