### PR TITLE
fix: initialize gossip after cluster services

### DIFF
--- a/logs/log1755969060.md
+++ b/logs/log1755969060.md
@@ -1,0 +1,8 @@
+# Log 1755969060
+
+## Summary
+- Reordered `StartMemberAsync` to call `BeginStartAsync` before `StartGossipActorAsync`, ensuring `MemberList` and `Remote` are initialized before gossip starts.
+- Added a clarifying comment documenting the dependency.
+
+## Motivation
+`StartGossipActorAsync` accessed `MemberList` and the remote block list before they were initialized, leading to intermittent null-reference failures during cluster startup and tests.

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -164,9 +164,9 @@ public class Cluster : IActorSystemExtension<Cluster>
     /// </summary>
     public async Task StartMemberAsync()
     {
+        await BeginStartAsync(false).ConfigureAwait(false); // ensure MemberList and Remote are initialized
         await Gossip.StartGossipActorAsync().ConfigureAwait(false);
-        await BeginStartAsync(false).ConfigureAwait(false);
-        //gossiper must be started whenever any topology events starts flowing
+        // gossiper must be started whenever any topology events starts flowing
         await Gossip.StartgossipLoopAsync().ConfigureAwait(false);
         MemberList.InitializeTopologyConsensus();
         await Provider.StartMemberAsync(this).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- ensure cluster member initialization runs before starting gossiper so member list and remote block list are available
- clarify gossiper dependency in `StartMemberAsync`

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -c Release`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj -c Release`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68a9cb51add083289896118015dfe45f