### PR TITLE
Add cancellation support to Throttle

### DIFF
--- a/logs/log1755937590.md
+++ b/logs/log1755937590.md
@@ -1,0 +1,8 @@
+## Change Log
+- extended Throttle.Create with optional CancellationToken and wired through Task.Delay
+- documented throttle window in Throttle.cs
+- updated all Throttle.Create callers to pass CancellationToken
+- adjusted ThrottleTests to use explicit tokens and clarify Task.Delay usage
+
+## Motivation
+Ensures throttle timing can be cancelled by system shutdown, preventing background timers from running after cancellation and clarifies throttle window semantics.

--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -34,10 +34,12 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
     private object? _messageOrEnvelope;
     private ContextState _state;
     
-    private readonly ShouldThrottle _shouldThrottleStartLogs = Throttle.Create(1000,TimeSpan.FromSeconds(1), droppedLogs =>
-    {
-        Logger.ActorContextThrottledLogs(droppedLogs);
-    } );
+    private readonly ShouldThrottle _shouldThrottleStartLogs = Throttle.Create(
+        1000,
+        TimeSpan.FromSeconds(1),
+        droppedLogs => { Logger.ActorContextThrottledLogs(droppedLogs); },
+        CancellationToken.None
+    );
 
 
     private ActorContext(ActorSystem system, Props props, PID? parent, PID self, IMailbox mailbox)

--- a/src/Proto.Actor/EventStream/EventStream.cs
+++ b/src/Proto.Actor/EventStream/EventStream.cs
@@ -38,9 +38,11 @@ public class EventStream : EventStream<object>
             return;
         }
 
