### PR TITLE
Use CancellationTokens helper in cluster tests

### DIFF
--- a/logs/log1755892615.md
+++ b/logs/log1755892615.md
@@ -1,0 +1,8 @@
+### Summary
+- `tests/Proto.Cluster.Tests/ClusterTests.cs`: replace inline `new CancellationTokenSource(TimeSpan.FromSeconds(x)).Token` with reusable `CancellationTokens.FromSeconds` helper; add `using Proto` for access.
+- `tests/Proto.Cluster.Tests/ClusterTestsWithLocalAffinity.cs`: swap manual token source with `CancellationTokens.FromSeconds` and add `using Proto`.
+
+### Testing
+- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
+- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
+- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`

--- a/tests/Proto.Cluster.Tests/ClusterTests.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 using ClusterTest.Messages;
 using FluentAssertions;
+using Proto;
 using Proto.Cluster.Gossip;
 using Proto.Cluster.Identity;
 using Proto.Utils;
@@ -40,7 +41,7 @@ public abstract class ClusterTests : ClusterTestBase
     {
         await Trace(async () =>
         {
-            var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token;
+            var timeout = CancellationTokens.FromSeconds(10);
 
             var entryNode = Members[0];
 
@@ -59,7 +60,7 @@ public abstract class ClusterTests : ClusterTestBase
 
         await Trace(async () =>
         {
-            var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token;
+            var timeout = CancellationTokens.FromSeconds(10);
 
             var clientNode = await ClusterFixture.SpawnClient();
 

--- a/tests/Proto.Cluster.Tests/ClusterTestsWithLocalAffinity.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTestsWithLocalAffinity.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ClusterTest.Messages;
 using FluentAssertions;
+using Proto;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -21,7 +22,7 @@ public abstract class ClusterTestsWithLocalAffinity : ClusterTests
     {
         await Trace(async () =>
         {
-            var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(20)).Token;
+            var timeout = CancellationTokens.FromSeconds(20);
             var firstNode = Members[0];
             var secondNode = Members[1];
 


### PR DESCRIPTION
## Summary
- refactor cluster tests to use shared `CancellationTokens.FromSeconds` helper for timeouts
- enable helper by importing `Proto` namespace

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8ca1594848328b28c1cfbdcae4a77