### PR TITLE
feat(gossip): inject member and block list dependencies

### DIFF
--- a/logs/log1755949362.md
+++ b/logs/log1755949362.md
@@ -1,0 +1,5 @@
+- Introduced IMemberList and IBlockList interfaces to decouple GossipActor from concrete MemberList and BlockList implementations.
+- Modified GossipActor to receive these interfaces, improving testability and making member/block lookups explicit dependencies.
+- Updated GossipSender to operate on IMemberList, reducing reliance on full Cluster object.
+- Adjusted Gossiper to supply MemberList and BlockList when creating GossipActor, ensuring compatibility with new constructor.
+- Revised GossipTransport tests to accommodate new GossipSender signature.

--- a/src/Proto.Cluster/Gossip/GossipActor.cs
+++ b/src/Proto.Cluster/Gossip/GossipActor.cs
@@ -20,6 +20,8 @@ public class GossipActor : IActor
 #pragma warning restore CS0618 // Type or member is obsolete
     private readonly TimeSpan _gossipRequestTimeout;
     private readonly IGossip _internal;
+    private readonly IMemberList _memberList;
+    private readonly IBlockList _blockList;
     private readonly IGossipTransport _transport;
 
     // lookup from state key -> consensus checks
@@ -31,12 +33,16 @@ public class GossipActor : IActor
         int gossipFanout,
         int gossipMaxSend,
         IGossip gossip,
-        IGossipTransport transport
+        IGossipTransport transport,
+        IMemberList memberList,
+        IBlockList blockList
     )
     {
         _gossipRequestTimeout = gossipRequestTimeout;
         _internal = gossip;
         _transport = transport;
+        _memberList = memberList;
+        _blockList = blockList;
     }
 
     public async Task ReceiveAsync(IContext context)
@@ -121,7 +127,7 @@ public class GossipActor : IActor
         var logger = context.Logger()?.BeginScope<GossipActor>();
         logger?.LogDebug("Gossip Request {Sender}", context.Sender!);
         
-        if (context.Remote().BlockList.BlockedMembers.Contains(gossipRequest.MemberId))
+        if (_blockList.BlockedMembers.Contains(gossipRequest.MemberId))
         {
             Logger.LogInformation("Blocked gossip request from {MemberId}", gossipRequest.MemberId);
             context.Respond(new GossipResponse()
@@ -130,8 +136,7 @@ public class GossipActor : IActor
             });
             return Task.CompletedTask;
         }
-
-        if (!context.Cluster().MemberList.ContainsMemberId(gossipRequest.MemberId))
+        if (!_memberList.ContainsMemberId(gossipRequest.MemberId))
         {
             Logger.LogInformation("Ignoring gossip request from {MemberId} as it is not a member", gossipRequest.MemberId);
             context.Respond(new GossipResponse()
@@ -140,9 +145,6 @@ public class GossipActor : IActor
             });
             return Task.CompletedTask;
         }
-        
-        
-        
 
         if (Logger.IsEnabled(LogLevel.Debug))
         {
@@ -150,8 +152,6 @@ public class GossipActor : IActor
         }
         
         ReceiveState(context, gossipRequest.State);
-
-        
         if (context.Cluster().Config.GossipDebugLogging)
         {
             Logger.LogInformation("Responding to GossipRequest {Request} to {MemberId}", gossipRequest, gossipRequest.MemberId);
@@ -216,6 +216,6 @@ public class GossipActor : IActor
             Logger.LogInformation("Sending GossipRequest {Request} to {MemberId}", gossipRequest, targetMember.Id);
         }
 
-        GossipSender.Send(context, context.Cluster(), targetMember, memberStateDelta, gossipRequest, _gossipRequestTimeout, _transport);
+        GossipSender.Send(context, _memberList, targetMember, memberStateDelta, gossipRequest, _gossipRequestTimeout, _transport);
     }
 }

--- a/src/Proto.Cluster/Gossip/GossipSender.cs
+++ b/src/Proto.Cluster/Gossip/GossipSender.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Proto;
 using Proto.Logging;
+using Proto.Cluster;
 
 namespace Proto.Cluster.Gossip;
 
