### PR TITLE
Document Task.Delay usage across codebase

### DIFF
--- a/logs/log1755937774.md
+++ b/logs/log1755937774.md
@@ -1,0 +1,4 @@
+## Task.Delay audit
+- Documented every `Task.Delay` in the core sources with context (backoff, throttling, or deterministic waiting).
+- Added explanatory comments across tests to clarify intentional delays and avoid busy waits.
+- Ensures all timed waits are intentional and understandable, reducing flakiness and easing future maintenance.

--- a/src/Proto.Actor/Supervision/ExponentialBackoffStrategy.cs
+++ b/src/Proto.Actor/Supervision/ExponentialBackoffStrategy.cs
@@ -48,6 +48,8 @@ public class ExponentialBackoffStrategy : ISupervisorStrategy
         var backoff = rs.FailureCount * (int)_initialBackoff.TotalMilliseconds;
         var noise = _random.Next(500);
         var duration = TimeSpan.FromMilliseconds(backoff + noise);
+
+        // Schedule restart after a backoff period to avoid aggressive retry loops
         Task.Delay(duration).ContinueWith(t => supervisor.RestartChildren(reason, child));
     }
 }

--- a/src/Proto.Actor/Timers/Scheduler.cs
+++ b/src/Proto.Actor/Timers/Scheduler.cs
@@ -137,6 +137,7 @@ public class Scheduler
 
     private async Task Delay(TimeSpan delay, CancellationToken token)
     {
+        // Use provided time provider to allow deterministic and testable delays
         var delayTask = Task.Delay(delay, _timeProvider, token);
         _schedulerHook?.OnTimerRegistered();
         await delayTask.ConfigureAwait(false);

--- a/src/Proto.Actor/Utils/Retry.cs
+++ b/src/Proto.Actor/Utils/Retry.cs
@@ -52,6 +52,7 @@ public static class Retry
                 }
 
                 var backoff = Math.Min(i * backoffMilliSeconds, maxBackoffMilliseconds);
+                // Wait using incremental backoff before retrying operation
                 await Task.Delay(backoff).ConfigureAwait(false);
             }
         }
@@ -82,6 +83,7 @@ public static class Retry
                 }
 
                 var backoff = Math.Min(i * backoffMilliSeconds, maxBackoffMilliseconds);
+                // Wait using incremental backoff before retrying operation
                 await Task.Delay(backoff).ConfigureAwait(false);
             }
         }
@@ -125,6 +127,7 @@ public static class Retry
                 }
 
                 var backoff = Math.Min(i * backoffMilliSeconds, maxBackoffMilliseconds);
+                // Wait using incremental backoff before retrying operation
                 await Task.Delay(backoff).ConfigureAwait(false);
             }
         }

--- a/src/Proto.Actor/Utils/TaskClock.cs
+++ b/src/Proto.Actor/Utils/TaskClock.cs
@@ -49,6 +49,7 @@ public class TaskClock
     /// </summary>
     public void Start()
     {
+        // Initialize first bucket to signal after the combined timeout interval
         CurrentBucket = Task.Delay(_bucketSize, _ct);
 
         _ = SafeTask.Run(async () =>
@@ -57,7 +58,10 @@ public class TaskClock
             {
                 try
                 {
+                    // Rotate bucket to provide a fresh completion task for next tick
                     CurrentBucket = Task.Delay(_bucketSize, _ct);
+
+                    // Delay until it's time to update the bucket again
                     await Task.Delay(_updateInterval, _ct).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)

--- a/src/Proto.Actor/Utils/TaskExtensions.cs
+++ b/src/Proto.Actor/Utils/TaskExtensions.cs
@@ -37,6 +37,7 @@ public static class TaskExtensions
                 _        => new CancellationTokenSource()
             };
 
+        // Compete the original task against a timeout to enforce upper execution bound
         var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token))
             .ConfigureAwait(false);
 

