### PR TITLE
Revert cluster request backoff changes

### DIFF
--- a/logs/log1755953311.md
+++ b/logs/log1755953311.md
@@ -1,0 +1,9 @@
+## Change Summary
+- Use request cancellation token for retry delays so cancellation stops waiting
+- Cap retry backoff to remaining request timeout to avoid exceeding configured timeout
+
+## Testing
+- `dotnet test tests/Proto.Actor.Tests`
+- `dotnet test tests/Proto.Remote.Tests`
+- `dotnet test tests/Proto.Cluster.Tests --filter FullyQualifiedName~RetryOnDeadLetterTests.ShouldRetryRequestOnDeadLetterResponseRegardlessOfResponseType`
+- `dotnet test tests/Proto.Cluster.Tests` *(failed to complete, run hung)*

--- a/logs/log1755953663.md
+++ b/logs/log1755953663.md
@@ -1,0 +1,8 @@
+## Summary
+- Reverted DefaultClusterContext.cs to state from commit 7fdf7dbb per user request
+- Installed missing .NET SDK and reran unit tests
+
+## Testing
+- `dotnet test tests/Proto.Actor.Tests`
+- `dotnet test tests/Proto.Remote.Tests`
+- `dotnet test tests/Proto.Cluster.Tests` *(hangs, cancelled)*


### PR DESCRIPTION
## Summary
- revert DefaultClusterContext.cs to previous implementation

## Testing
- `dotnet test tests/Proto.Actor.Tests`
- `dotnet test tests/Proto.Remote.Tests`
- `dotnet test tests/Proto.Cluster.Tests` *(hangs, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b4de76188328a7913dee7ac1e177