### PR TITLE
Use AwaitConditionAsync in PID cache invalidation test

### DIFF
--- a/logs/log1755887133.md
+++ b/logs/log1755887133.md
@@ -1,0 +1,1 @@
+- Added static Proto.TestKit.TestKit import and replaced fixed Task.Delay in PidCacheInvalidationTests with AwaitConditionAsync to poll PID cache until entry is removed.

--- a/tests/Proto.Cluster.Tests/PidCacheInvalidationTests.cs
+++ b/tests/Proto.Cluster.Tests/PidCacheInvalidationTests.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ClusterTest.Messages;
 using FluentAssertions;
+using static Proto.TestKit.TestKit;
 using Xunit;
 
 namespace Proto.Cluster.Tests;
@@ -37,7 +38,9 @@ public class PidCacheInvalidationTests : IClassFixture<InMemoryPidCacheInvalidat
         cachedPid.Should().NotBeNull();
         await remoteMember.RequestAsync<object>(id, EchoActor.Kind, new Die(), CancellationToken.None);
 
-        await Task.Delay(2000); // PidCache is asynchronously cleared, allow the system to purge it
+        await AwaitConditionAsync(
+            () => GetFromPidCache(remoteMember, id) is null,
+            TimeSpan.FromSeconds(5)); // Wait until the pid cache entry is purged
 
         var cachedPidAfterStopping = GetFromPidCache(remoteMember, id);
 


### PR DESCRIPTION
## Summary
- replace fixed delay in PID cache invalidation test with AwaitConditionAsync to wait for real cache removal

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8b5c7085c8328829c8bce72629983