--- a/src/Proto.Actor/Utils/ThreadPoolStats.cs
+++ b/src/Proto.Actor/Utils/ThreadPoolStats.cs
@@ -21,6 +21,7 @@ public static class ThreadPoolStats
 
         while (!cancellationToken.IsCancellationRequested)
         {
+            // Wait for the configured sampling interval before measuring again
             await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
             var t1 = DateTime.UtcNow;
 

--- a/src/Proto.Actor/Utils/Throttle.cs
+++ b/src/Proto.Actor/Utils/Throttle.cs
@@ -90,6 +90,7 @@ public static class Throttle
         void StartTimer(Action<int>? callBack) =>
             _ = SafeTask.Run(async () =>
                 {
+                    // Pause for the throttling period before resetting the counter
                     await Task.Delay(period).ConfigureAwait(false);
                     var timesCalled = Interlocked.Exchange(ref currentEvents, 0);
 

--- a/src/Proto.Cluster.AmazonECS/AmazonEcsProvider.cs
+++ b/src/Proto.Cluster.AmazonECS/AmazonEcsProvider.cs
@@ -140,6 +140,7 @@ public class AmazonEcsProvider : IClusterProvider
                         Logger.LogError(x, "Failed to get members from ECS");
                     }
 
+                    // Wait before polling ECS again for cluster membership changes
                     await Task.Delay(TimeSpan.FromSeconds(_config.PollIntervalSeconds)).ConfigureAwait(false);
                 }
             }

--- a/src/Proto.Cluster.Consul/ConsulProvider.cs
+++ b/src/Proto.Cluster.Consul/ConsulProvider.cs
@@ -191,7 +191,7 @@ public class ConsulProvider : IClusterProvider
                         {
                             _logger.LogError(x, "Consul Monitor failed");
 
-                            //just backoff and try again
+                            // Back off briefly before retrying the Consul query
                             await Task.Delay(2000).ConfigureAwait(false);
                         }
                     }
@@ -222,6 +222,7 @@ public class ConsulProvider : IClusterProvider
                     try
                     {
                         await _client.Agent.PassTTL("service:" + _consulServiceInstanceId, "").ConfigureAwait(false);
+                        // Wait until the TTL needs refreshing again
                         await Task.Delay(_refreshTtl, _cluster.System.Shutdown).ConfigureAwait(false);
                     }
                     catch (Exception x)

--- a/src/Proto.Cluster.Dashboard/Pages/ClusterOverview.razor
+++ b/src/Proto.Cluster.Dashboard/Pages/ClusterOverview.razor
@@ -102,6 +102,7 @@
             }
 
             await InvokeAsync(StateHasChanged).ConfigureAwait(false);
+            // Briefly pause to limit how often the dashboard refreshes
             await Task.Delay(100).ConfigureAwait(false);
         }
     }

--- a/src/Proto.Cluster.Dashboard/Shared/MemberSearch.razor
+++ b/src/Proto.Cluster.Dashboard/Shared/MemberSearch.razor
@@ -68,6 +68,7 @@
                 _gossipState = await System.Cluster().Gossip.GetStateSnapshot().ConfigureAwait(false);
                 _members = System.Cluster().MemberList.GetAllMembers();
                 await InvokeAsync(async () => { await GossipState(_gossipState).ConfigureAwait(false); }).ConfigureAwait(false);
+                // Delay briefly to throttle refresh rate of the dashboard
                 await Task.Delay(100).ConfigureAwait(false);
             }
             catch (Exception x)

