### PR TITLE
refactor: add pure MergeStates and tests

### DIFF
--- a/logs/log1755942454.md
+++ b/logs/log1755942454.md
@@ -1,0 +1,6 @@
+# MergeStates refactor
+- Introduced pure `MergeStates` in `GossipStateManagement` to merge gossip states without mutating inputs. This allows tests to verify immutability and follows functional style.
+- Updated `Gossip.ReceiveState` to rely on the new function, keeping state commit separate from calculation.
+- Replaced in-place timestamp updates with copies to ensure original states remain unchanged.
+- Added unit tests exercising `MergeStates` and confirming inputs are unaffected.
+- Verified functionality by running `Proto.Actor.Tests`, `Proto.Remote.Tests`, and `Proto.Cluster.Tests`.

--- a/src/Proto.Cluster/Gossip/Gossip.cs
+++ b/src/Proto.Cluster/Gossip/Gossip.cs
@@ -137,7 +137,7 @@ internal class Gossip
 
     public ImmutableList<GossipUpdate> ReceiveState(GossipState remoteState)
     {
-        var updates = GossipStateManagement.MergeState(_state, remoteState, out var newState, out var updatedKeys);
+        var (newState, updates, updatedKeys) = GossipStateManagement.MergeStates(_state, remoteState);
 
         if (updates.Count == 0)
         {
@@ -153,7 +153,7 @@ internal class Gossip
         }
 
         _state = newState;
-        
+
         CheckConsensus(updatedKeys);
 
         return updates.ToImmutableList();

--- a/src/Proto.Cluster/Gossip/GossipStateManagement.cs
+++ b/src/Proto.Cluster/Gossip/GossipStateManagement.cs
@@ -62,67 +62,59 @@ internal static class GossipStateManagement
         return memberState;
     }
 
