### PR TITLE
refactor: add TestProbe.Self property

### DIFF
--- a/logs/log1755879377.md
+++ b/logs/log1755879377.md
@@ -1,0 +1,10 @@
+- **src/Proto.TestKit/ITestProbe.cs**: Added `Self` property so probes can expose their PID without relying on implicit conversions.
+- **src/Proto.TestKit/TestProbe.cs**: Removed implicit PID conversion and introduced `Self` getter, clarifying how to obtain the probe's PID.
+- **src/Proto.TestKit/ProbeMailboxStatistics.cs**: Switched internal sending to `_probe.Self` to match new API.
+- **src/Proto.TestKit/PropsTestProbeExtensions.cs**: Updated middleware helpers to send via `probe.Self` rather than implicit conversion.
+- **tests/Proto.Actor.Tests/ReceiveTimeoutTests.cs**: Adjusted test actor code to send to `probe.Self` explicitly.
+- **tests/Proto.Actor.Tests/Router/BroadcastGroupTests.cs**: Modified helper actor to forward messages using `_probe.Self`.
+- **tests/Proto.Actor.Tests/Router/BroadcastPoolRouterTests.cs**: Resolved routee lookup by comparing `p.Self` with returned PIDs.
+- **tests/Proto.Actor.Tests/Router/ConsistentHashGroupTests.cs**: Replaced implicit probe-to-PID usages with explicit `Self` property.
+- **tests/Proto.Actor.Tests/Router/RandomGroupRouterTests.cs**: Updated router tests to reference `probe.Self` wherever a PID is required.
+- **tests/Proto.Actor.Tests/Router/RoundRobinGroupTests.cs**: Converted probe usages to `Self` property, keeping existing PID variables where already provided.

--- a/logs/log1755879960.md
+++ b/logs/log1755879960.md
@@ -1,0 +1,19 @@
+# Change Log
+
+## tests/Proto.Actor.Tests/Router/BroadcastGroupTests.cs
+- dropped manual `Touch` dance and replaced with `ExpectEmptyMailboxAsync` after routee removal to confirm no further messages.
+
+## tests/Proto.Actor.Tests/Router/BroadcastPoolRouterTests.cs
+- removed explicit `RequestAsync<Touched>` and `ExpectNoMessageAsync`; now a single `ExpectEmptyMailboxAsync` validates routee is silent post-removal.
+
+## tests/Proto.Actor.Tests/Router/RandomGroupRouterTests.cs
+- simplified removed-routee test by using `ExpectEmptyMailboxAsync` after message flood, eliminating separate touch request.
+
+## tests/Proto.Actor.Tests/Router/RoundRobinGroupTests.cs
+- replaced touch/no-message checks with `ExpectEmptyMailboxAsync` when routee is removed.
+- converted remaining `ExpectNoMessageAsync` assertions to `ExpectEmptyMailboxAsync` for better liveness verification.
+
+## tests/Proto.Actor.Tests/Router/ConsistentHashGroupTests.cs
+- swapped manual touch and no-message assertions for `ExpectEmptyMailboxAsync` in removal and reassignment scenarios.
+- updated other tests to prefer `ExpectEmptyMailboxAsync` over `ExpectNoMessageAsync` for idle probes.
+

--- a/src/Proto.TestKit/ITestProbe.cs
+++ b/src/Proto.TestKit/ITestProbe.cs
@@ -23,6 +23,11 @@ public interface ITestProbe
     PID? Sender { get; }
 
     /// <summary>
+    ///     The PID of this probe.
+    /// </summary>
+    PID Self { get; }
+
+    /// <summary>
     ///     asynchronously checks that no message arrives within the time allowed
     /// </summary>
     /// <param name="timeAllowed"></param>

--- a/src/Proto.TestKit/ProbeMailboxStatistics.cs
+++ b/src/Proto.TestKit/ProbeMailboxStatistics.cs
@@ -20,7 +20,7 @@ public class ProbeMailboxStatistics : IMailboxStatistics
     }
 
     public void MessageReceived(object message) =>
