### PR TITLE
Introduce gossip transport abstraction and tests

### DIFF
--- a/logs/log1755940658.md
+++ b/logs/log1755940658.md
@@ -1,0 +1,7 @@
+## Change Log
+- Added IGossipTransport abstraction to decouple GossipActor from transport details.
+- Introduced GossipSender helper to centralize timeout handling and elapsed time measurements for gossip requests.
+- Modified GossipActor to use injected IGossipTransport and helper for sending gossip.
+- Updated Gossiper to provide transport implementation when starting GossipActor.
+- Added unit tests with mock transport covering success, rejection, timeout, and dead letter scenarios.
+- Installed .NET 8 SDK to run tests.

--- a/src/Proto.Cluster/Gossip/GossipActor.cs
+++ b/src/Proto.Cluster/Gossip/GossipActor.cs
@@ -20,6 +20,7 @@ public class GossipActor : IActor
 #pragma warning restore CS0618 // Type or member is obsolete
     private readonly TimeSpan _gossipRequestTimeout;
     private readonly IGossip _internal;
+    private readonly IGossipTransport _transport;
 
     // lookup from state key -> consensus checks
 
@@ -29,11 +30,13 @@ public class GossipActor : IActor
         InstanceLogger? instanceLogger,
         int gossipFanout,
         int gossipMaxSend,
-        IGossip gossip
+        IGossip gossip,
+        IGossipTransport transport
     )
     {
         _gossipRequestTimeout = gossipRequestTimeout;
         _internal = gossip;
+        _transport = transport;
     }
 
     public async Task ReceiveAsync(IContext context)
@@ -197,14 +200,11 @@ public class GossipActor : IActor
     private void SendGossipForMember(IContext context, Member targetMember,
         MemberStateDelta memberStateDelta)
     {
-        var pid = PID.FromAddress(targetMember.Address, Gossiper.GossipActorName);
-
         if (Logger.IsEnabled(LogLevel.Debug))
         {
             Logger.LogDebug("Sending GossipRequest to {MemberId}", targetMember.Id);
         }
 
-        var start = DateTime.UtcNow;
         var gossipRequest = new GossipRequest
         {
             MemberId = context.System.Id,
@@ -215,55 +215,7 @@ public class GossipActor : IActor
             gossipRequest.RequestId = Guid.NewGuid().ToString("N");
             Logger.LogInformation("Sending GossipRequest {Request} to {MemberId}", gossipRequest, targetMember.Id);
         }
-        context.RequestReenter<GossipResponse>(pid, gossipRequest,
-            async task =>
-            {
-                var delta = DateTime.UtcNow - start;
-                var self = context.Cluster().MemberList.Self;
-                
-                //if the target is no longer part of the cluster. don't log. the failure is expected.. issue #1992
-                if (!context.Cluster().MemberList.TryGetMember(targetMember.Id, out _))
-                {
-                    return;
-                }
 
-                try
-                {
-                    var res = await task.ConfigureAwait(false);
-                    if (res.Rejected)
-                    {
-                        //we could be smarter here. rejected because of block? then init shutdown
-                        return;
-                    }
-                    
-                    memberStateDelta.CommitOffsets();
-                }
-                catch (TimeoutException)
-                {
-                    //log member issue #1993
-                    Logger.LogWarning(
-                        "Timeout in GossipReenterAfterSend, elapsed {Delta}ms for target member {TargetMember} from {SelfMember}",
-                        delta.TotalMilliseconds, targetMember, self);
-                }
-                catch (DeadLetterException x)
-                {
-                    Logger.LogDebug(x,
-                        "DeadLetter in GossipReenterAfterSend, elapsed {Delta}ms for target member {TargetMember} from {SelfMember}",
-                        delta.TotalMilliseconds, targetMember, self);
-                }
-                catch (Exception x)
-                {
-                    //if the target is no longer part of the cluster. don't log. the failure is expected.. issue #1992
-                    if (context.Cluster().MemberList.TryGetMember(targetMember.Id, out _))
-                    {
-                        //log member issue #1993
-                        Logger.LogError(x,
-                            "GossipReenterAfterSend failed, elapsed {Delta}ms for target member {TargetMember} from {SelfMember}",
-                            delta.TotalMilliseconds, targetMember, self);
-                    }
-                }
-            },
-            CancellationTokens.WithTimeout(_gossipRequestTimeout)
-        );
+        GossipSender.Send(context, context.Cluster(), targetMember, memberStateDelta, gossipRequest, _gossipRequestTimeout, _transport);
     }
 }

