### PR TITLE
Wait for TestProbe context and drop probe startup delays

### DIFF
--- a/logs/log1755875598.md
+++ b/logs/log1755875598.md
@@ -1,0 +1,7 @@
+# Change Log 1755875598
+
+## src/Proto.TestKit/TestProbe.cs
+- Added spin-wait in `Context` property to wait up to one second for the probe context to initialize, avoiding `InvalidOperationException` when tests access `probe.Context` immediately.
+
+## tests/Proto.Remote.Tests/RemoteTests.cs
+- Removed `Task.Delay(20)` calls that previously waited for test probes to start or remote watch propagation; the probe now waits internally for its context, eliminating ad-hoc delays.

--- a/src/Proto.TestKit/TestProbe.cs
+++ b/src/Proto.TestKit/TestProbe.cs
@@ -51,12 +51,13 @@ public class TestProbe : IActor, ITestProbe
     {
         get
         {
-            if (_context is null)
+            // Spin-wait for up to one second for the probe's context to be set.
+            if (!SpinWait.SpinUntil(() => _context != null, TimeSpan.FromSeconds(1)))
             {
                 throw new InvalidOperationException("Probe context is null");
             }
 
-            return _context;
+            return _context!;
         }
         private set => _context = value;
     }

--- a/tests/Proto.Remote.Tests/RemoteTests.cs
+++ b/tests/Proto.Remote.Tests/RemoteTests.cs
@@ -165,9 +165,7 @@ public abstract class RemoteTests
         var remoteActor = await SpawnRemoteActor(_fixture.RemoteAddress);
 
         var (probe, _) = System.CreateTestProbe();
-        await Task.Delay(20); // wait for probe to start
         probe.Context.Watch(remoteActor);
-        await Task.Delay(20); // allow RemoteWatch to propagate
 
         await System.Root.PoisonAsync(remoteActor);
 
@@ -182,10 +180,8 @@ public abstract class RemoteTests
         var remoteActor2 = await SpawnRemoteActor(_fixture.RemoteAddress);
 
         var (probe, _) = System.CreateTestProbe();
-        await Task.Delay(20); // wait for probe to start
         probe.Context.Watch(remoteActor1);
         probe.Context.Watch(remoteActor2);
-        await Task.Delay(20); // allow RemoteWatch to propagate
 
         await System.Root.PoisonAsync(remoteActor1);
         await System.Root.PoisonAsync(remoteActor2);
@@ -205,10 +201,8 @@ public abstract class RemoteTests
 
         var (probe1, _) = System.CreateTestProbe();
         var (probe2, _) = System.CreateTestProbe();
-        await Task.Delay(20); // wait for probes to start
         probe1.Context.Watch(remoteActor);
         probe2.Context.Watch(remoteActor);
-        await Task.Delay(20); // allow RemoteWatch to propagate
 
         await System.Root.PoisonAsync(remoteActor);
 
@@ -224,10 +218,8 @@ public abstract class RemoteTests
 
         var (probe1, _) = System.CreateTestProbe();
         var (probe2, _) = System.CreateTestProbe();
-        await Task.Delay(20); // wait for probes to start
         probe1.Context.Watch(remoteActor);
         probe2.Context.Watch(remoteActor);
-        await Task.Delay(20); // allow RemoteWatch to propagate
 
         probe2.Context.Unwatch(remoteActor);
         await Task.Delay(TimeSpan.FromSeconds(3));
@@ -246,9 +238,7 @@ public abstract class RemoteTests
         var remoteActor = await SpawnRemoteActor(_fixture.RemoteAddress);
 
         var (probe, _) = System.CreateTestProbe();
-        await Task.Delay(20); // wait for probe to start
         probe.Context.Watch(remoteActor);
-        await Task.Delay(20); // allow RemoteWatch to propagate
 
         System.Root.Send(remoteActor, new Die());
 


### PR DESCRIPTION
## Summary
- Spin-wait for up to one second when accessing `TestProbe.Context`
- Remove ad-hoc `Task.Delay` calls from remote watch tests
- Document changes in logs

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8889e89ec8328aeb6f58d6ebb6db6