### PR TITLE
Encapsulate TestProbe context

### DIFF
--- a/logs/log1755877694.md
+++ b/logs/log1755877694.md
@@ -1,0 +1,9 @@
+# Change Log
+
+- **src/Proto.TestKit/ITestProbe.cs**: Removed public `Context` property and added `Watch`/`Unwatch` methods to limit external access to actor context.
+- **src/Proto.TestKit/TestProbe.cs**: Made `Context` property private and added `Watch`/`Unwatch` wrappers so probes no longer expose internal context.
+- **src/Proto.TestKit/PropsTestProbeExtensions.cs**: Updated middleware to use new `Send` API instead of accessing probe context directly.
+- **src/Proto.TestKit/ProbeMailboxStatistics.cs**: Forward mailbox messages through probe `Send` method, avoiding direct context exposure.
+- **tests/Proto.Remote.Tests/RemoteTests.cs**: Replaced `probe.Context.Watch/Unwatch` with new probe methods.
+- **tests/Proto.TestKit.Tests/TestProbeAsyncTests.cs**: Removed direct context check, relying on probe methods for mailbox validation.
+- **tests/Proto.Actor.Tests/Router/BroadcastPoolRouterTests.cs**: Used implicit PID conversion instead of context access when matching routees.

--- a/src/Proto.TestKit/ITestProbe.cs
+++ b/src/Proto.TestKit/ITestProbe.cs
@@ -23,11 +23,6 @@ public interface ITestProbe
     PID? Sender { get; }
 
     /// <summary>
-    ///     the context of the test probe
-    /// </summary>
-    IContext? Context { get; }
-
-    /// <summary>
     ///     asynchronously checks that no message arrives within the time allowed
     /// </summary>
     /// <param name="timeAllowed"></param>
@@ -182,6 +177,18 @@ public interface ITestProbe
     /// </summary>
     /// <param name="message"></param>
     void Respond(object message);
+
+    /// <summary>
+    ///     starts watching the target actor
+    /// </summary>
+    /// <param name="pid"></param>
+    void Watch(PID pid);
+
+    /// <summary>
+    ///     stops watching the target actor
+    /// </summary>
+    /// <param name="pid"></param>
+    void Unwatch(PID pid);
 
     /// <summary>
     ///     sends a request message from the test probe to the target

--- a/src/Proto.TestKit/ProbeMailboxStatistics.cs
+++ b/src/Proto.TestKit/ProbeMailboxStatistics.cs
@@ -20,7 +20,7 @@ public class ProbeMailboxStatistics : IMailboxStatistics
     }
 
     public void MessageReceived(object message) =>
