### PR TITLE
Use AwaitConditionAsync in mailbox scheduling tests

### DIFF
--- a/logs/log1755871331.md
+++ b/logs/log1755871331.md
@@ -1,0 +1,6 @@
+# Log 1755871331
+
+## tests/Proto.Actor.Tests/Mailbox/MailboxSchedulingTests.cs
+- Added Proto.TestKit namespace and static import to enable AwaitConditionAsync.
+- Replaced fixed Task.Delay calls with AwaitConditionAsync to poll mailbox state instead of sleeping.
+- Ensured mailbox idles by waiting for Status == 0 after message completion.

--- a/tests/Proto.Actor.Tests/Mailbox/MailboxSchedulingTests.cs
+++ b/tests/Proto.Actor.Tests/Mailbox/MailboxSchedulingTests.cs
@@ -1,5 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Proto.TestFixtures;
+using Proto.TestKit;
+using static Proto.TestKit.TestKit;
 using Xunit;
 
 namespace Proto.Mailbox.Tests;
@@ -21,7 +24,7 @@ public class MailboxSchedulingTests
         mailbox.PostUserMessage(msg1);
         mailbox.PostUserMessage(msg2);
 
-        await Task.Delay(1000);
+        await AwaitConditionAsync(() => userMailbox.HasMessages, TimeSpan.FromMilliseconds(100));
 
         Assert.True(userMailbox.HasMessages,
             "Mailbox should not have processed msg2 because processing of msg1 is not completed."
@@ -29,7 +32,7 @@ public class MailboxSchedulingTests
 
         msg2.TaskCompletionSource.SetResult(0);
         msg1.TaskCompletionSource.SetResult(0);
-        await Task.Delay(1000);
+        await AwaitConditionAsync(() => !userMailbox.HasMessages, TimeSpan.FromMilliseconds(100));
 
         Assert.False(userMailbox.HasMessages,
             "Mailbox should have processed msg2 because processing of msg1 is completed."
@@ -53,7 +56,7 @@ public class MailboxSchedulingTests
         mailbox.PostUserMessage(msg1);
         mailbox.PostUserMessage(msg2);
 
-        await Task.Delay(1000);
+        await AwaitConditionAsync(() => !userMailbox.HasMessages, TimeSpan.FromMilliseconds(100));
 
         Assert.False(userMailbox.HasMessages,
             "Mailbox should have processed both messages because they were already completed."
@@ -81,7 +84,7 @@ public class MailboxSchedulingTests
 
         msg2.TaskCompletionSource.SetResult(0);
         msg1.TaskCompletionSource.SetResult(0);
-        await Task.Delay(1000);
+        await AwaitConditionAsync(() => !systemMessages.HasMessages, TimeSpan.FromMilliseconds(100));
 
         Assert.False(systemMessages.HasMessages,
             "Mailbox should have processed msg2 because processing of msg1 is completed."
@@ -104,7 +107,7 @@ public class MailboxSchedulingTests
 
         mailbox.PostSystemMessage(msg1);
         mailbox.PostSystemMessage(msg2);
-        await Task.Delay(1000);
+        await AwaitConditionAsync(() => !systemMessages.HasMessages, TimeSpan.FromMilliseconds(100));
 
         Assert.False(systemMessages.HasMessages,
             "Mailbox should have processed both messages because they were already completed."
@@ -123,9 +126,9 @@ public class MailboxSchedulingTests
         var msg1 = new TestMessageWithTaskCompletionSource();
         mailbox.PostUserMessage(msg1);
 
-        await Task.Delay(1000);
+        await AwaitConditionAsync(() => !userMailbox.HasMessages, TimeSpan.FromMilliseconds(100));
         msg1.TaskCompletionSource.SetResult(0);
-        await Task.Delay(1000);
+        await AwaitConditionAsync(() => mailbox.Status == 0, TimeSpan.FromMilliseconds(100));
 
         // Mailbox becomes idle (status 0) after completing the user message
         Assert.Equal(0, mailbox.Status);


### PR DESCRIPTION
## Summary
- use Proto.TestKit's AwaitConditionAsync in mailbox scheduling tests instead of fixed delays
- wait for mailbox idle status to avoid timing dependencies

## Testing
- `dotnet test tests/Proto.Actor.Tests`
- `dotnet test tests/Proto.Remote.Tests`
- `dotnet test tests/Proto.Cluster.Tests`


------
https://chatgpt.com/codex/tasks/task_e_68a875e39b4c8328b31f60537d0a6042