### PR TITLE
feat(gossip): add deterministic random provider

### DIFF
--- a/logs/log1755942573.md
+++ b/logs/log1755942573.md
@@ -1,0 +1,11 @@
+# Log 1755942573
+
+## Summary
+- Introduced `IRandomProvider` abstraction for gossip to allow deterministic behavior in tests.
+- Replaced direct `Random` usage in `Gossip` and `MemberStateDeltaBuilder` with the abstraction.
+- Added `SystemRandomProvider` as the production implementation.
+- Updated random ordering extensions and added deterministic tests verifying ordering and delta contents.
+- Installed .NET 8 SDK and executed core test suites.
+
+## Motivation
+These changes decouple gossip logic from `System.Random`, enabling deterministic unit tests and allowing alternative random sources. This improves reproducibility and flexibility of the gossip subsystem.

--- a/src/Proto.Cluster/Gossip/Gossip.cs
+++ b/src/Proto.Cluster/Gossip/Gossip.cs
@@ -64,7 +64,7 @@ internal class Gossip
     private readonly int _gossipMaxSend;
     private readonly InstanceLogger? _logger;
     private readonly string _myId;
-    private readonly Random _rnd = new();
+    private readonly IRandomProvider _random;
     private readonly MemberStateDeltaBuilder _memberStateDeltaBuilder;
     private ImmutableHashSet<string> _activeMemberIds = ImmutableHashSet<string>.Empty;
     private ImmutableDictionary<string, long> _committedOffsets = ImmutableDictionary<string, long>.Empty;
@@ -73,7 +73,7 @@ internal class Gossip
     private GossipState _state = new();
 
     public Gossip(string myId, int gossipFanout, int gossipMaxSend, InstanceLogger? logger,
-        Func<ImmutableHashSet<string>> getMembers, bool gossipDebugLogging)
+        Func<ImmutableHashSet<string>> getMembers, bool gossipDebugLogging, IRandomProvider? randomProvider = null)
     {
         _myId = myId;
         _logger = logger;
@@ -81,6 +81,7 @@ internal class Gossip
         _gossipDebugLogging = gossipDebugLogging;
         _gossipFanout = gossipFanout;
         _gossipMaxSend = gossipMaxSend;
+        _random = randomProvider ?? new SystemRandomProvider();
         _memberStateDeltaBuilder = new MemberStateDeltaBuilder(myId, gossipMaxSend);
     }
 
@@ -193,7 +194,7 @@ internal class Gossip
                 GossipStateManagement.EnsureMemberStateExists(_state, member.Id);
             }
 
-            var randomMembers = _otherMembers.OrderByRandom(_rnd).ToArray();
+            var randomMembers = _otherMembers.OrderByRandom(_random).ToArray();
 
             var fanoutCount = 0;
 
@@ -233,7 +234,7 @@ internal class Gossip
     public MemberStateDelta GetMemberStateDelta(string targetMemberId)
     {
         var (state, pendingOffsets, hasState) =
-            _memberStateDeltaBuilder.Build(_state, targetMemberId, _committedOffsets, _rnd);
+            _memberStateDeltaBuilder.Build(_state, targetMemberId, _committedOffsets, _random);
 
         return new MemberStateDelta(targetMemberId, hasState, state, () => CommitPendingOffsets(pendingOffsets));
     }

--- a/src/Proto.Cluster/Gossip/IRandomProvider.cs
+++ b/src/Proto.Cluster/Gossip/IRandomProvider.cs
@@ -1,0 +1,6 @@
+namespace Proto.Cluster.Gossip;
+
+public interface IRandomProvider
+{
+    int Next();
+}

--- a/src/Proto.Cluster/Gossip/MemberStateDeltaBuilder.cs
+++ b/src/Proto.Cluster/Gossip/MemberStateDeltaBuilder.cs
@@ -20,7 +20,7 @@ internal class MemberStateDeltaBuilder
         GossipState currentState,
         string targetMemberId,
         ImmutableDictionary<string, long> committedOffsets,