-        _probe.Context.Send(_probe.Context.Self, message);
+        _probe.Send(_probe, message);
 
     public void MailboxEmpty()
     {

--- a/src/Proto.TestKit/PropsTestProbeExtensions.cs
+++ b/src/Proto.TestKit/PropsTestProbeExtensions.cs
@@ -15,7 +15,7 @@ public static class PropsTestProbeExtensions
         props.WithReceiverMiddleware(next => async (ctx, env) =>
         {
             await next(ctx, env);
-            probe.Context.Send(probe.Context.Self, new MessageEnvelope(env.Message, env.Sender));
+            probe.Send(probe, new MessageEnvelope(env.Message, env.Sender));
         });
 
     /// <summary>
@@ -24,7 +24,7 @@ public static class PropsTestProbeExtensions
     public static Props WithSendProbe(this Props props, TestProbe probe) =>
         props.WithSenderMiddleware(next => async (ctx, target, env) =>
         {
-            probe.Context.Send(probe.Context.Self, new MessageEnvelope(env.Message, target));
+            probe.Send(probe, new MessageEnvelope(env.Message, target));
             await next(ctx, target, env);
         });
 

--- a/src/Proto.TestKit/TestProbe.cs
+++ b/src/Proto.TestKit/TestProbe.cs
@@ -46,8 +46,7 @@ public class TestProbe : IActor, ITestProbe
     /// <inheritdoc />
     public PID? Sender { get; private set; }
 
-    /// <inheritdoc />
-    public IContext Context
+    private IContext Context
     {
         get
         {
@@ -59,7 +58,7 @@ public class TestProbe : IActor, ITestProbe
 
             return _context!;
         }
-        private set => _context = value;
+        set => _context = value;
     }
 
     /// <inheritdoc />
@@ -182,6 +181,10 @@ public class TestProbe : IActor, ITestProbe
     /// <inheritdoc />
     public Task<T> RequestAsync<T>(PID target, object message, TimeSpan timeAllowed) =>
         Context.RequestAsync<T>(target, message, timeAllowed);
+
+    public void Watch(PID pid) => Context.Watch(pid);
+
+    public void Unwatch(PID pid) => Context.Unwatch(pid);
 
     public static implicit operator PID?(TestProbe tp) => tp.Context.Self;
 

--- a/tests/Proto.Actor.Tests/Router/BroadcastPoolRouterTests.cs
+++ b/tests/Proto.Actor.Tests/Router/BroadcastPoolRouterTests.cs
@@ -35,9 +35,9 @@ public class BroadcastPoolRouterTests
         var routee2 = routees.Pids[1];
         var routee3 = routees.Pids[2];
 
-        var probe1 = probes.Find(p => p.Context.Self == routee1)!;
-        var probe2 = probes.Find(p => p.Context.Self == routee2)!;
-        var probe3 = probes.Find(p => p.Context.Self == routee3)!;
+        var probe1 = probes.Find(p => (PID)p == routee1)!;
+        var probe2 = probes.Find(p => (PID)p == routee2)!;
+        var probe3 = probes.Find(p => (PID)p == routee3)!;
 
         system.Root.Send(router, "first");
         await probe1.ExpectNextUserMessageAsync<string>(x => x == "first");

--- a/tests/Proto.Remote.Tests/RemoteTests.cs
+++ b/tests/Proto.Remote.Tests/RemoteTests.cs
@@ -165,7 +165,7 @@ public abstract class RemoteTests
         var remoteActor = await SpawnRemoteActor(_fixture.RemoteAddress);
 
         var (probe, _) = System.CreateTestProbe();
-        probe.Context.Watch(remoteActor);
+        probe.Watch(remoteActor);
 
         await System.Root.PoisonAsync(remoteActor);
 
@@ -180,8 +180,8 @@ public abstract class RemoteTests
         var remoteActor2 = await SpawnRemoteActor(_fixture.RemoteAddress);
 
         var (probe, _) = System.CreateTestProbe();
-        probe.Context.Watch(remoteActor1);
-        probe.Context.Watch(remoteActor2);
+        probe.Watch(remoteActor1);
+        probe.Watch(remoteActor2);
 
         await System.Root.PoisonAsync(remoteActor1);
         await System.Root.PoisonAsync(remoteActor2);
@@ -201,8 +201,8 @@ public abstract class RemoteTests
 
         var (probe1, _) = System.CreateTestProbe();
         var (probe2, _) = System.CreateTestProbe();
-        probe1.Context.Watch(remoteActor);
-        probe2.Context.Watch(remoteActor);
+        probe1.Watch(remoteActor);
+        probe2.Watch(remoteActor);
 
         await System.Root.PoisonAsync(remoteActor);
 
@@ -218,10 +218,10 @@ public abstract class RemoteTests
 
         var (probe1, _) = System.CreateTestProbe();
         var (probe2, _) = System.CreateTestProbe();
-        probe1.Context.Watch(remoteActor);
-        probe2.Context.Watch(remoteActor);
+        probe1.Watch(remoteActor);
+        probe2.Watch(remoteActor);
 
-        probe2.Context.Unwatch(remoteActor);
+        probe2.Unwatch(remoteActor);
         await Task.Delay(TimeSpan.FromSeconds(3));
 
         await System.Root.PoisonAsync(remoteActor);
@@ -238,7 +238,7 @@ public abstract class RemoteTests
         var remoteActor = await SpawnRemoteActor(_fixture.RemoteAddress);
 
         var (probe, _) = System.CreateTestProbe();
-        probe.Context.Watch(remoteActor);
+        probe.Watch(remoteActor);
 
         System.Root.Send(remoteActor, new Die());
 

--- a/tests/Proto.TestKit.Tests/TestProbeAsyncTests.cs
+++ b/tests/Proto.TestKit.Tests/TestProbeAsyncTests.cs
@@ -52,17 +52,6 @@ public class TestProbeAsyncTests
         var (probe, pid) = system.CreateTestProbe();
 
         system.Root.Send(pid, "hello");
-        SpinWait.SpinUntil(() =>
-        {
-            try
-            {
-                return probe.Context != null;
-            }
-            catch
-            {
-                return false;
-            }
-        }, TimeSpan.FromSeconds(1));
         await Assert.ThrowsAsync<TestKitException>(() => probe.ExpectEmptyMailboxAsync());
     }
 }


### PR DESCRIPTION
## Summary
- hide TestProbe actor context and expose explicit Watch/Unwatch helpers
- route probe messages through Send API instead of direct context access
- update tests to use new probe methods

## Testing
- `dotnet test tests/Proto.TestKit.Tests/Proto.TestKit.Tests.csproj`
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a88eb4d1f883289f0535c4c6db7a65