### PR TITLE
test: remove fixed delays via TestKit

### DIFF
--- a/logs/log1755893016.md
+++ b/logs/log1755893016.md
@@ -1,0 +1,3 @@
+- Added Proto.TestKit imports and used AwaitConditionAsync in DeduplicationContextTests to wait for message processing instead of fixed Task.Delay.
+- Replaced arbitrary Task.Delay in TimerExtensionsTests with a TestSchedulerHook that waits for timer registration before advancing the FakeTimeProvider.
+- Substituted Task.Delay in PidCacheTests with AwaitConditionAsync polling the PID cache for removal after actor shutdown.

--- a/tests/Proto.Actor.Tests/DeduplicationContextTests.cs
+++ b/tests/Proto.Actor.Tests/DeduplicationContextTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Threading.Tasks;
 using Proto.Deduplication;
 using Proto;
+using Proto.TestKit;
+using static Proto.TestKit.TestKit;
 using Xunit;
 
 namespace Proto.Tests;
@@ -36,7 +38,8 @@ public class DeduplicationContextTests
         context.Send(pid, "one");
         context.Send(pid, "one");
         context.Send(pid, "two");
-        await Task.Delay(100);
+
+        await AwaitConditionAsync(() => count == 2, TimeSpan.FromSeconds(1));
 
         Assert.Equal(2, count);
     }

--- a/tests/Proto.Actor.Tests/TimerExtensionsTests.cs
+++ b/tests/Proto.Actor.Tests/TimerExtensionsTests.cs
@@ -34,15 +34,24 @@ public class TimerExtensionsTests
         var (probe, pid) = system.CreateTestProbe();
 
         var timeProvider = new FakeTimeProvider();
-        var scheduler = context.Scheduler(timeProvider);
+        var hook = new TestSchedulerHook();
+        var scheduler = context.Scheduler(timeProvider, hook);
 
         scheduler.SendOnce(TimeSpan.FromSeconds(10), pid, "Wakeup");
 
-        // Give the inner Task.Delay a head start
-        await Task.Delay(50);
+        await hook.WaitAsync();
         timeProvider.Advance(TimeSpan.FromMinutes(1));
 
         await probe.ExpectNextUserMessageAsync<string>(s => s == "Wakeup");
+    }
+
+    private sealed class TestSchedulerHook : ISchedulerHook
+    {
+        private readonly TaskCompletionSource _tcs = new();
+
+        public Task WaitAsync() => _tcs.Task;
+
+        public void OnTimerRegistered() => _tcs.TrySetResult();
     }
 }
 

--- a/tests/Proto.Cluster.Tests/PidCacheTests.cs
+++ b/tests/Proto.Cluster.Tests/PidCacheTests.cs
@@ -9,6 +9,8 @@ using Proto.Cluster.Partition;
 using Proto.Cluster.Testing;
 using Proto.Remote;
 using Proto.Remote.GrpcNet;
+using Proto.TestKit;
+using static Proto.TestKit.TestKit;
 using Xunit;
 
 namespace Proto.Cluster.Tests;
@@ -77,8 +79,8 @@ public class PidCacheTests
 
         await cluster.RequestAsync<Ack>(identity, new Die(), timeout.Token);
 
-        // Let the system purge the terminated PID,
-        await Task.Delay(50);
+        await AwaitConditionAsync(() => !cluster.PidCache.TryGet(identity, out _),
+            TimeSpan.FromSeconds(5));
 
         cluster.PidCache.TryGet(identity, out _).Should().BeFalse();
     }


### PR DESCRIPTION
## Summary
- use TestSchedulerHook in TimerExtensionsTests instead of fixed delay
- await PID cache purge in PidCacheTests without sleep
- poll counter in DeduplicationContextTests instead of Task.Delay

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8cb797f048328994fb591e9399541