-        Random rnd)
+        IRandomProvider rnd)
     {
         var members = currentState
             .Members

--- a/src/Proto.Cluster/Gossip/RandomOrderExtensions.cs
+++ b/src/Proto.Cluster/Gossip/RandomOrderExtensions.cs
@@ -12,13 +12,13 @@ namespace Proto.Cluster.Gossip;
 
 public static class RandomOrderExtensions
 {
-    public static IEnumerable<T> OrderByRandom<T>(this IEnumerable<T> items, Random rnd) =>
+    public static IEnumerable<T> OrderByRandom<T>(this IEnumerable<T> items, IRandomProvider rnd) =>
         items
             .Select(m => (item: m, index: rnd.Next()))
             .OrderBy(m => m.index)
             .Select(m => m.item);
 
-    public static IEnumerable<T> OrderByRandom<T>(this IEnumerable<T> items, Random rnd, Func<T, bool> shouldBeFirst) =>
+    public static IEnumerable<T> OrderByRandom<T>(this IEnumerable<T> items, IRandomProvider rnd, Func<T, bool> shouldBeFirst) =>
         items
             .Select(m => (item: m, index: rnd.Next()))
             .OrderBy(m =>

--- a/src/Proto.Cluster/Gossip/SystemRandomProvider.cs
+++ b/src/Proto.Cluster/Gossip/SystemRandomProvider.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Proto.Cluster.Gossip;
+
+internal sealed class SystemRandomProvider : IRandomProvider
+{
+    private readonly Random _random;
+
+    public SystemRandomProvider() : this(new Random())
+    {
+    }
+
+    public SystemRandomProvider(Random random)
+    {
+        _random = random;
+    }
+
+    public int Next() => _random.Next();
+}

--- a/tests/Proto.Cluster.Tests/DeterministicRandomProvider.cs
+++ b/tests/Proto.Cluster.Tests/DeterministicRandomProvider.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using Proto.Cluster.Gossip;
+
+namespace Proto.Cluster.Tests;
+
+internal sealed class DeterministicRandomProvider : IRandomProvider
+{
+    private readonly Queue<int> _values;
+
+    public DeterministicRandomProvider(IEnumerable<int> values)
+    {
+        _values = new Queue<int>(values);
+    }
+
+    public int Next() => _values.Count > 0 ? _values.Dequeue() : 0;
+}

--- a/tests/Proto.Cluster.Tests/GossipRandomOrderingTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipRandomOrderingTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using ClusterTest.Messages;
+using FluentAssertions;
+using Proto.Cluster.Gossip;
+using Xunit;
+
+namespace Proto.Cluster.Tests;
+
+public class GossipRandomOrderingTests
+{
+    [Fact]
+    public async Task SendState_UsesRandomProviderOrdering()
+    {
+        var rnd = new DeterministicRandomProvider(new[] { 1, 0, 2 });
+        var myId = "me";
+        var gossip = new Gossip.Gossip(myId, gossipFanout: 3, gossipMaxSend: 10, logger: null,
+            () => ImmutableHashSet.Create(myId, "a", "b", "c"), false, rnd);
+
+        var topology = new ClusterTopology
+        {
+            Members =
+            {
+                new Member { Id = myId },
+                new Member { Id = "a" },
+                new Member { Id = "b" },
+                new Member { Id = "c" }
+            }
+        };
+
+        await gossip.UpdateClusterTopology(topology);
+        gossip.SetState("k", new SomeGossipState { Key = "v" });
+
+        var sends = gossip.SendState().ToList();
+        sends.Select(s => s.member.Id).Should().Equal("b", "a", "c");
+
+        foreach (var send in sends)
+        {
+            send.memberState.State.Members.Should().ContainKey(myId);
+            send.memberState.State.Members[myId].Values.Should().ContainKey("k");
+        }
+    }
+}

--- a/tests/Proto.Cluster.Tests/MemberStateDeltaBuilderTests.cs
+++ b/tests/Proto.Cluster.Tests/MemberStateDeltaBuilderTests.cs
@@ -49,4 +49,33 @@ public class MemberStateDeltaBuilderTests
 
         result.State.Members.Count.Should().BeLessOrEqualTo(3);
     }
+
+    [Fact]
+    public void Build_UsesRandomProviderOrdering()
+    {
+        var state = new GossipState();
+
+        var me = new GossipState.Types.GossipMemberState();
+        me.Values.Add("k-me", new GossipKeyValue { SequenceNumber = 1 });
+        state.Members.Add("me", me);
+
+        var a = new GossipState.Types.GossipMemberState();
+        a.Values.Add("k-a", new GossipKeyValue { SequenceNumber = 1 });
+        state.Members.Add("a", a);
+
+        var b = new GossipState.Types.GossipMemberState();
+        b.Values.Add("k-b", new GossipKeyValue { SequenceNumber = 1 });
+        state.Members.Add("b", b);
+
+        var committed = ImmutableDictionary<string, long>.Empty;
+        var rnd = new DeterministicRandomProvider(new[] { 5, 1, 2 });
+        var builder = new MemberStateDeltaBuilder("me", 10);
+
+        var result = builder.Build(state, "target", committed, rnd);
+
+        result.State.Members.Keys.Should().Equal("me", "a", "b");
+        result.State.Members["me"].Values.Keys.Should().Equal("k-me");
+        result.State.Members["a"].Values.Keys.Should().Equal("k-a");
+        result.State.Members["b"].Values.Keys.Should().Equal("k-b");
+    }
 }


### PR DESCRIPTION
## Summary
- add `IRandomProvider` abstraction for gossip logic
- default to `SystemRandomProvider` in production
- enable deterministic member ordering via tests

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a98d003dc08328ad649200c4c018b6