-        _probe.Send(_probe, message);
+        _probe.Send(_probe.Self, message);
 
     public void MailboxEmpty()
     {

--- a/src/Proto.TestKit/PropsTestProbeExtensions.cs
+++ b/src/Proto.TestKit/PropsTestProbeExtensions.cs
@@ -15,7 +15,7 @@ public static class PropsTestProbeExtensions
         props.WithReceiverMiddleware(next => async (ctx, env) =>
         {
             await next(ctx, env);
-            probe.Send(probe, new MessageEnvelope(env.Message, env.Sender));
+            probe.Send(probe.Self, new MessageEnvelope(env.Message, env.Sender));
         });
 
     /// <summary>
@@ -24,7 +24,7 @@ public static class PropsTestProbeExtensions
     public static Props WithSendProbe(this Props props, TestProbe probe) =>
         props.WithSenderMiddleware(next => async (ctx, target, env) =>
         {
-            probe.Send(probe, new MessageEnvelope(env.Message, target));
+            probe.Send(probe.Self, new MessageEnvelope(env.Message, target));
             await next(ctx, target, env);
         });
 

--- a/src/Proto.TestKit/TestProbe.cs
+++ b/src/Proto.TestKit/TestProbe.cs
@@ -46,6 +46,11 @@ public class TestProbe : IActor, ITestProbe
     /// <inheritdoc />
     public PID? Sender { get; private set; }
 
+    /// <summary>
+    ///     The PID of this probe.
+    /// </summary>
+    public PID Self => Context.Self;
+
     private IContext Context
     {
         get
@@ -186,7 +191,6 @@ public class TestProbe : IActor, ITestProbe
 
     public void Unwatch(PID pid) => Context.Unwatch(pid);
 
-    public static implicit operator PID?(TestProbe tp) => tp.Context.Self;
 
     private async Task<MessageAndSender> ReceiveNextAsync(TimeSpan? timeAllowed,
         CancellationToken cancellationToken)

--- a/tests/Proto.Actor.Tests/ReceiveTimeoutTests.cs
+++ b/tests/Proto.Actor.Tests/ReceiveTimeoutTests.cs
@@ -24,7 +24,7 @@ public class ReceiveTimeoutTests
                         ctx.SetReceiveTimeout(TimeSpan.FromMilliseconds(150));
                         break;
                     case ReceiveTimeout msg:
-                        ctx.Send(probe, msg);
+                        ctx.Send(probe.Self, msg);
                         break;
                 }
 
@@ -52,7 +52,7 @@ public class ReceiveTimeoutTests
                         ctx.SetReceiveTimeout(TimeSpan.FromMilliseconds(150));
                         break;
                     case ReceiveTimeout msg:
-                        ctx.Send(probe, msg);
+                        ctx.Send(probe.Self, msg);
                         break;
                 }
 
@@ -86,7 +86,7 @@ public class ReceiveTimeoutTests
                         // regular messages reset the receive timeout
                         break;
                     case ReceiveTimeout msg:
-                        ctx.Send(probe, msg);
+                        ctx.Send(probe.Self, msg);
                         break;
                 }
 
@@ -116,10 +116,10 @@ public class ReceiveTimeoutTests
                 {
                     case Started:
                         ctx.SetReceiveTimeout(TimeSpan.FromMilliseconds(1500));
-                        ctx.Send(probe, "started");
+                        ctx.Send(probe.Self, "started");
                         break;
                     case ReceiveTimeout msg:
-                        ctx.Send(probe, msg);
+                        ctx.Send(probe.Self, msg);
                         break;
                 }
 
@@ -152,7 +152,7 @@ public class ReceiveTimeoutTests
                         endingTimeout = ctx.ReceiveTimeout;
                         break;
                     case ReceiveTimeout msg:
-                        ctx.Send(probe, msg); // should never happen
+                        ctx.Send(probe.Self, msg); // should never happen
                         break;
                 }
 
@@ -184,7 +184,7 @@ public class ReceiveTimeoutTests
                         ctx.SetReceiveTimeout(TimeSpan.FromMilliseconds(150));
                         break;
                     case ReceiveTimeout msg:
-                        ctx.Send(probe, msg);
+                        ctx.Send(probe.Self, msg);
                         break;
                 }
 

--- a/tests/Proto.Actor.Tests/Router/BroadcastGroupTests.cs
+++ b/tests/Proto.Actor.Tests/Router/BroadcastGroupTests.cs
@@ -98,14 +98,12 @@ public class BroadcastGroupTests
         system.Root.Send(router, "first message");
         system.Root.Send(router, new RouterRemoveRoutee(routee1));
         await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