@@ -19,7 +20,7 @@ internal static class GossipSender
 
     public static void Send(
         IContext context,
-        Cluster cluster,
+        IMemberList memberList,
         Member targetMember,
         MemberStateDelta memberStateDelta,
         GossipRequest request,
@@ -36,9 +37,9 @@ internal static class GossipSender
             async task =>
             {
                 var delta = DateTime.UtcNow - start;
-                var self = cluster.MemberList.Self;
+                var self = memberList.Self;
 
-                if (!cluster.MemberList.TryGetMember(targetMember.Id, out _))
+                if (!memberList.TryGetMember(targetMember.Id, out _))
                 {
                     return;
                 }
@@ -72,7 +73,7 @@ internal static class GossipSender
                 }
                 catch (Exception x)
                 {
-                    if (cluster.MemberList.TryGetMember(targetMember.Id, out _))
+                    if (memberList.TryGetMember(targetMember.Id, out _))
                     {
                         Logger.LogError(
                             x,

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -204,7 +204,9 @@ public class Gossiper
             _cluster.Config.GossipFanout,
             _cluster.Config.GossipMaxSend,
             _gossip,
-            transport ?? new GossipTransport()));
+            transport ?? new GossipTransport(),
+            _cluster.MemberList,
+            _cluster.System.Remote().BlockList));
 
         _pid = _context.SpawnNamedSystem(props, GossipActorName);
         _cluster.System.EventStream.Subscribe<ClusterTopology>(topology =>

--- a/src/Proto.Cluster/Membership/IMemberList.cs
+++ b/src/Proto.Cluster/Membership/IMemberList.cs
@@ -1,0 +1,9 @@
+namespace Proto.Cluster;
+
+public interface IMemberList
+{
+    bool ContainsMemberId(string memberId);
+    bool TryGetMember(string memberId, out Member? value);
+    Member Self { get; }
+}
+

--- a/src/Proto.Cluster/Membership/MemberList.cs
+++ b/src/Proto.Cluster/Membership/MemberList.cs
@@ -27,7 +27,7 @@ namespace Proto.Cluster;
 ///     If the member learns that it is blocked from gossip, it will initiate shutdown.
 /// </summary>
 [PublicAPI]
-public record MemberList
+public record MemberList : IMemberList
 {
 #pragma warning disable CS0618 // Type or member is obsolete
     private static readonly ILogger Logger = Log.CreateLogger<MemberList>();

--- a/src/Proto.Remote/BlockList.cs
+++ b/src/Proto.Remote/BlockList.cs
@@ -18,7 +18,7 @@ public record MemberBlocked(string MemberId, string Reason);
 ///     unresponsiveness. Entries on this list expire after <see cref="ActorSystemConfig.BlockedMemberDuration"/>,
 ///     defaults to 1 hour.
 /// </summary>
-public class BlockList
+public class BlockList : IBlockList
 {
     private readonly object _lock = new();
     private readonly ActorSystem _system;

--- a/src/Proto.Remote/IBlockList.cs
+++ b/src/Proto.Remote/IBlockList.cs
@@ -1,0 +1,9 @@
+using System.Collections.Immutable;
+
+namespace Proto.Remote;
+
+public interface IBlockList
+{
+    ImmutableHashSet<string> BlockedMembers { get; }
+}
+

--- a/tests/Proto.Cluster.Tests/GossipTransportTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTransportTests.cs
@@ -54,7 +54,7 @@ public class GossipTransportTests
 
         var props = Props.FromFunc(ctx =>
         {
-            GossipSender.Send(ctx, cluster, targetMember, delta, request, cluster.Config.GossipRequestTimeout, transport);
+            GossipSender.Send(ctx, cluster.MemberList, targetMember, delta, request, cluster.Config.GossipRequestTimeout, transport);
             return Task.CompletedTask;
         });
 
@@ -87,7 +87,7 @@ public class GossipTransportTests
 
         var props = Props.FromFunc(ctx =>
         {
-            GossipSender.Send(ctx, cluster, targetMember, delta, request, cluster.Config.GossipRequestTimeout, transport);
+            GossipSender.Send(ctx, cluster.MemberList, targetMember, delta, request, cluster.Config.GossipRequestTimeout, transport);
             return Task.CompletedTask;
         });
 
@@ -119,7 +119,7 @@ public class GossipTransportTests
 
         var props = Props.FromFunc(ctx =>
         {
-            GossipSender.Send(ctx, cluster, targetMember, delta, request, cluster.Config.GossipRequestTimeout, transport);
+            GossipSender.Send(ctx, cluster.MemberList, targetMember, delta, request, cluster.Config.GossipRequestTimeout, transport);
             return Task.CompletedTask;
         });
 
@@ -151,7 +151,7 @@ public class GossipTransportTests
 
         var props = Props.FromFunc(ctx =>
         {
-            GossipSender.Send(ctx, cluster, targetMember, delta, request, cluster.Config.GossipRequestTimeout, transport);
+            GossipSender.Send(ctx, cluster.MemberList, targetMember, delta, request, cluster.Config.GossipRequestTimeout, transport);
             return Task.CompletedTask;
         });
 


### PR DESCRIPTION
## Summary
- define IMemberList and IBlockList interfaces
- inject MemberList and BlockList into GossipActor and GossipSender
- adjust Gossiper and tests for new gossip dependencies

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a9a719e2d4832891665a63291be06c