### PR TITLE
docs: focus testkit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,33 +92,6 @@ You should see the output `Hello Alex`.
 
 [https://github.com/asynkron/realtimemap-dotnet](https://github.com/asynkron/realtimemap-dotnet)
 
-## TestKit
-
-Proto.Actor includes a TestKit library for unit testing actors.
-
-- **TestProbe** is an actor that records incoming messages. The API is fully asynchronous:
-
-  ```csharp
-  var probe = new TestProbe();
-  system.Root.Spawn(Props.FromProducer(() => probe));
-  await probe.ExpectNextUserMessageAsync<string>();
-  await probe.ExpectNoMessageAsync(TimeSpan.FromMilliseconds(100));
-  ```
-
-- **TestMailboxStats** captures mailbox events such as posted and received messages:
-
-  ```csharp
-  var stats = new TestMailboxStats(msg => msg is MyMessage);
-  var props = Props.FromProducer(() => new MyActor())
-      .WithMailbox(() => UnboundedMailbox.Create(stats));
-  ```
-
-- **Props extensions** help observe actor behavior:
-
-  - `WithReceiveProbe` intercepts messages an actor receives.
-  - `WithSendProbe` observes messages an actor sends.
-  - `WithMailboxProbe` taps into mailbox traffic using `ProbeMailboxStatistics`.
-
 ## Contributors
 
 <a href="https://github.com/asynkron/protoactor-dotnet/graphs/contributors">

--- a/logs/log1755881596.md
+++ b/logs/log1755881596.md
@@ -1,0 +1,7 @@
+# Change Log
+
+## README.md
+- Removed TestKit section to avoid duplicating documentation; dedicated TestKit README now covers these details.
+
+## src/Proto.TestKit/README.md
+- Expanded documentation to cover all TestKit features and practical use cases, including TestProbe, mailbox statistics, Props extensions, awaiting conditions, and deterministic scheduler tests.

--- a/src/Proto.TestKit/README.md
+++ b/src/Proto.TestKit/README.md
@@ -2,6 +2,47 @@
 
 `Proto.TestKit` provides utilities for writing unit tests against Proto.Actor components.
 
+## TestProbe: observing messages
+
+`TestProbe` is an actor that records incoming messages asynchronously. Use it to verify
+that actors send the expected messages or to assert that no messages are received
+within a given period.
+
+```csharp
+var probe = new TestProbe();
+system.Root.Spawn(Props.FromProducer(() => probe));
+await probe.ExpectNextUserMessageAsync<string>();
+await probe.ExpectNoMessageAsync(TimeSpan.FromMilliseconds(100));
+```
+
+Practical when: you need fine‑grained assertions about message flow without modifying
+the actors under test.
+
+## Mailbox statistics
+
+`TestMailboxStats` captures mailbox activity such as posted and received messages. It helps
+diagnose how an actor uses its mailbox and whether specific messages were enqueued.
+
+```csharp
+var stats = new TestMailboxStats(msg => msg is MyMessage);
+var props = Props.FromProducer(() => new MyActor())
+    .WithMailbox(() => UnboundedMailbox.Create(stats));
+```
+
+Practical when: you want insight into mailbox throughput or to confirm that particular
+messages entered the mailbox.
+
+## Props extensions
+
+The TestKit includes `Props` extensions that instrument actors:
+
+- `WithReceiveProbe` intercepts messages an actor receives.
+- `WithSendProbe` observes messages an actor sends.
+- `WithMailboxProbe` taps into mailbox traffic using `ProbeMailboxStatistics`.
+
+These helpers are useful when debugging complex message interactions while keeping
+the actor code unchanged.
+
 ## Awaiting Conditions
 
 Use `AwaitConditionAsync` to poll for a condition until it becomes true:
@@ -12,14 +53,17 @@ using static Proto.TestKit.TestKit;
 await AwaitConditionAsync(() => value == expected, TimeSpan.FromSeconds(5), "value was never updated");
 ```
 
-The helper evaluates the condition every 20ms and throws a `TimeoutException`—including the optional
-message—if the condition is not met within the supplied timeout.
+The helper evaluates the condition every 20ms and throws a `TimeoutException`—including
+the optional message—if the condition is not met within the supplied timeout.
+
+Practical when: a test depends on asynchronous state changes and busy‑waiting would
+introduce flakiness.
 
 ## Deterministic Scheduler Tests
 
-`Proto.Timers` exposes a test hook, `ISchedulerHook`, that signals when a
-`Scheduler` has registered its internal `Task.Delay` timer. When testing with
-`FakeTimeProvider`, await this hook before advancing time to avoid flakiness:
+`Proto.Timers` exposes a test hook, `ISchedulerHook`, that signals when a `Scheduler`
+has registered its internal `Task.Delay` timer. When testing with `FakeTimeProvider`,
+await this hook before advancing time to avoid flakiness:
 
 ```csharp
 var hook = new TestSchedulerHook();
@@ -30,6 +74,8 @@ await hook.WaitAsync();
 fakeTimeProvider.Advance(TimeSpan.FromSeconds(5));
 ```
 
-Implement `ISchedulerHook` with a `TaskCompletionSource` to observe timer
-registration. This allows tests to deterministically control when scheduled
-messages are delivered.
+Implement `ISchedulerHook` with a `TaskCompletionSource` to observe timer registration.
+This allows tests to deterministically control when scheduled messages are delivered.
+
+Practical when: verifying behavior that relies on timers or scheduled messages.
+


### PR DESCRIPTION
## Summary
- remove TestKit section from main README
- expand Proto.TestKit README with feature overview and usage tips

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a89f26c5408328bcdd217fca5c8499