### PR TITLE
feat: inject gossip config

### DIFF
--- a/logs/log1755953264.md
+++ b/logs/log1755953264.md
@@ -1,0 +1,3 @@
+- abstracted ClusterConfig dependency out of GossipActor by injecting gossip debug logging flag instead of accessing Cluster extension
+- simplified GossipActor constructor accordingly and updated Gossiper to pass the flag
+- motivation: enables running gossip actors without requiring a full Cluster extension, improving testability and isolation

--- a/src/Proto.Cluster/Gossip/GossipActor.cs
+++ b/src/Proto.Cluster/Gossip/GossipActor.cs
@@ -23,19 +23,17 @@ public class GossipActor : IActor
     private readonly IMemberList _memberList;
     private readonly IBlockList _blockList;
     private readonly IGossipTransport _transport;
+    private readonly bool _gossipDebugLogging;
 
     // lookup from state key -> consensus checks
 
     public GossipActor(
-        ActorSystem system,
         TimeSpan gossipRequestTimeout,
-        InstanceLogger? instanceLogger,
-        int gossipFanout,
-        int gossipMaxSend,
         IGossip gossip,
         IGossipTransport transport,
         IMemberList memberList,
-        IBlockList blockList
+        IBlockList blockList,
+        bool gossipDebugLogging
     )
     {
         _gossipRequestTimeout = gossipRequestTimeout;
@@ -43,6 +41,7 @@ public class GossipActor : IActor
         _transport = transport;
         _memberList = memberList;
         _blockList = blockList;
+        _gossipDebugLogging = gossipDebugLogging;
     }
 
     public async Task ReceiveAsync(IContext context)
@@ -152,7 +151,7 @@ public class GossipActor : IActor
         }
         
         ReceiveState(context, gossipRequest.State);
-        if (context.Cluster().Config.GossipDebugLogging)
+        if (_gossipDebugLogging)
         {
             Logger.LogInformation("Responding to GossipRequest {Request} to {MemberId}", gossipRequest, gossipRequest.MemberId);
         }
@@ -210,7 +209,7 @@ public class GossipActor : IActor
             MemberId = context.System.Id,
             State = memberStateDelta.State.Clone(), //ensure we have a copy and not send state that might mutate
         };
-        if (context.Cluster().Config.GossipDebugLogging)
+        if (_gossipDebugLogging)
         {
             gossipRequest.RequestId = Guid.NewGuid().ToString("N");
             Logger.LogInformation("Sending GossipRequest {Request} to {MemberId}", gossipRequest, targetMember.Id);

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -198,15 +198,12 @@ public class Gossiper
             _cluster.Config.GossipDebugLogging);
 
         var props = Props.FromProducer(() => new GossipActor(
-            _cluster.System,
             _cluster.Config.GossipRequestTimeout,
-            _cluster.System.Logger(),
-            _cluster.Config.GossipFanout,
-            _cluster.Config.GossipMaxSend,
             _gossip,
             transport ?? new GossipTransport(),
             _cluster.MemberList,
-            _cluster.System.Remote().BlockList));
+            _cluster.System.Remote().BlockList,
+            _cluster.Config.GossipDebugLogging));
 
         _pid = _context.SpawnNamedSystem(props, GossipActorName);
         _cluster.System.EventStream.Subscribe<ClusterTopology>(topology =>


### PR DESCRIPTION
## Summary
- decouple GossipActor from Cluster by injecting gossip debug flag
- update Gossiper to supply flag

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a9b5811bd48328b715169d5218dc9b