### PR TITLE
feat(testkit): enqueue repeated start

### DIFF
--- a/logs/log1755884377.md
+++ b/logs/log1755884377.md
@@ -1,0 +1,4 @@
+## Log 1755884377
+- Updated TestProbe to track its own startup and enqueue subsequent `Started` messages so tests can assert restarts.
+- Added regression test ensuring extra `Started` messages are captured by probes.
+- Adjusted probe middleware tests to account for new queued `Started` message.

--- a/src/Proto.TestKit/TestProbe.cs
+++ b/src/Proto.TestKit/TestProbe.cs
@@ -19,14 +19,21 @@ public class TestProbe : IActor, ITestProbe
     private readonly Channel<MessageAndSender> _channel = Channel.CreateUnbounded<MessageAndSender>();
 
     private IContext? _context;
+    // Tracks if the probe has processed its own startup.
+    private bool _started;
 
     /// <inheritdoc />
     public Task ReceiveAsync(IContext context)
     {
         switch (context.Message)
         {
-            case Started _:
+            case Started _ when !_started:
                 Context = context;
+                _started = true;
+
+                break;
+            case Started _:
+                _channel.Writer.TryWrite(new MessageAndSender(context));
 
                 break;
             case Terminated _:

--- a/tests/Proto.TestKit.Tests/ProbeMiddlewareTests.cs
+++ b/tests/Proto.TestKit.Tests/ProbeMiddlewareTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using FluentAssertions;
+using Proto;
 using Proto.TestKit;
 using Xunit;
 
@@ -30,6 +31,9 @@ public class ProbeMiddlewareTests
         var props = Props.FromProducer(() => new ForwardActor(target)).WithSendProbe(probe);
         var pid = system.Root.Spawn(props);
 
+        // The probe receives a Started message when the actor starts
+        await probe.ExpectNextSystemMessageAsync<Started>();
+
         system.Root.Send(pid, "hi");
         await probe.ExpectNextUserMessageAsync<string>(s => s == "hi");
         probe.Sender.Should().Be(target);
@@ -43,6 +47,9 @@ public class ProbeMiddlewareTests
 
         var props = Props.FromProducer(() => new EmptyActor()).WithMailboxProbe(probe);
         var pid = system.Root.Spawn(props);
+
+        // The probe receives a Started message when the actor starts
+        await probe.ExpectNextSystemMessageAsync<Started>();
 
         system.Root.Send(pid, "hello");
         await probe.ExpectNextUserMessageAsync<string>(s => s == "hello");

--- a/tests/Proto.TestKit.Tests/TestProbeAsyncTests.cs
+++ b/tests/Proto.TestKit.Tests/TestProbeAsyncTests.cs
@@ -54,5 +54,17 @@ public class TestProbeAsyncTests
         system.Root.Send(pid, "hello");
         await Assert.ThrowsAsync<TestKitException>(() => probe.ExpectEmptyMailboxAsync());
     }
+
+    [Fact]
+    public async Task SubsequentStartedMessages_are_enqueued()
+    {
+        var system = new ActorSystem();
+        var (probe, pid) = system.CreateTestProbe();
+
+        // Send an extra Started message and ensure probe receives it
+        system.Root.Send(pid, Started.Instance);
+
+        await probe.ExpectNextSystemMessageAsync<Started>();
+    }
 }
 }


### PR DESCRIPTION
## Summary
- track TestProbe startup to enqueue later `Started` messages
- add coverage and adjust probe middleware tests

## Testing
- `dotnet test tests/Proto.TestKit.Tests/Proto.TestKit.Tests.csproj -c Release`
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -c Release`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj -c Release`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68a8ab0ab1c083288e4e9bc37d28aa3a