--- a/src/Proto.Cluster/Gossip/GossipSender.cs
+++ b/src/Proto.Cluster/Gossip/GossipSender.cs
@@ -1,0 +1,88 @@
+// -----------------------------------------------------------------------
+// <copyright file="GossipSender.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Proto;
+using Proto.Logging;
+
+namespace Proto.Cluster.Gossip;
+
+internal static class GossipSender
+{
+    private static readonly ILogger Logger = Log.CreateLogger<GossipActor>();
+
+    public static void Send(
+        IContext context,
+        Cluster cluster,
+        Member targetMember,
+        MemberStateDelta memberStateDelta,
+        GossipRequest request,
+        TimeSpan timeout,
+        IGossipTransport transport)
+    {
+        var pid = PID.FromAddress(targetMember.Address, Gossiper.GossipActorName);
+        var start = DateTime.UtcNow;
+
+        transport.Request(
+            context,
+            pid,
+            request,
+            async task =>
+            {
+                var delta = DateTime.UtcNow - start;
+                var self = cluster.MemberList.Self;
+
+                if (!cluster.MemberList.TryGetMember(targetMember.Id, out _))
+                {
+                    return;
+                }
+
+                try
+                {
+                    var res = await task.ConfigureAwait(false);
+                    if (res.Rejected)
+                    {
+                        return;
+                    }
+
+                    memberStateDelta.CommitOffsets();
+                }
+                catch (TimeoutException)
+                {
+                    Logger.LogWarning(
+                        "Timeout in GossipReenterAfterSend, elapsed {Delta}ms for target member {TargetMember} from {SelfMember}",
+                        delta.TotalMilliseconds,
+                        targetMember,
+                        self);
+                }
+                catch (DeadLetterException x)
+                {
+                    Logger.LogDebug(
+                        x,
+                        "DeadLetter in GossipReenterAfterSend, elapsed {Delta}ms for target member {TargetMember} from {SelfMember}",
+                        delta.TotalMilliseconds,
+                        targetMember,
+                        self);
+                }
+                catch (Exception x)
+                {
+                    if (cluster.MemberList.TryGetMember(targetMember.Id, out _))
+                    {
+                        Logger.LogError(
+                            x,
+                            "GossipReenterAfterSend failed, elapsed {Delta}ms for target member {TargetMember} from {SelfMember}",
+                            delta.TotalMilliseconds,
+                            targetMember,
+                            self);
+                    }
+                }
+            },
+            CancellationTokens.WithTimeout(timeout));
+    }
+}

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -187,7 +187,7 @@ public class Gossiper
         }
     }
 
