### PR TITLE
Ensure block list propagation before gossip in graceful leave test

### DIFF
--- a/logs/log1755887170.md
+++ b/logs/log1755887170.md
@@ -1,0 +1,3 @@
+# Change Log
+
+- Updated `tests/Proto.Cluster.Tests/GracefulLeaveTests.cs` to wait for the leaving member to appear in the block list using `TestKit.AwaitConditionAsync` before sending a gossip request. This replaces the fixed delay and makes the test more deterministic.

--- a/tests/Proto.Cluster.Tests/GracefulLeaveTests.cs
+++ b/tests/Proto.Cluster.Tests/GracefulLeaveTests.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Google.Protobuf.WellKnownTypes;
 using Proto;
 using Proto.Cluster.Gossip;
+using static Proto.TestKit.TestKit;
 using Proto.Utils;
 using Xunit;
 
@@ -23,8 +25,10 @@ public class GracefulLeaveTests
 
         await leaver.Gossip.SetStateAsync(GossipKeys.GracefullyLeft, new Empty());
 
-        var interval = leaver.Config.GossipInterval;
-        await Task.Delay(interval + interval);
+        await AwaitConditionAsync(
+            // Wait until the leaving member is added to the block list
+            () => other.Remote.BlockList.BlockedMembers.Contains(leaver.System.Id),
+            TimeSpan.FromSeconds(5));
 
         other.Remote.BlockList.BlockedMembers.Should().Contain(leaver.System.Id);
 


### PR DESCRIPTION
## Summary
- Wait for block list update using `AwaitConditionAsync` before sending gossip to a leaving member
- Document test update in change log

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8b5c017f0832880cb7a3e772f7ad5