--- a/src/Proto.Cluster.Identity.MongoDb/MongoIdentityStorage.cs
+++ b/src/Proto.Cluster.Identity.MongoDb/MongoIdentityStorage.cs
@@ -44,7 +44,7 @@ public sealed class MongoIdentityStorage : IIdentityStorage
 
         if (lockId != null)
         {
-            //There is an active lock on the pid, spin wait
+            //There is an active lock on the pid, spin wait with incremental backoff
             var i = 0;
 
             do

--- a/src/Proto.Cluster.Identity.Redis/RedisIdentityStorage.cs
+++ b/src/Proto.Cluster.Identity.Redis/RedisIdentityStorage.cs
@@ -75,6 +75,7 @@ public sealed class RedisIdentityStorage : IIdentityStorage
 
             do
             {
+                // Incrementally back off while waiting for the lock to be released
                 await Task.Delay(20 * i++, ct).ConfigureAwait(false);
             } while (!ct.IsCancellationRequested
                      && _maxLockTime > timer.Elapsed

--- a/src/Proto.Cluster.Kubernetes/KubernetesClusterMonitor.cs
+++ b/src/Proto.Cluster.Kubernetes/KubernetesClusterMonitor.cs
@@ -97,6 +97,7 @@ internal class KubernetesClusterMonitor : IActor
                 await Watch();
             }
 
+            // Delay to avoid tight loop when restarting watcher
             await Task.Delay(1000);
 
             context.Send(context.Self, new StartWatchingCluster(_clusterName));

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -220,6 +220,7 @@ public class Cluster : IActorSystemExtension<Cluster>
                 {
                     while (!System.Shutdown.IsCancellationRequested)
                     {
+                        // Periodically clear expired entries from the remote PID cache
                         await Task.Delay(Config.RemotePidCacheClearInterval, System.Shutdown).ConfigureAwait(false);
                         PidCache.RemoveIdleRemoteProcessesOlderThan(Config.RemotePidCacheTimeToLive);
                     }
@@ -295,7 +296,7 @@ public class Cluster : IActorSystemExtension<Cluster>
             await Gossip.SetStateAsync(GossipKeys.GracefullyLeft, new Empty()).ConfigureAwait(false);
 
             Logger.LogInformation("Waiting for two gossip intervals to pass for {Id}", System.Id);
-            // In case provider shutdown is quick, let's wait at least 2 gossip intervals.
+            // Allow gossip to propagate leave message before deregistering
             await Task.Delay((int)Config.GossipInterval.TotalMilliseconds * 2).ConfigureAwait(false);
 
             Logger.LogInformation("Stopping cluster provider for {Id}", System.Id);

--- a/src/Proto.Cluster/DefaultClusterContext.cs
+++ b/src/Proto.Cluster/DefaultClusterContext.cs
@@ -102,6 +102,7 @@ public class DefaultClusterContext : IClusterContext
                         return TimeoutOrThrow();
                     }
                     
+                    // Back off slightly before retrying PID lookup to reduce contention
                     await Task.Delay(i * 20, CancellationToken.None).ConfigureAwait(false);
 
                     continue;
@@ -217,6 +218,7 @@ public class DefaultClusterContext : IClusterContext
                     _pidCache.RemoveByVal(clusterIdentity, pid);
                     RefreshFuture();
                     await RemoveFromSource(clusterIdentity, PidSource.Cache, pid).ConfigureAwait(false);
+                    // Back off slightly before retrying after an exception
                     await Task.Delay(i * 20, CancellationToken.None).ConfigureAwait(false);
 
                     continue;

--- a/src/Proto.Cluster/Gossip/Consensus.cs
+++ b/src/Proto.Cluster/Gossip/Consensus.cs
@@ -33,6 +33,7 @@ internal class GossipConsensusHandle<T> : IConsensusHandle<T> where T : notnull
         {
             var t = Volatile.Read(ref _consensusTcs).Task;
             // ReSharper disable once MethodSupportsCancellation
+            // Poll for consensus completion or timeout to periodically check cancellation
             await Task.WhenAny(t, Task.Delay(500)).ConfigureAwait(false);
 
             if (t.IsCompleted)

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -237,6 +237,7 @@ public class Gossiper
         {
             try
             {
+                // Space out gossip broadcasts according to configured interval
                 await Task.Delay(_cluster.Config.GossipInterval).ConfigureAwait(false);
 
                 await BlockExpiredHeartbeats().ConfigureAwait(false);

--- a/src/Proto.Cluster/Identity/IdentityActivatorProxy.cs
+++ b/src/Proto.Cluster/Identity/IdentityActivatorProxy.cs
@@ -122,6 +122,7 @@ internal class IdentityActivatorProxy : IActor
                                 replacedPid, identity, attempt);
                         }
 
+                        // Back off before retrying to replace activation and avoid rapid retry loops
                         context.ReenterAfter(Task.Delay(50 * attempt),
                             _ => ReplaceActivation(identity, replacedPid, context, attempt + 1));
 

--- a/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
+++ b/src/Proto.Cluster/Identity/IdentityStoragePlacementActor.cs
@@ -293,6 +293,7 @@ internal class IdentityStoragePlacementActor : IActor
                 if (++attempts < PersistenceRetries)
                 {
                     Logger.LogWarning(e, "No entry was updated {@SpawnLock}. Retrying", spawnLock);
+                    // Give storage a moment before retrying to store the activation
                     await Task.Delay(50).ConfigureAwait(false);
                 }
                 else

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -184,6 +184,7 @@ internal class IdentityStorageWorker : IActor
                         _logger.LogWarning(e, "Failed to get PID for {ClusterIdentity}", clusterIdentity);
                     }
 
+                    // Exponential backoff before retrying activation retrieval
                     await Task.Delay(tries * 20).ConfigureAwait(false);
                 }
                 catch (Exception e)
@@ -198,6 +199,7 @@ internal class IdentityStorageWorker : IActor
                         _logger.LogError(e, "Failed to get PID for {ClusterIdentity}", clusterIdentity);
                     }
 
