### PR TITLE
Refactor gossip member delta builder for deterministic behavior

### DIFF
--- a/logs/log1755940517.md
+++ b/logs/log1755940517.md
@@ -1,0 +1,13 @@
+## Summary
+- Refactored `MemberStateDeltaBuilder` with a pure `BuildOrdered` function returning state, updated offsets and a flag without mutating inputs.
+- Added wrapper `Build` that orders members randomly before delegating to the pure function.
+- Updated tests to use deterministic member sequences verifying watermark updates and `gossipMaxSend` limits.
+
+## Motivation
+- Separating deterministic delta calculation improves testability and aligns with functional style guidance.
+- Fixed-order tests ensure gossip state logic behaves predictably and respects configuration limits.
+
+## Testing
+- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
+- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
+- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`

--- a/src/Proto.Cluster/Gossip/MemberStateDeltaBuilder.cs
+++ b/src/Proto.Cluster/Gossip/MemberStateDeltaBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Proto.Cluster.Gossip;
@@ -21,14 +22,28 @@ internal class MemberStateDeltaBuilder
         ImmutableDictionary<string, long> committedOffsets,
         Random rnd)
     {
-        var newState = new GossipState();
-        var pendingOffsets = committedOffsets;
-        var count = 0;
-
         var members = currentState
             .Members
             .Where(m => m.Key != targetMemberId)
             .OrderByRandom(rnd, m => m.Key == _myId);
+
+        return BuildOrdered(currentState, targetMemberId, committedOffsets, members, _gossipMaxSend);
+    }
+
+    /// <summary>
+    /// Calculates a member state delta based on a deterministic member sequence.
+    /// Returns a new state, updated offsets and a flag indicating if any state was sent.
+    /// </summary>
+    public static MemberStateDeltaBuildResult BuildOrdered(
+        GossipState currentState,
+        string targetMemberId,
+        ImmutableDictionary<string, long> committedOffsets,
+        IEnumerable<KeyValuePair<string, GossipState.Types.GossipMemberState>> members,
+        int gossipMaxSend)
+    {
+        var newState = new GossipState();
+        var pendingOffsets = committedOffsets;
+        var count = 0;
 
         foreach (var (memberId, memberState) in members)
         {
@@ -57,7 +72,7 @@ internal class MemberStateDeltaBuilder
                 newState.Members.Add(memberId, newMemberState);
                 pendingOffsets = pendingOffsets.SetItem(watermarkKey, newWatermark);
                 count++;
-                if (count >= _gossipMaxSend)
+                if (count >= gossipMaxSend)
                 {
                     break;
                 }

--- a/tests/Proto.Cluster.Tests/MemberStateDeltaBuilderTests.cs
+++ b/tests/Proto.Cluster.Tests/MemberStateDeltaBuilderTests.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Collections.Immutable;
+using System.Linq;
 using FluentAssertions;
 using Proto.Cluster.Gossip;
 using Xunit;
@@ -11,7 +11,6 @@ public class MemberStateDeltaBuilderTests
     [Fact]
     public void Build_FiltersUsingWatermarks()
     {
-        var builder = new MemberStateDeltaBuilder("a", 10);
         var state = new GossipState();
 
         var memberA = new GossipState.Types.GossipMemberState();
@@ -22,7 +21,9 @@ public class MemberStateDeltaBuilderTests
         var committed = ImmutableDictionary<string, long>.Empty
             .SetItem("c.a", 1);
 
-        var result = builder.Build(state, "c", committed, new Random(0));
+        var members = state.Members.Where(m => m.Key != "c");
+
+        var result = MemberStateDeltaBuilder.BuildOrdered(state, "c", committed, members, 10);
 
         result.State.Members.Should().ContainKey("a");
         result.State.Members["a"].Values.Keys.Should().BeEquivalentTo("k2");
@@ -33,7 +34,6 @@ public class MemberStateDeltaBuilderTests
     [Fact]
     public void Build_RespectsMaxSend()
     {
-        var builder = new MemberStateDeltaBuilder("member0", 3);
         var state = new GossipState();
 
         for (var i = 0; i < 5; i++)
@@ -43,7 +43,9 @@ public class MemberStateDeltaBuilderTests
             state.Members.Add($"member{i}", ms);
         }
 
-        var result = builder.Build(state, "target", ImmutableDictionary<string, long>.Empty, new Random(0));
+        var members = state.Members.OrderBy(m => m.Key);
+
+        var result = MemberStateDeltaBuilder.BuildOrdered(state, "target", ImmutableDictionary<string, long>.Empty, members, 3);
 
         result.State.Members.Count.Should().BeLessOrEqualTo(3);
     }


### PR DESCRIPTION
## Summary
- extract pure `BuildOrdered` function for gossip member deltas
- delegate existing builder to ordered function
- test watermark and `gossipMaxSend` behavior with deterministic members

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a9853c47dc8328b4e5bd31e2e7f9cc