-    public static IReadOnlyCollection<GossipUpdate> MergeState(
+    // Merge two states and return the new state and associated updates without touching the inputs
+    public static (GossipState newState, IReadOnlyCollection<GossipUpdate> updates, HashSet<string> updatedKeys) MergeStates(
         GossipState localState,
-        GossipState remoteState,
-        out GossipState newState,
-        out HashSet<string> updatedKeys
+        GossipState remoteState
     )
     {
-        newState = localState.Clone();
+        var newState = localState.Clone();
         var updates = new List<GossipUpdate>();
-        updatedKeys = new HashSet<string>();
+        var updatedKeys = new HashSet<string>();
 
         foreach (var (memberId, remoteMemberState) in remoteState.Members)
         {
-            //this entry does not exist in newState, just copy all of it
-            if (!newState.Members.ContainsKey(memberId))
+            if (!newState.Members.TryGetValue(memberId, out var newMemberState))
             {
-                newState.Members.Add(memberId, remoteMemberState);
+                var clonedMemberState = remoteMemberState.Clone();
 
-                foreach (var entry in remoteMemberState.Values)
+                foreach (var (key, value) in clonedMemberState.Values)
                 {
-                    updates.Add(new GossipUpdate(memberId, entry.Key, entry.Value.Value, entry.Value.SequenceNumber));
-                    entry.Value.LocalTimestampUnixMilliseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-                    updatedKeys.Add(entry.Key);
+                    value.LocalTimestampUnixMilliseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                    updates.Add(new GossipUpdate(memberId, key, value.Value, value.SequenceNumber));
+                    updatedKeys.Add(key);
                 }
 
+                newState.Members.Add(memberId, clonedMemberState);
                 continue;
             }
 
-            //this entry exists in both newState and remoteState, we should merge them
-            var newMemberState = newState.Members[memberId];
-
             foreach (var (key, remoteValue) in remoteMemberState.Values)
             {
-                //this entry does not exist in newMemberState, just copy all of it
-                if (!newMemberState.Values.ContainsKey(key))
+                if (!newMemberState.Values.TryGetValue(key, out var existingValue))
                 {
-                    newMemberState.Values.Add(key, remoteValue);
-                    updates.Add(new GossipUpdate(memberId, key, remoteValue.Value, remoteValue.SequenceNumber));
-                    remoteValue.LocalTimestampUnixMilliseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                    var newValue = remoteValue.Clone();
+                    newValue.LocalTimestampUnixMilliseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                    newMemberState.Values.Add(key, newValue);
+                    updates.Add(new GossipUpdate(memberId, key, newValue.Value, newValue.SequenceNumber));
                     updatedKeys.Add(key);
-
                     continue;
                 }
 
-                var newValue = newMemberState.Values[key];
-
-                //remote value is older, ignore
-                if (remoteValue.SequenceNumber <= newValue.SequenceNumber)
+                if (remoteValue.SequenceNumber <= existingValue.SequenceNumber)
                 {
                     continue;
                 }
 
-                //just replace the existing value
-                newMemberState.Values[key] = remoteValue;
-                updates.Add(new GossipUpdate(memberId, key, remoteValue.Value, remoteValue.SequenceNumber));
-                remoteValue.LocalTimestampUnixMilliseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                var replacedValue = remoteValue.Clone();
+                replacedValue.LocalTimestampUnixMilliseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                newMemberState.Values[key] = replacedValue;
+                updates.Add(new GossipUpdate(memberId, key, replacedValue.Value, replacedValue.SequenceNumber));
                 updatedKeys.Add(key);
             }
         }
 
-        return updates;
+        return (newState, updates, updatedKeys);
     }
 
     public static long SetKey(GossipState state, string key, IMessage value, string memberId, long sequenceNo)

--- a/tests/Proto.Cluster.Tests/GossipStateManagementTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipStateManagementTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+using Proto.Cluster.Gossip;
+using Xunit;
+
+namespace Proto.Cluster.Tests;
+
+public class GossipStateManagementTests
+{
+    [Fact]
+    public void MergeStates_should_merge_without_mutating_inputs()
+    {
+        // local state with one value
+        var localState = new GossipState();
+        var localMember = new GossipState.Types.GossipMemberState();
+        localMember.Values.Add("k1", new GossipKeyValue
+        {
+            SequenceNumber = 1,
+            Value = Any.Pack(new StringValue { Value = "old" }),
+            LocalTimestampUnixMilliseconds = 100
+        });
+        localState.Members.Add("A", localMember);
+
+        // remote state with new values and a new member
+        var remoteState = new GossipState();
+        var remoteMemberA = new GossipState.Types.GossipMemberState();
+        remoteMemberA.Values.Add("k1", new GossipKeyValue
+        {
+            SequenceNumber = 2,
+            Value = Any.Pack(new StringValue { Value = "new" }),
+            LocalTimestampUnixMilliseconds = 200
+        });
+        remoteMemberA.Values.Add("k2", new GossipKeyValue
+        {
+            SequenceNumber = 1,
+            Value = Any.Pack(new StringValue { Value = "other" }),
+            LocalTimestampUnixMilliseconds = 300
+        });
+        remoteState.Members.Add("A", remoteMemberA);
+
+        var remoteMemberB = new GossipState.Types.GossipMemberState();
+        remoteMemberB.Values.Add("k3", new GossipKeyValue
+        {
+            SequenceNumber = 1,
+            Value = Any.Pack(new StringValue { Value = "b1" }),
+            LocalTimestampUnixMilliseconds = 400
+        });
+        remoteState.Members.Add("B", remoteMemberB);
+
+        var (newState, updates, updatedKeys) = GossipStateManagement.MergeStates(localState, remoteState);
+
+        // new state contains merged data
+        newState.Members.Should().ContainKey("A").WhoseValue.Values.Should().ContainKeys("k1", "k2");
+        newState.Members.Should().ContainKey("B");
+        newState.Members["A"].Values["k1"].SequenceNumber.Should().Be(2);
+        newState.Members["A"].Values["k1"].Value.Unpack<StringValue>().Value.Should().Be("new");
+        newState.Members["A"].Values["k2"].SequenceNumber.Should().Be(1);
+        newState.Members["A"].Values["k2"].Value.Unpack<StringValue>().Value.Should().Be("other");
+        newState.Members["B"].Values["k3"].SequenceNumber.Should().Be(1);
+        newState.Members["B"].Values["k3"].Value.Unpack<StringValue>().Value.Should().Be("b1");
+
+        // updates reflect added/changed keys
+        updates.Should().HaveCount(3);
+        updates.Should().Contain(u => u.MemberId == "A" && u.Key == "k1" && u.SequenceNumber == 2);
+        updates.Should().Contain(u => u.MemberId == "A" && u.Key == "k2" && u.SequenceNumber == 1);
+        updates.Should().Contain(u => u.MemberId == "B" && u.Key == "k3" && u.SequenceNumber == 1);
+        updatedKeys.Should().BeEquivalentTo(new[] { "k1", "k2", "k3" });
+
+        // input states remain untouched
+        localState.Members["A"].Values.Should().ContainKey("k1");
+        localState.Members["A"].Values.Should().NotContainKey("k2");
+        localState.Members["A"].Values["k1"].SequenceNumber.Should().Be(1);
+        localState.Members["A"].Values["k1"].LocalTimestampUnixMilliseconds.Should().Be(100);
+        remoteState.Members["A"].Values["k1"].LocalTimestampUnixMilliseconds.Should().Be(200);
+        remoteState.Members["A"].Values["k2"].LocalTimestampUnixMilliseconds.Should().Be(300);
+        remoteState.Members["B"].Values["k3"].LocalTimestampUnixMilliseconds.Should().Be(400);
+    }
+}


### PR DESCRIPTION
## Summary
- add `MergeStates` to combine gossip states without mutating inputs
- refactor `ReceiveState` to use `MergeStates`
- test merging behavior and immutability

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a98cf18e6883289d39b9b500b9b21d