-        var shouldThrottle = Throttle.Create(system.Config.DeadLetterThrottleCount,
+        var shouldThrottle = Throttle.Create(
+            system.Config.DeadLetterThrottleCount,
             system.Config.DeadLetterThrottleInterval,
-            droppedLogs => _logger.DeadLetterThrottled(droppedLogs)
+            droppedLogs => _logger.DeadLetterThrottled(droppedLogs),
+            system.Shutdown
         );
 
         Subscribe<DeadLetterEvent>(

--- a/src/Proto.Actor/Utils/Throttle.cs
+++ b/src/Proto.Actor/Utils/Throttle.cs
@@ -48,6 +48,7 @@ public static class Throttle
     /// <param name="maxEventsInPeriod">Event limit</param>
     /// <param name="period">Time window to verify event limit</param>
     /// <param name="throttledCallBack">This will be called with the number of events that was throttled after the period</param>
+    /// <param name="token">Cancellation token to abort waiting for the throttle window</param>
     /// <returns>
     ///     <see cref="ShouldThrottle" /> delegate that records an event when called, and returns current state of the
     ///     throttle valve
@@ -55,7 +56,8 @@ public static class Throttle
     public static ShouldThrottle Create(
         int maxEventsInPeriod,
         TimeSpan period,
-        Action<int>? throttledCallBack = null
+        Action<int>? throttledCallBack = null,
+        CancellationToken token = default
     )
     {
         if (maxEventsInPeriod == 0)
@@ -90,7 +92,8 @@ public static class Throttle
         void StartTimer(Action<int>? callBack) =>
             _ = SafeTask.Run(async () =>
                 {
-                    await Task.Delay(period).ConfigureAwait(false);
+                    // Defines the throttle window
+                    await Task.Delay(period, token).ConfigureAwait(false);
                     var timesCalled = Interlocked.Exchange(ref currentEvents, 0);
 
                     if (timesCalled > maxEventsInPeriod)
@@ -103,9 +106,10 @@ public static class Throttle
 
     public static ShouldThrottle Create(
         this ThrottleOptions options,
-        Action<int>? throttledCallBack = null
+        Action<int>? throttledCallBack = null,
+        CancellationToken token = default
     ) =>
-        Create(options.MaxEventsInPeriod, options.Period, throttledCallBack);
+        Create(options.MaxEventsInPeriod, options.Period, throttledCallBack, token);
 
     public static bool IsOpen(this Valve valve) => valve != Valve.Closed;
 }

--- a/src/Proto.Cluster/DefaultClusterContext.cs
+++ b/src/Proto.Cluster/DefaultClusterContext.cs
@@ -42,7 +42,8 @@ public class DefaultClusterContext : IClusterContext
         _requestLogThrottle = Throttle.Create(
             config.MaxNumberOfEventsInRequestLogThrottlePeriod,
             config.RequestLogThrottlePeriod,
-            i => Logger.LogInformation("Throttled {LogCount} TryRequestAsync logs", i)
+            i => Logger.LogInformation("Throttled {LogCount} TryRequestAsync logs", i),
+            _system.Shutdown
         );
 
         _requestTimeoutSeconds = (int)config.ActorRequestTimeout.TotalSeconds;

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -32,16 +32,17 @@ internal class IdentityStorageWorker : IActor
 
     public IdentityStorageWorker(IdentityStorageLookup storageLookup)
     {
-        _shouldThrottle = Throttle.Create(
-            10,
-            TimeSpan.FromSeconds(5),
-            i => _logger.LogInformation("Throttled {LogCount} IdentityStorageWorker logs", i)
-        );
-
         _cluster = storageLookup.Cluster;
         _memberList = storageLookup.MemberList;
         _lookup = storageLookup;
         _storage = storageLookup.Storage;
+
+        _shouldThrottle = Throttle.Create(
+            10,
+            TimeSpan.FromSeconds(5),
+            i => _logger.LogInformation("Throttled {LogCount} IdentityStorageWorker logs", i),
+            _cluster.System.Shutdown
+        );
     }
 
     public Task ReceiveAsync(IContext context)

--- a/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
+++ b/src/Proto.Cluster/PartitionActivator/PartitionActivatorActor.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Proto.Utils;
@@ -23,7 +24,9 @@ public class PartitionActivatorActor : IActor
     private readonly PartitionActivatorManager _manager;
     private readonly string _myAddress;
 
-    private readonly ShouldThrottle _wrongPartitionLogThrottle = Throttle.Create(1, TimeSpan.FromSeconds(1),
+    private readonly ShouldThrottle _wrongPartitionLogThrottle = Throttle.Create(
+        1,
+        TimeSpan.FromSeconds(1),
         wrongNodeCount =>
         {
             if (wrongNodeCount > 1)
@@ -31,7 +34,8 @@ public class PartitionActivatorActor : IActor
                 Logger.LogWarning("[PartitionActivator] Forwarded {SpawnCount} attempts to spawn on wrong node",
                     wrongNodeCount);
             }
-        }
+        },
+        CancellationToken.None
     );
 
     private ulong _topologyHash;

--- a/src/Proto.Cluster/PubSub/BatchingProducerConfig.cs
+++ b/src/Proto.Cluster/PubSub/BatchingProducerConfig.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Proto.Utils;
@@ -23,8 +24,11 @@ public record BatchingProducerConfig
 {
     private static readonly ILogger Logger = Log.CreateLogger<BatchingProducer>();
 
-    private static readonly ShouldThrottle DefaultLogThrottle = Throttle.Create(3, TimeSpan.FromSeconds(10),
-        droppedLogs => Logger.LogInformation("[BatchingProducer] Throttled {LogCount} logs", droppedLogs)
+    private static readonly ShouldThrottle DefaultLogThrottle = Throttle.Create(
+        3,
+        TimeSpan.FromSeconds(10),
+        droppedLogs => Logger.LogInformation("[BatchingProducer] Throttled {LogCount} logs", droppedLogs),
+        CancellationToken.None
     );
 
     /// <summary>

--- a/src/Proto.Cluster/PubSub/PubSubMemberDeliveryActor.cs
+++ b/src/Proto.Cluster/PubSub/PubSubMemberDeliveryActor.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Proto.Utils;
@@ -15,8 +16,11 @@ namespace Proto.Cluster.PubSub;
 
 public class PubSubMemberDeliveryActor : IActor
 {
-    private static readonly ShouldThrottle LogThrottle = Throttle.Create(10, TimeSpan.FromSeconds(1),
-        droppedLogs => Logger?.LogInformation("[PubSubMemberDeliveryActor] Throttled {LogCount} logs", droppedLogs)
+    private static readonly ShouldThrottle LogThrottle = Throttle.Create(
+        10,
+        TimeSpan.FromSeconds(1),
+        droppedLogs => Logger?.LogInformation("[PubSubMemberDeliveryActor] Throttled {LogCount} logs", droppedLogs),
+        CancellationToken.None
     );
 
     private static readonly ILogger Logger = Log.CreateLogger<PubSubMemberDeliveryActor>();

--- a/src/Proto.Cluster/PubSub/TopicActor.cs
+++ b/src/Proto.Cluster/PubSub/TopicActor.cs
@@ -20,8 +20,12 @@ public sealed class TopicActor : IActor
     public const string
         Kind = "prototopic"; // only alphanum in the name, to maximize chances it works on all clustering providers
 
-    private static readonly ShouldThrottle LogThrottle = Throttle.Create(10, TimeSpan.FromSeconds(1),
-        droppedLogs => Logger?.LogInformation("[TopicActor] Throttled {LogCount} logs", droppedLogs));
+    private static readonly ShouldThrottle LogThrottle = Throttle.Create(
+        10,
+        TimeSpan.FromSeconds(1),
+        droppedLogs => Logger?.LogInformation("[TopicActor] Throttled {LogCount} logs", droppedLogs),
+        CancellationToken.None
+    );
 
     private static readonly ILogger Logger = Log.CreateLogger<TopicActor>();
     private readonly IKeyValueStore<Subscribers> _subscriptionStore;

--- a/tests/Proto.Actor.Tests/Utils/ThrottleTests.cs
+++ b/tests/Proto.Actor.Tests/Utils/ThrottleTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Proto.Utils;
@@ -13,7 +14,7 @@ public class ThrottleTests
     {
         const int maxEvents = 2;
         var triggered = 0;
-        var shouldThrottle = Throttle.Create(maxEvents, TimeSpan.FromSeconds(1));
+        var shouldThrottle = Throttle.Create(maxEvents, TimeSpan.FromSeconds(1), null, CancellationToken.None);
 
         for (var i = 0; i < 10000; i++)
         {
@@ -31,7 +32,7 @@ public class ThrottleTests
     {
         const int maxEvents = 2;
         var triggered = 0;
-        var shouldThrottle = Throttle.Create(maxEvents, TimeSpan.FromMilliseconds(50));
+        var shouldThrottle = Throttle.Create(maxEvents, TimeSpan.FromMilliseconds(50), null, CancellationToken.None);
 
         for (var i = 0; i < 100; i++)
         {
@@ -43,7 +44,7 @@ public class ThrottleTests
 
         triggered.Should().Be(maxEvents);
 
-        await Task.Delay(2000);
+        await Task.Delay(2000); // wait for throttle window to reset
 
         for (var i = 0; i < 100; i++)
         {
@@ -60,12 +61,12 @@ public class ThrottleTests
     public async Task GivesCorrectValveStatus()
     {
         const int maxEvents = 2;
-        var shouldThrottle = Throttle.Create(maxEvents, TimeSpan.FromMilliseconds(50));
+        var shouldThrottle = Throttle.Create(maxEvents, TimeSpan.FromMilliseconds(50), null, CancellationToken.None);
 
         shouldThrottle().Should().Be(Throttle.Valve.Open, "It accepts multiple event before closing");
         shouldThrottle().Should().Be(Throttle.Valve.Closing, "Last event before close");
         shouldThrottle().Should().Be(Throttle.Valve.Closed, "Anything over the limit is throttled");
-        await Task.Delay(1000);
+        await Task.Delay(1000); // allow throttle to reopen
         shouldThrottle().Should().Be(Throttle.Valve.Open, "After the period it should open again");
     }
 }


### PR DESCRIPTION
## Summary
- add optional CancellationToken to Throttle.Create and document throttle window
- thread cancellation tokens through all Throttle.Create callers
- expand Throttle tests to use explicit tokens

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj --no-build`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a9798b58b48328a8bc876d5e48fa5d