### PR TITLE
Use ExpectEmptyMailbox in watch test

### DIFF
--- a/logs/log1755887131.md
+++ b/logs/log1755887131.md
@@ -1,0 +1,2 @@
+## Log
+- Updated `tests/Proto.Actor.Tests/WatchTests.cs` to use `ExpectEmptyMailboxAsync` after receiving the `Terminated` system message in `MultipleStopsTriggerSingleTerminated`. This ensures the probe mailbox is fully drained and adheres to preferred testing utilities.

--- a/tests/Proto.Actor.Tests/WatchTests.cs
+++ b/tests/Proto.Actor.Tests/WatchTests.cs
@@ -37,7 +37,8 @@ public class WatchTests
         context.Send(child, "stop");
 
         await probe.ExpectNextSystemMessageAsync<Terminated>(t => Equals(t.Who, child));
-        await probe.ExpectNoMessageAsync(TimeSpan.FromMilliseconds(100));
+        // ensure no additional messages are left in the probe
+        await probe.ExpectEmptyMailboxAsync();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- ensure watch tests drain probe mailbox after termination

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8b5db6f008328a0bc5d92e346353b