-    internal Task StartGossipActorAsync(IGossip? gossip = null)
+    internal Task StartGossipActorAsync(IGossip? gossip = null, IGossipTransport? transport = null)
     {
         _gossip = gossip ?? new Gossip(
             _cluster.System.Id,
@@ -203,7 +203,8 @@ public class Gossiper
             _cluster.System.Logger(),
             _cluster.Config.GossipFanout,
             _cluster.Config.GossipMaxSend,
-            _gossip));
+            _gossip,
+            transport ?? new GossipTransport()));
 
         _pid = _context.SpawnNamedSystem(props, GossipActorName);
         _cluster.System.EventStream.Subscribe<ClusterTopology>(topology =>

--- a/src/Proto.Cluster/Gossip/IGossipTransport.cs
+++ b/src/Proto.Cluster/Gossip/IGossipTransport.cs
@@ -1,0 +1,47 @@
+// -----------------------------------------------------------------------
+// <copyright file="IGossipTransport.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Proto;
+
+namespace Proto.Cluster.Gossip;
+
+/// <summary>
+/// Abstraction over sending gossip requests.
+/// </summary>
+public interface IGossipTransport
+{
+    /// <summary>
+    /// Sends a <see cref="GossipRequest"/> and invokes the callback once a response is available.
+    /// </summary>
+    /// <param name="context">Actor context used for the request.</param>
+    /// <param name="pid">Target gossip actor PID.</param>
+    /// <param name="request">The request to send.</param>
+    /// <param name="onResponse">Continuation executed when the request completes.</param>
+    /// <param name="cancellationToken">Cancellation token controlling the request timeout.</param>
+    void Request(
+        IContext context,
+        PID pid,
+        GossipRequest request,
+        Func<Task<GossipResponse>, Task> onResponse,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Default transport that forwards requests using <see cref="IContext.RequestReenter{T}"/>.
+/// </summary>
+public sealed class GossipTransport : IGossipTransport
+{
+    public void Request(
+        IContext context,
+        PID pid,
+        GossipRequest request,
+        Func<Task<GossipResponse>, Task> onResponse,
+        CancellationToken cancellationToken) =>
+        context.RequestReenter(pid, request, onResponse, cancellationToken);
+}

--- a/tests/Proto.Cluster.Tests/GossipTransportTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTransportTests.cs
@@ -1,0 +1,164 @@
+// -----------------------------------------------------------------------
+// <copyright file="GossipTransportTests.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Proto;
+using Proto.Cluster;
+using Proto.Cluster.Gossip;
+using Xunit;
+using static Proto.TestKit.TestKit;
+
+namespace Proto.Cluster.Tests;
+
+[Collection("ClusterTests")]
+public class GossipTransportTests
+{
+    private sealed class MockTransport : IGossipTransport
+    {
+        private readonly Action<Func<Task<GossipResponse>, Task>, CancellationToken> _handler;
+
+        public MockTransport(Action<Func<Task<GossipResponse>, Task>, CancellationToken> handler) => _handler = handler;
+
+        public void Request(
+            IContext context,
+            PID pid,
+            GossipRequest request,
+            Func<Task<GossipResponse>, Task> onResponse,
+            CancellationToken cancellationToken) =>
+            _handler(onResponse, cancellationToken);
+    }
+
+    [Fact]
+    public async Task Success_should_commit_offsets()
+    {
+        var fixture = new InMemoryClusterFixture();
+        await using var _ = fixture;
+        await fixture.InitializeAsync();
+        var cluster = fixture.Members[0];
+        var targetMember = fixture.Members[1].MemberList.Self;
+        await AwaitConditionAsync(() => cluster.MemberList.ContainsMemberId(targetMember.Id), TimeSpan.FromSeconds(10));
+        var committed = false;
+        var delta = new MemberStateDelta(targetMember.Id, true, new GossipState(), () => committed = true);
+        var request = new GossipRequest { MemberId = cluster.System.Id, State = delta.State };
+        var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var transport = new MockTransport((cb, _) =>
+        {
+            cb(Task.FromResult(new GossipResponse())).ContinueWith(_ => done.SetResult());
+        });
+
+        var props = Props.FromFunc(ctx =>
+        {
+            GossipSender.Send(ctx, cluster, targetMember, delta, request, cluster.Config.GossipRequestTimeout, transport);
+            return Task.CompletedTask;
+        });
+
+        var pid = cluster.System.Root.Spawn(props);
+        cluster.System.Root.Send(pid, "go");
+
+        await done.Task;
+        Assert.True(committed);
+    }
+
+    [Fact]
+    public async Task Rejection_should_not_commit_offsets()
+    {
+        var fixture = new InMemoryClusterFixture();
+        await using var _ = fixture;
+        await fixture.InitializeAsync();
+        var cluster = fixture.Members[0];
+        var targetMember = fixture.Members[1].MemberList.Self;
+        await AwaitConditionAsync(() => cluster.MemberList.ContainsMemberId(targetMember.Id), TimeSpan.FromSeconds(10));
+        var committed = false;
+        var delta = new MemberStateDelta(targetMember.Id, true, new GossipState(), () => committed = true);
+        var request = new GossipRequest { MemberId = cluster.System.Id, State = delta.State };
+        var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var transport = new MockTransport((cb, _) =>
+        {
+            var resp = new GossipResponse { Rejected = true };
+            cb(Task.FromResult(resp)).ContinueWith(_ => done.SetResult());
+        });
+
+        var props = Props.FromFunc(ctx =>
+        {
+            GossipSender.Send(ctx, cluster, targetMember, delta, request, cluster.Config.GossipRequestTimeout, transport);
+            return Task.CompletedTask;
+        });
+
+        var pid = cluster.System.Root.Spawn(props);
+        cluster.System.Root.Send(pid, "go");
+
+        await done.Task;
+        Assert.False(committed);
+    }
+
+    [Fact]
+    public async Task Timeout_should_not_commit_offsets()
+    {
+        var fixture = new InMemoryClusterFixture();
+        await using var _ = fixture;
+        await fixture.InitializeAsync();
+        var cluster = fixture.Members[0];
+        var targetMember = fixture.Members[1].MemberList.Self;
+        await AwaitConditionAsync(() => cluster.MemberList.ContainsMemberId(targetMember.Id), TimeSpan.FromSeconds(10));
+        var committed = false;
+        var delta = new MemberStateDelta(targetMember.Id, true, new GossipState(), () => committed = true);
+        var request = new GossipRequest { MemberId = cluster.System.Id, State = delta.State };
+        var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var transport = new MockTransport((cb, _) =>
+        {
+            cb(Task.FromException<GossipResponse>(new TimeoutException())).ContinueWith(_ => done.SetResult());
+        });
+
+        var props = Props.FromFunc(ctx =>
+        {
+            GossipSender.Send(ctx, cluster, targetMember, delta, request, cluster.Config.GossipRequestTimeout, transport);
+            return Task.CompletedTask;
+        });
+
+        var pid = cluster.System.Root.Spawn(props);
+        cluster.System.Root.Send(pid, "go");
+
+        await done.Task;
+        Assert.False(committed);
+    }
+
+    [Fact]
+    public async Task DeadLetter_should_not_commit_offsets()
+    {
+        var fixture = new InMemoryClusterFixture();
+        await using var _ = fixture;
+        await fixture.InitializeAsync();
+        var cluster = fixture.Members[0];
+        var targetMember = fixture.Members[1].MemberList.Self;
+        await AwaitConditionAsync(() => cluster.MemberList.ContainsMemberId(targetMember.Id), TimeSpan.FromSeconds(10));
+        var committed = false;
+        var delta = new MemberStateDelta(targetMember.Id, true, new GossipState(), () => committed = true);
+        var request = new GossipRequest { MemberId = cluster.System.Id, State = delta.State };
+        var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var transport = new MockTransport((cb, _) =>
+        {
+            cb(Task.FromException<GossipResponse>(new DeadLetterException(PID.FromAddress("", "")))).ContinueWith(_ => done.SetResult());
+        });
+
+        var props = Props.FromFunc(ctx =>
+        {
+            GossipSender.Send(ctx, cluster, targetMember, delta, request, cluster.Config.GossipRequestTimeout, transport);
+            return Task.CompletedTask;
+        });
+
+        var pid = cluster.System.Root.Spawn(props);
+        cluster.System.Root.Send(pid, "go");
+
+        await done.Task;
+        Assert.False(committed);
+    }
+}


### PR DESCRIPTION
## Summary
- add `IGossipTransport` interface and default implementation
- centralize elapsed time and timeout handling in `GossipSender`
- inject transport into `GossipActor` and cover scenarios with tests

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj` *(fails: GossipCoreTests.Large_cluster_should_get_topology_consensus)*

------
https://chatgpt.com/codex/tasks/task_e_68a9844c3fb48328803db4a03eee95e1