-        await system.Root.RequestAsync<Touched>(routee1, new Touch(), _timeout);
         system.Root.Send(router, "second message");
 
         await probe1.ExpectNextUserMessageAsync<string>(x => x == "first message");
         await probe2.ExpectNextUserMessageAsync<string>(x => x == "first message");
         await probe3.ExpectNextUserMessageAsync<string>(x => x == "first message");
-        await probe1.ExpectNextUserMessageAsync<Touch>();
-        await probe1.ExpectNoMessageAsync(_timeout);
+        await probe1.ExpectEmptyMailboxAsync(_timeout);
         await probe2.ExpectNextUserMessageAsync<string>(x => x == "second message");
         await probe3.ExpectNextUserMessageAsync<string>(x => x == "second message");
     }
@@ -178,7 +176,7 @@ public class BroadcastGroupTests
                 return;
             }
 
-            context.Send(_probe, context.Message);
+            context.Send(_probe.Self, context.Message);
         }
     }
 }

--- a/tests/Proto.Actor.Tests/Router/BroadcastPoolRouterTests.cs
+++ b/tests/Proto.Actor.Tests/Router/BroadcastPoolRouterTests.cs
@@ -35,9 +35,9 @@ public class BroadcastPoolRouterTests
         var routee2 = routees.Pids[1];
         var routee3 = routees.Pids[2];
 
-        var probe1 = probes.Find(p => (PID)p == routee1)!;
-        var probe2 = probes.Find(p => (PID)p == routee2)!;
-        var probe3 = probes.Find(p => (PID)p == routee3)!;
+        var probe1 = probes.Find(p => p.Self == routee1)!;
+        var probe2 = probes.Find(p => p.Self == routee2)!;
+        var probe3 = probes.Find(p => p.Self == routee3)!;
 
         system.Root.Send(router, "first");
         await probe1.ExpectNextUserMessageAsync<string>(x => x == "first");
@@ -46,13 +46,10 @@ public class BroadcastPoolRouterTests
 
         system.Root.Send(router, new RouterRemoveRoutee(routee1));
         await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
-        await system.Root.RequestAsync<Touched>(routee1, new Touch(), _timeout);
-        await probe1.ExpectNextUserMessageAsync<Touch>();
-
         system.Root.Send(router, "second");
 
         await probe2.ExpectNextUserMessageAsync<string>(x => x == "second");
         await probe3.ExpectNextUserMessageAsync<string>(x => x == "second");
-        await probe1.ExpectNoMessageAsync();
+        await probe1.ExpectEmptyMailboxAsync(_timeout);
     }
 }

--- a/tests/Proto.Actor.Tests/Router/ConsistentHashGroupTests.cs
+++ b/tests/Proto.Actor.Tests/Router/ConsistentHashGroupTests.cs
@@ -25,8 +25,8 @@ public class ConsistentHashGroupTests
         system.Root.Send(router, new Message("message1"));
         await probe1.ExpectNextUserMessageAsync<Message>(m => m.ToString() == "message1");
 
-        await probe2.ExpectNoMessageAsync();
-        await probe3.ExpectNoMessageAsync();
+        await probe2.ExpectEmptyMailboxAsync(_timeout);
+        await probe3.ExpectEmptyMailboxAsync(_timeout);
     }
 
     [Fact]
@@ -43,8 +43,8 @@ public class ConsistentHashGroupTests
         system.Root.Send(router, "message1");
         await probe1.ExpectNextUserMessageAsync<string>(x => x == "message1");
 
-        await probe2.ExpectNoMessageAsync();
-        await probe3.ExpectNoMessageAsync();
+        await probe2.ExpectEmptyMailboxAsync(_timeout);
+        await probe3.ExpectEmptyMailboxAsync(_timeout);
     }
 
     [Fact]
@@ -78,9 +78,9 @@ public class ConsistentHashGroupTests
         system.Root.Send(router, new Message("message1"));
 
         await probe1.ExpectNextUserMessageAsync<Message>(m => m.ToString() == "message1");
-        await probe2.ExpectNoMessageAsync();
-        await probe3.ExpectNoMessageAsync();
-        await probe4.ExpectNoMessageAsync();
+        await probe2.ExpectEmptyMailboxAsync(_timeout);
+        await probe3.ExpectEmptyMailboxAsync(_timeout);
+        await probe4.ExpectEmptyMailboxAsync(_timeout);
     }
 
     [Fact]
