### PR TITLE
feat: inject gossip instance

### DIFF
--- a/logs/log1755890748.md
+++ b/logs/log1755890748.md
@@ -1,0 +1,9 @@
+### Summary
+- modify GossipActor constructor to accept injected IGossip implementation
+- allow Gossiper to pass provided IGossip and support injecting test doubles
+- expose IGossip interfaces publicly for test fakes
+
+### Testing
+- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -c Release`
+- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj -c Release`
+- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj -c Release`

--- a/src/Proto.Cluster/Gossip/GossipActor.cs
+++ b/src/Proto.Cluster/Gossip/GossipActor.cs
@@ -28,12 +28,12 @@ public class GossipActor : IActor
         TimeSpan gossipRequestTimeout,
         InstanceLogger? instanceLogger,
         int gossipFanout,
-        int gossipMaxSend
+        int gossipMaxSend,
+        IGossip gossip
     )
     {
         _gossipRequestTimeout = gossipRequestTimeout;
-        _internal = new Gossip(system.Id, gossipFanout, gossipMaxSend, instanceLogger,
-            () => system.Cluster().MemberList.GetMembers(), system.Cluster().Config.GossipDebugLogging);
+        _internal = gossip;
     }
 
     public async Task ReceiveAsync(IContext context)

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -54,6 +54,7 @@ public class Gossiper
 #pragma warning restore CS0618 // Type or member is obsolete
     private readonly Cluster _cluster;
     private readonly IRootContext _context;
+    private IGossip _gossip = null!;
     private PID _pid = null!;
 
     public Gossiper(Cluster cluster)
@@ -186,14 +187,23 @@ public class Gossiper
         }
     }
 
-    internal Task StartGossipActorAsync()
+    internal Task StartGossipActorAsync(IGossip? gossip = null)
     {
+        _gossip = gossip ?? new Gossip(
+            _cluster.System.Id,
+            _cluster.Config.GossipFanout,
+            _cluster.Config.GossipMaxSend,
+            _cluster.System.Logger(),
+            () => _cluster.MemberList.GetMembers(),
+            _cluster.Config.GossipDebugLogging);
+
         var props = Props.FromProducer(() => new GossipActor(
             _cluster.System,
             _cluster.Config.GossipRequestTimeout,
             _cluster.System.Logger(),
             _cluster.Config.GossipFanout,
-            _cluster.Config.GossipMaxSend));
+            _cluster.Config.GossipMaxSend,
+            _gossip));
 
         _pid = _context.SpawnNamedSystem(props, GossipActorName);
         _cluster.System.EventStream.Subscribe<ClusterTopology>(topology =>

--- a/src/Proto.Cluster/Gossip/IGossip.cs
+++ b/src/Proto.Cluster/Gossip/IGossip.cs
@@ -12,11 +12,11 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Proto.Cluster.Gossip;
 
-internal interface IGossip : IGossipStateStore, IGossipConsensusChecker, IGossipCore
+public interface IGossip : IGossipStateStore, IGossipConsensusChecker, IGossipCore
 {
 }
 
-internal interface IGossipCore
+public interface IGossipCore
 {
     Task UpdateClusterTopology(ClusterTopology clusterTopology);
 
@@ -33,14 +33,14 @@ internal interface IGossipCore
     IEnumerable<(Member member, MemberStateDelta memberState)> SendState();
 }
 
-internal interface IGossipConsensusChecker
+public interface IGossipConsensusChecker
 {
     void AddConsensusCheck(string id, ConsensusCheck check);
 
     void RemoveConsensusCheck(string id);
 }
 
-internal interface IGossipStateStore
+public interface IGossipStateStore
 {
     GossipState GetStateSnapshot();
 


### PR DESCRIPTION
## Summary
- allow injecting IGossip into GossipActor
- pass gossip implementation from Gossiper and expose IGossip interfaces

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -c Release`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj -c Release`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68a8c1f765188328833cc20ffe8be274