+                    // Exponential backoff before retrying after failure
                     await Task.Delay(tries * 20).ConfigureAwait(false);
                 }
             }

--- a/src/Proto.Cluster/Partition/PartitionIdentityRebalanceWorker.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityRebalanceWorker.cs
@@ -125,6 +125,7 @@ internal class PartitionIdentityRebalanceWorker : IActor, IDisposable
             default:
                 Logger.LogWarning("[PartitionIdentity] Partition {Member} unreachable", response.MemberAddress);
 
+                // Delay before retrying to prevent tight retry loops when a partition is unreachable
                 context.ReenterAfter(Task.Delay(200, _cancellationToken), () =>
                 {
                     StartRebalanceFromMember(_request!, context, response.MemberAddress);

--- a/src/Proto.Cluster/PubSub/BatchingProducer.cs
+++ b/src/Proto.Cluster/PubSub/BatchingProducer.cs
@@ -283,6 +283,7 @@ public class BatchingProducer : IAsyncDisposable
                 }
                 else if (decision.Delay != null)
                 {
+                    // Delay according to retry strategy before attempting to publish again
                     await Task.Delay(decision.Delay.Value).ConfigureAwait(false);
                 }
             }

--- a/src/Proto.Persistence.DynamoDB/DynamoDBExtensions.cs
+++ b/src/Proto.Persistence.DynamoDB/DynamoDBExtensions.cs
@@ -81,6 +81,7 @@ public static class DynamoDBExtensions
 
             if (res.TableStatus != "ACTIVE")
             {
+                // Newly created table is not active yet; wait before verifying creation
                 await Task.Delay(2000).ConfigureAwait(false);
                 await dynamoDB.IsTableCreated(tableName, false).ConfigureAwait(false);
             }

--- a/src/Proto.Remote/Endpoints/EndpointManager.cs
+++ b/src/Proto.Remote/Endpoints/EndpointManager.cs
@@ -124,6 +124,7 @@ public sealed class EndpointManager : IDiagnosticsProvider
 
                 if (evt.ShouldBlock && _remoteConfig.WaitAfterEndpointTerminationTimeSpan.HasValue)
                 {
+                    // Give remote transport a chance to release resources before reconnecting
                     await Task.Delay(_remoteConfig.WaitAfterEndpointTerminationTimeSpan.Value, CancellationToken).ConfigureAwait(false);
                 }
 

--- a/src/Proto.Remote/Endpoints/ServerConnector.cs
+++ b/src/Proto.Remote/Endpoints/ServerConnector.cs
@@ -233,6 +233,7 @@ public sealed class ServerConnector
                 var backoff = rs.FailureCount * (int)_backoff.TotalMilliseconds;
                 var noise = _random.Next(500);
                 var duration = TimeSpan.FromMilliseconds(backoff + noise);
+                // Exponential backoff before attempting to reconnect to the remote endpoint
                 await Task.Delay(duration).ConfigureAwait(false);
 
                 _logger.LogWarning(

--- a/src/Proto.TestKit/TestKit.cs
+++ b/src/Proto.TestKit/TestKit.cs
@@ -60,6 +60,7 @@ public static class TestKit
                 return;
             }
 
+            // Pause briefly to avoid busy waiting before rechecking the condition
             await Task.Delay(PollInterval, cancellationToken).ConfigureAwait(false);
         }
 