@@ -90,12 +90,12 @@ public class ConsistentHashGroupTests
 
         var (router, routee1, routee2, routee3) = CreateRouterWith3Routees(system);
 
-        system.Root.Send(router, new RouterRemoveRoutee(routee1));
+        system.Root.Send(router, new RouterRemoveRoutee(routee1.Self));
 
         var routees = await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
-        Assert.DoesNotContain(routee1, routees.Pids);
-        Assert.Contains(routee2, routees.Pids);
-        Assert.Contains(routee3, routees.Pids);
+        Assert.DoesNotContain(routee1.Self, routees.Pids);
+        Assert.Contains(routee2.Self, routees.Pids);
+        Assert.Contains(routee3.Self, routees.Pids);
     }
 
     [Fact]
@@ -108,9 +108,9 @@ public class ConsistentHashGroupTests
         system.Root.Send(router, new RouterAddRoutee(routee4));
 
         var routees = await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
-        Assert.Contains((PID)routee1, routees.Pids);
-        Assert.Contains((PID)routee2, routees.Pids);
-        Assert.Contains((PID)routee3, routees.Pids);
+        Assert.Contains(routee1.Self, routees.Pids);
+        Assert.Contains(routee2.Self, routees.Pids);
+        Assert.Contains(routee3.Self, routees.Pids);
         Assert.Contains(routee4, routees.Pids);
     }
 
@@ -121,12 +121,10 @@ public class ConsistentHashGroupTests
 
         var (router, probe1, _, _) = CreateRouterWith3Routees(system);
 
-        system.Root.Send(router, new RouterRemoveRoutee(probe1));
+        system.Root.Send(router, new RouterRemoveRoutee(probe1.Self));
         await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
-        await system.Root.RequestAsync<Touched>(probe1, new Touch(), _timeout);
-        await probe1.ExpectNextUserMessageAsync<Touch>();
         system.Root.Send(router, new Message("message1"));
-        await probe1.ExpectNoMessageAsync();
+        await probe1.ExpectEmptyMailboxAsync(_timeout);
     }
 
     [Fact]
@@ -151,11 +149,10 @@ public class ConsistentHashGroupTests
 
         system.Root.Send(router, new Message("message1"));
         await probe1.ExpectNextUserMessageAsync<Message>(m => m.ToString() == "message1");
-        system.Root.Send(router, new RouterRemoveRoutee(probe1));
+        system.Root.Send(router, new RouterRemoveRoutee(probe1.Self));
         await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
-        await system.Root.RequestAsync<Touched>(probe1, new Touch(), _timeout);
-        await probe1.ExpectNextUserMessageAsync<Touch>();
         system.Root.Send(router, new Message("message1"));
+        await probe1.ExpectEmptyMailboxAsync(_timeout);
 
         await probe2.ExpectNextUserMessageAsync<Message>(m => m.ToString() == "message1");
     }

--- a/tests/Proto.Actor.Tests/Router/RandomGroupRouterTests.cs
+++ b/tests/Proto.Actor.Tests/Router/RandomGroupRouterTests.cs
@@ -56,18 +56,16 @@ public class RandomGroupRouterTests
 
         var (router, probe1, _, _) = CreateRouterWith3Routees(system);
 
-        system.Root.Send(router, new RouterRemoveRoutee(probe1));
+        system.Root.Send(router, new RouterRemoveRoutee(probe1.Self));
 
         await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
-        await system.Root.RequestAsync<Touched>(probe1, new Touch(), _timeout);
-        await probe1.ExpectNextUserMessageAsync<Touch>();
 
         for (var i = 0; i < 100; i++)
         {
             system.Root.Send(router, i.ToString());
         }
 
-        await probe1.ExpectNoMessageAsync();
+        await probe1.ExpectEmptyMailboxAsync(_timeout);
     }
 
     [Fact]
@@ -78,12 +76,12 @@ public class RandomGroupRouterTests
 
         var (router, routee1, routee2, routee3) = CreateRouterWith3Routees(system);
 
-        system.Root.Send(router, new RouterRemoveRoutee(routee1));
+        system.Root.Send(router, new RouterRemoveRoutee(routee1.Self));
 
         var routees = await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
