### PR TITLE
docs: document member delta builder

### DIFF
--- a/CLUSTER_MEMBERSHIP_GOSSIP.md
+++ b/CLUSTER_MEMBERSHIP_GOSSIP.md
@@ -30,6 +30,35 @@ state to randomly chosen peers ([Gossiper.cs](src/Proto.Cluster/Gossip/Gossiper.
 Peers merge received updates, which allows membership changes to spread
 throughout the cluster.
 
+## Delta-based member state propagation
+
+`MemberStateDeltaBuilder` constructs per-target deltas by tracking a watermark
+for each `{target}.{member}` pair. The watermark represents the highest sequence
+number previously sent to that target for a given member. During a build, values
+with a higher sequence number are included in the delta and the watermark is
+advanced:
+
+```csharp
+var watermarkKey = $"{targetMemberId}.{memberId}";
+committedOffsets.TryGetValue(watermarkKey, out var watermark);
+...
+if (value.SequenceNumber <= watermark) continue;
+if (value.SequenceNumber > newWatermark) newWatermark = value.SequenceNumber;
+```
+
+The builder stops once it has added updates for `_gossipMaxSend` members,
+ensuring that large clusters do not overwhelm the network. Members exceeding
+this limit are retried in later cycles:
+
+```csharp
+count++;
+if (count >= _gossipMaxSend) break;
+```
+
+If no sequence numbers exceed the watermark, the member is omitted from the
+delta and its watermark remains unchanged. This prevents redundant transmissions
+but means updates may be delayed when the `gossipMaxSend` limit is hit.
+
 ## Member states
 
 - **Joined / Left** – Calculated by `MemberList.UpdateClusterTopology` and

--- a/logs/log1755940222.md
+++ b/logs/log1755940222.md
@@ -1,0 +1,5 @@
+## CLUSTER_MEMBERSHIP_GOSSIP.md update
+
+- Added a new section explaining how `MemberStateDeltaBuilder` computes member state deltas using `{target}.{member}` watermarks and sequence numbers.
+- Included code excerpts to illustrate watermark handling and the `gossipMaxSend` safety limit.
+- Motivation: The previous documentation described membership gossip flow but lacked details on delta computation. Clarifying watermark and sequence usage aids maintainers and users in understanding how state replication remains efficient and bounded.


### PR DESCRIPTION
## Summary
- clarify how `MemberStateDeltaBuilder` computes deltas using `{target}.{member}` watermarks and sequence numbers
- note the `_gossipMaxSend` cap and add example for edge cases

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a98550396083289a4c4d5d5ecc233e