--- a/tests/Proto.Actor.Tests/ActorTests.cs
+++ b/tests/Proto.Actor.Tests/ActorTests.cs
@@ -255,6 +255,7 @@ public class ActorTests
                 {
                     try
                     {
+                        // Simulate long-running work that should be cancellable
                         await Task.Delay(5000, ctx.CancellationToken);
                     }
                     catch (Exception e)

--- a/tests/Proto.Actor.Tests/Futures/BaseFutureTests.cs
+++ b/tests/Proto.Actor.Tests/Futures/BaseFutureTests.cs
@@ -102,6 +102,7 @@ public abstract class BaseFutureTests : ActorTestBase
                 {
                     if (ctx.Sender is not null)
                     {
+                        // Delay slightly to exceed future timeout
                         await Task.Delay(1);
                         ctx.Respond(ctx.Message!);
                     }

--- a/tests/Proto.Actor.Tests/Futures/BatchFutureTests.cs
+++ b/tests/Proto.Actor.Tests/Futures/BatchFutureTests.cs
@@ -96,6 +96,7 @@ public class BatchFutureTests : ActorTestBase
                 {
                     if (ctx.Sender is not null)
                     {
+                        // Delay just enough to trigger timeout in test
                         await Task.Delay(1);
                         ctx.Respond(ctx.Message!);
                     }

--- a/tests/Proto.Actor.Tests/Mailbox/MailboxQueuesTests.cs
+++ b/tests/Proto.Actor.Tests/Mailbox/MailboxQueuesTests.cs
@@ -86,6 +86,7 @@ public class MailboxQueuesTests
                             return;
                         }
 
+                        // Yield to avoid busy-spin while waiting for new items
                         await Task.Delay(1, cancelSource.Token);
                         popped = sut.Pop();
                     }

--- a/tests/Proto.Actor.Tests/ReenterTests.cs
+++ b/tests/Proto.Actor.Tests/ReenterTests.cs
@@ -25,6 +25,7 @@ public class ReenterTests : ActorTestBase
                 switch (ctx.Message)
                 {
                     case "reenter":
+                        // Simulate async processing before responding
                         await Task.Delay(500);
                         ctx.Respond("done");
 
@@ -56,6 +57,7 @@ public class ReenterTests : ActorTestBase
             {
                 if (ctx.Message is "reenter")
                 {
+                    // Simulate asynchronous work before reentering
                     var delay = Task.Delay(500);
                     ctx.ReenterAfter(delay, () =>
                     {
@@ -158,6 +160,7 @@ public class ReenterTests : ActorTestBase
                 {
                     var task = Task.Run(async () =>
                     {
+                        // Delay before throwing to emulate work that fails
                         await Task.Delay(100);
 
                         throw new Exception("Failed!");
@@ -220,6 +223,7 @@ public class ReenterTests : ActorTestBase
                     //use ++ on purpose, any race condition would make the counter go out of sync
                     counter++;
 
+                    // Immediate delay to schedule reenter continuation asynchronously
                     var task = Task.Delay(0);
 
                     ctx.ReenterAfter(task, () =>
@@ -266,6 +270,7 @@ public class ReenterTests : ActorTestBase
                         CancellationTokenSource cts = new();
 
                         ctx.ReenterAfter(
+                            // Wait indefinitely until cancellation triggered by restart
                             Task.Delay(-1, cts.Token),
                             () =>
                             {
@@ -324,6 +329,7 @@ public class ReenterTests : ActorTestBase
                     case "start":
 
                         ctx.ReenterAfter(
+                            // Wait indefinitely until cancellation token triggers on actor stop
                             Task.Delay(-1, cts.Token),
                             () =>
                             {

--- a/tests/Proto.Actor.Tests/Router/BroadcastGroupTests.cs
+++ b/tests/Proto.Actor.Tests/Router/BroadcastGroupTests.cs
@@ -172,6 +172,7 @@ public class BroadcastGroupTests
         {
             if (context.Message is string s && s == "go slow")
             {
+                // Simulate a slow routee for broadcast testing
                 await Task.Delay(5000);
                 return;
             }

--- a/tests/Proto.Actor.Tests/Router/RandomGroupRouterTests.cs
+++ b/tests/Proto.Actor.Tests/Router/RandomGroupRouterTests.cs
@@ -37,6 +37,7 @@ public class RandomGroupRouterTests
         var (router, probe1, probe2, probe3) = CreateRouterWith3Routees(system);
         var (probe4, routee4) = system.CreateTestProbe();
         system.Root.Send(router, new RouterAddRoutee(routee4));
+        // Give router time to register the new routee
         await Task.Delay(500);
         for (var i = 0; i < 100; i++)
         {

--- a/tests/Proto.Actor.Tests/SchedulerTests.cs
+++ b/tests/Proto.Actor.Tests/SchedulerTests.cs
@@ -64,6 +64,7 @@ public class SchedulerTests
 
         await hook.WaitAsync();
         cts.Cancel();
+        // Give the cancellation time to propagate before advancing the clock
         await Task.Delay(50);
 
         timeProvider.Advance(TimeSpan.FromMinutes(1));
@@ -121,6 +122,7 @@ public class SchedulerTests
         await Task.Delay(50);
 
         timeProvider.Advance(TimeSpan.FromSeconds(10));
+        // Allow scheduled callbacks to execute after advancing time
         await Task.Delay(50);
 
         await probe.ExpectNoMessageAsync(TimeSpan.FromMilliseconds(50));

--- a/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_OneForOne.cs
@@ -312,6 +312,7 @@ public class SupervisionTestsOneForOne
         var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(1);
         while (!parentMailboxStats.Received.ToArray().Any(msg => msg is Restart) && DateTime.UtcNow < deadline)
         {
+            // Poll for restart notification until timeout
             await Task.Delay(10);
         }
 

--- a/tests/Proto.Actor.Tests/Utils/ThrottleTests.cs
+++ b/tests/Proto.Actor.Tests/Utils/ThrottleTests.cs
@@ -43,6 +43,7 @@ public class ThrottleTests
 
         triggered.Should().Be(maxEvents);
 
+        // Wait for throttle window to elapse before sending more events
         await Task.Delay(2000);
 
         for (var i = 0; i < 100; i++)
@@ -65,6 +66,7 @@ public class ThrottleTests
         shouldThrottle().Should().Be(Throttle.Valve.Open, "It accepts multiple event before closing");
         shouldThrottle().Should().Be(Throttle.Valve.Closing, "Last event before close");
         shouldThrottle().Should().Be(Throttle.Valve.Closed, "Anything over the limit is throttled");
+        // Wait for the throttle period before verifying it reopens
         await Task.Delay(1000);
         shouldThrottle().Should().Be(Throttle.Valve.Open, "After the period it should open again");
     }

--- a/tests/Proto.Cluster.Identity.Tests/IdentityStorageTests.cs
+++ b/tests/Proto.Cluster.Identity.Tests/IdentityStorageTests.cs
@@ -291,6 +291,7 @@ public abstract class IdentityStorageTests : IDisposable
 
         _ = SafeTask.Run(async () =>
             {
+                // Simulate activation being stored asynchronously after a delay
                 await Task.Delay(500, timeout);
                 await _storage.StoreActivation(activator.Id, spawnLock!, pid, timeout);
             }, timeout

--- a/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityTests.cs
@@ -109,6 +109,7 @@ public class PartitionIdentityTests
 
         while (!stop.IsCancellationRequested)
         {
+            // Report request throughput once per second
             await Task.Delay(TimeSpan.FromSeconds(1));
             var now = Interlocked.Read(ref _requests);
 
@@ -125,6 +126,7 @@ public class PartitionIdentityTests
         _output.WriteLine($"Stopped cluster in {timer.Elapsed}");
         
         // delay to reduce flakiness
+        // Delay to reduce flakiness when tearing down the cluster
         await Task.Delay(2000);
 
         var actorStates = fixture.Repository.Contents.ToList();
@@ -231,6 +233,7 @@ public class PartitionIdentityTests
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {
+                    // Randomize kill timing to simulate non-deterministic actor lifetimes
                     await Task.Delay(rnd.Next(50), cancellationToken);
                     var id = RandomIdentity(identities, rnd);
                     var member = clusterFixture.Members[rnd.Next(clusterFixture.Members.Count)];
@@ -265,6 +268,7 @@ public class PartitionIdentityTests
                 {
                     while (!cancellationToken.IsCancellationRequested)
                     {
+                        // Random delay between cluster membership changes
                         await Task.Delay(rnd.Next(10000), cancellationToken);
                         var spawn = rnd.Next() % 2 == 0;
 

--- a/tests/Proto.Cluster.PubSub.Tests/PubSubBatchingProducerTests.cs
+++ b/tests/Proto.Cluster.PubSub.Tests/PubSubBatchingProducerTests.cs
@@ -270,6 +270,7 @@ public class PubSubBatchingProducerTests
 
     private async Task<PublishResponse> Wait(PubSubBatch _)
     {
+        // Simulate a slow publisher call
         await Task.Delay(1000);
 
         return new PublishResponse();
@@ -278,6 +279,7 @@ public class PubSubBatchingProducerTests
     private Func<PubSubBatch, Task<PublishResponse>> Wait(int ms = 1000) =>
         async _ =>
         {
+            // Simulate configurable processing delay
             await Task.Delay(ms);
 
             return new PublishResponse();
@@ -285,6 +287,7 @@ public class PubSubBatchingProducerTests
 
     private async Task<PublishResponse> WaitThenFail(PubSubBatch _)
     {
+        // Delay before failing to mimic transient issues
         await Task.Delay(500);
 
         throw new TestException();
@@ -293,6 +296,7 @@ public class PubSubBatchingProducerTests
     private Func<PubSubBatch, Task<PublishResponse>> WaitThenRecord(int ms = 500) =>
         async batch =>
         {
+            // Delay before recording to simulate batching latency
             await Task.Delay(ms);
 
             var copy = new PubSubBatch();

--- a/tests/Proto.Cluster.PubSub.Tests/PubSubClientTests.cs
+++ b/tests/Proto.Cluster.PubSub.Tests/PubSubClientTests.cs
@@ -69,9 +69,10 @@ public class PubSubClientTests : IAsyncLifetime
 		subscribers.Subscribers_.Should().Contain(s => s.Pid.Equals(clientPid));
         
 		// messages should not send or attempt to send
-		await _fixture.PublishData(topic, 2);
-		await Task.Delay(3000);
-		await _fixture.PublishData(topic, 2);
+                await _fixture.PublishData(topic, 2);
+                // Give the system time to attempt delivery before sending again
+                await Task.Delay(3000);
+                await _fixture.PublishData(topic, 2);
 	
 		// dead letter should be received, so the subscription is removed	
                 await AwaitConditionAsync(async () =>

--- a/tests/Proto.Cluster.PubSub.Tests/PubSubTests.cs
+++ b/tests/Proto.Cluster.PubSub.Tests/PubSubTests.cs
@@ -323,6 +323,7 @@ public class PubSubTests : IClassFixture<PubSubClusterFixture>
                 CancellationTokens.FromSeconds(2));
             Assert.NotNull(pid);
 
+            // Allow time for the topic actor to expire and be restarted
             await Task.Delay(TimeSpan.FromSeconds(5));
 
             var newPid = await firstCluster.GetAsync(ClusterIdentity.Create(topic, TopicActor.Kind),

--- a/tests/Proto.Cluster.Tests/ClusterFixture.cs
+++ b/tests/Proto.Cluster.Tests/ClusterFixture.cs
@@ -112,6 +112,7 @@ public abstract class ClusterFixture : IAsyncLifetime, IClusterFixture, IAsyncDi
         ),
         new ClusterKind(EchoActor.AsyncFilteredKind, EchoActor.Props).WithSpawnPredicate(async (identity, ct) =>
             {
+                // Simulate async predicate work before deciding spawn
                 await Task.Delay(100, ct);
 
                 return !identity.Equals(InvalidIdentity, StringComparison.InvariantCultureIgnoreCase);

--- a/tests/Proto.Cluster.Tests/ClusterTests.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTests.cs
@@ -324,6 +324,7 @@ public abstract class ClusterTests : ClusterTestBase
             var task = entryNode.RequestAsync<Ping>("non-existing", "gen-actor", new Ping(), tcs.Token);
             try
             {
+                // Bound the waiting time in case the request never completes
                 await Task.WhenAny(task, Task.Delay(entryNode.Config.ActorRequestTimeout.Add(TimeSpan.FromSeconds(2)), CancellationToken.None));
 
                 if (task.IsFaulted)
@@ -574,6 +575,7 @@ public abstract class ClusterTests : ClusterTestBase
 
             if (response == null)
             {
+                // Brief pause before retrying to avoid busy loop
                 await Task.Delay(200);
             }
         } while (response == null && !token.IsCancellationRequested);

--- a/tests/Proto.Cluster.Tests/ClusterTestsWithLocalAffinity.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTestsWithLocalAffinity.cs
@@ -39,6 +39,7 @@ public abstract class ClusterTestsWithLocalAffinity : ClusterTests
             LogProcessCounts();
 
             _testOutputHelper.WriteLine("Allowing time for actors to respawn..");
+            // Give actors time to relocate according to affinity
             await Task.Delay(200, timeout);
             LogProcessCounts();
 

--- a/tests/Proto.Cluster.Tests/ClusterTopologyBuilderTests.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTopologyBuilderTests.cs
@@ -23,6 +23,7 @@ public class ClusterTopologyBuilderTests
         var blocked = ImmutableHashSet.Create(m2.Id);
 
         var dupOld = CreateMember("3");
+        // Wait to ensure members have distinct timestamps
         await Task.Delay(1);
         var dupYoung = CreateMember("4");
         dupYoung.Host = dupOld.Host;

--- a/tests/Proto.Cluster.Tests/ConcurrencyVerificationActor.cs
+++ b/tests/Proto.Cluster.Tests/ConcurrencyVerificationActor.cs
@@ -82,6 +82,7 @@ public class ConcurrencyVerificationActor : IActor
     private async Task OnStopping(IContext context)
     {
         _state!.RecordStopping(context);
+        // Simulate async cleanup work
         await Task.Delay(Random.Shared.Next(50));
     }
 

--- a/tests/Proto.Cluster.Tests/EchoActor.cs
+++ b/tests/Proto.Cluster.Tests/EchoActor.cs
@@ -41,6 +41,7 @@ public class EchoActor : IActor
 
                 break;
             case SlowPing ping:
+                // Simulate slow processing before responding
                 await Task.Delay(ping.DelayMs);
                 var slowPong = new Pong { Message = ping.Message, Kind = _initKind ?? "", Identity = _identity ?? "" };
                 Logger.LogDebug("Received SlowPing, replying Pong after {Delay} ms: {@Pong}", ping.DelayMs, slowPong);

--- a/tests/Proto.Cluster.Tests/GithubActionsReporter.cs
+++ b/tests/Proto.Cluster.Tests/GithubActionsReporter.cs
@@ -36,6 +36,7 @@ public class GithubActionsReporter
 
     public async Task Run(Func<Task> test, [CallerMemberName] string testName = "")
     {
+        // Small delay to ensure tracing infrastructure is initialized
         await Task.Delay(1);
 
         using var activity = StartActivity(testName);

--- a/tests/Proto.Cluster.Tests/GossipTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTests.cs
@@ -58,6 +58,7 @@ public class GossipTests
         await using var _ = clusterFixture;
         await clusterFixture.InitializeAsync();
 
+        // Allow cluster to settle before verifying consensus
         await Task.Delay(1000);
 
         var (consensus, initialTopologyHash) =
@@ -127,6 +128,7 @@ public class GossipTests
                 "We should be able to read our writes, and locally we do not have consensus");
 
         _testOutputHelper.WriteLine("Read our own writes...");
+        // Allow time for gossip state to propagate
         await Task.Delay(5000);
 
         _testOutputHelper.WriteLine("Checking consensus...");
@@ -167,6 +169,7 @@ public class GossipTests
         var ct = CancellationTokens.FromSeconds(20);
         while (!ct.IsCancellationRequested && !await AllReplicated())
         {
+            // Poll periodically until all gossip states have replicated
             await Task.Delay(50, ct);
         }
 

--- a/tests/Proto.OpenTelemetry.Tests/OpenTelemetryTracingTests.cs
+++ b/tests/Proto.OpenTelemetry.Tests/OpenTelemetryTracingTests.cs
@@ -58,6 +58,7 @@ public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
         await VerifyTrace(async (rootContext, target) =>
             {
                 rootContext.Send(target, new TraceMe(SendAs.Send));
+                // Allow trace propagation before verifying
                 await Task.Delay(100);
             }
         );
@@ -76,6 +77,7 @@ public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
         await VerifyTrace(async (rootContext, target) =>
             {
                 rootContext.Request(target, new TraceMe(SendAs.Request));
+                // Allow trace propagation before verifying
                 await Task.Delay(100);
             }
         );
@@ -164,6 +166,7 @@ public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
             {
                 Baggage.Current = TestBaggage;
                 rootContext.Request(target, new TraceMe(SendAs.Request));
+                // Allow trace propagation before verifying
                 await Task.Delay(100);
             }
         );
@@ -238,6 +241,7 @@ public class OpenTelemetryTracingTests : IClassFixture<ActivityFixture>
         var (_, activityTraceId) = await Trace(async () =>
             {
                 tracedRoot.Send(testRoot, new TraceMe(SendAs.Invalid));
+                // Wait for the actor to process and record exception trace
                 await Task.Delay(500);
             }
         );

--- a/tests/Proto.Remote.Tests/RemoteTests.cs
+++ b/tests/Proto.Remote.Tests/RemoteTests.cs
@@ -222,6 +222,7 @@ public abstract class RemoteTests
         probe2.Watch(remoteActor);
 
         probe2.Unwatch(remoteActor);
+        // Wait to ensure the unwatch is processed before killing the actor
         await Task.Delay(TimeSpan.FromSeconds(3));
 
         await System.Root.PoisonAsync(remoteActor);

--- a/tests/Proto.TestKit.Tests/AwaitConditionAsyncTests.cs
+++ b/tests/Proto.TestKit.Tests/AwaitConditionAsyncTests.cs
@@ -13,6 +13,7 @@ namespace Proto.TestKit.Tests
             var value = 0;
             _ = Task.Run(async () =>
             {
+                // Update value asynchronously after short delay
                 await Task.Delay(50);
                 value = 1;
             });


### PR DESCRIPTION
## Summary
- Add explanatory comments to all `Task.Delay` usages in core sources
- Clarify intentional delays in tests to show backoff, throttling, or wait rationale
- Record change log for audit

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a979954d9483289744c5e67e67283a