-        Assert.DoesNotContain(routee1, routees.Pids);
-        Assert.Contains(routee2, routees.Pids);
-        Assert.Contains(routee3, routees.Pids);
+        Assert.DoesNotContain(routee1.Self, routees.Pids);
+        Assert.Contains(routee2.Self, routees.Pids);
+        Assert.Contains(routee3.Self, routees.Pids);
     }
 
     [Fact]
@@ -97,9 +95,9 @@ public class RandomGroupRouterTests
         system.Root.Send(router, new RouterAddRoutee(routee4));
 
         var routees = await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
-        Assert.Contains(routee1, routees.Pids);
-        Assert.Contains(routee2, routees.Pids);
-        Assert.Contains(routee3, routees.Pids);
+        Assert.Contains(routee1.Self, routees.Pids);
+        Assert.Contains(routee2.Self, routees.Pids);
+        Assert.Contains(routee3.Self, routees.Pids);
         Assert.Contains(routee4, routees.Pids);
     }
 

--- a/tests/Proto.Actor.Tests/Router/RoundRobinGroupTests.cs
+++ b/tests/Proto.Actor.Tests/Router/RoundRobinGroupTests.cs
@@ -21,23 +21,23 @@ public class RoundRobinGroupTests
 
         system.Root.Send(router, "1");
         await probe1.ExpectNextUserMessageAsync<string>(x => x == "1");
-        await probe2.ExpectNoMessageAsync();
-        await probe3.ExpectNoMessageAsync();
+        await probe2.ExpectEmptyMailboxAsync(_timeout);
+        await probe3.ExpectEmptyMailboxAsync(_timeout);
 
         system.Root.Send(router, "2");
         await probe2.ExpectNextUserMessageAsync<string>(x => x == "2");
-        await probe1.ExpectNoMessageAsync();
-        await probe3.ExpectNoMessageAsync();
+        await probe1.ExpectEmptyMailboxAsync(_timeout);
+        await probe3.ExpectEmptyMailboxAsync(_timeout);
 
         system.Root.Send(router, "3");
         await probe3.ExpectNextUserMessageAsync<string>(x => x == "3");
-        await probe1.ExpectNoMessageAsync();
-        await probe2.ExpectNoMessageAsync();
+        await probe1.ExpectEmptyMailboxAsync(_timeout);
+        await probe2.ExpectEmptyMailboxAsync(_timeout);
 
         system.Root.Send(router, "4");
         await probe1.ExpectNextUserMessageAsync<string>(x => x == "4");
-        await probe2.ExpectNoMessageAsync();
-        await probe3.ExpectNoMessageAsync();
+        await probe2.ExpectEmptyMailboxAsync(_timeout);
+        await probe3.ExpectEmptyMailboxAsync(_timeout);
     }
 
     [Fact]
@@ -95,10 +95,8 @@ public class RoundRobinGroupTests
         await probe2.ExpectNextUserMessageAsync<string>(x => x == "0");
         system.Root.Send(router, "0");
         await probe3.ExpectNextUserMessageAsync<string>(x => x == "0");
-        system.Root.Send(router, new RouterRemoveRoutee(probe1));
+        system.Root.Send(router, new RouterRemoveRoutee(probe1.Self));
         await system.Root.RequestAsync<Routees>(router, new RouterGetRoutees(), _timeout);
-        await system.Root.RequestAsync<Touched>(probe1, new Touch(), _timeout);
-        await probe1.ExpectNextUserMessageAsync<Touch>();
 
         system.Root.Send(router, "3");
         await probe3.ExpectNextUserMessageAsync<string>(x => x == "3");
@@ -107,7 +105,7 @@ public class RoundRobinGroupTests
         system.Root.Send(router, "3");
         await probe3.ExpectNextUserMessageAsync<string>(x => x == "3");
 
-        await probe1.ExpectNoMessageAsync();
+        await probe1.ExpectEmptyMailboxAsync(_timeout);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- expose TestProbe PID via new `Self` property and drop implicit PID conversion
- adjust internal helpers and tests to use explicit `probe.Self`
- streamline router tests by replacing manual touch/no-message checks with `ExpectEmptyMailboxAsync`

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a894b8e08c8328b9787c2ab1e546c7