### PR TITLE
stabilize flakey tests

### DIFF
--- a/logs/exceptions.md
+++ b/logs/exceptions.md
@@ -6,3 +6,10 @@
 
 ### Proto.Cluster.Tests (Timeout)
 `System.TimeoutException: Request timed out` in `InMemoryPartitionActivatorClusterTests.HandlesSlowResponsesCorrectly`.
+### Proto.Mailbox.Tests.EscalateFailureTests.GivenNonCompletedUserMessageTaskGotCancelled_ShouldEscalateFailure
+`System.TimeoutException: The condition was not met within the timeout of 00:00:00.1000000` when waiting for mailbox failure escalation.
+
+### Proto.Tests.SupervisionTestsAllForOne.AllForOneStrategy_Should_PassExceptionOnRestart
+`System.InvalidOperationException: Collection was modified; enumeration operation may not execute.` during enumeration of mailbox statistics.
+### Proto.Tests.SupervisionTestsAllForOne.AllForOneStrategy_Should_PassExceptionOnRestart
+`System.InvalidOperationException: Collection was modified; enumeration operation may not execute.` during enumeration of mailbox statistics.

--- a/logs/log1755975410.md
+++ b/logs/log1755975410.md
@@ -1,0 +1,2 @@
+- Increased timeout in `GivenNonCompletedUserMessageTaskGotCancelled_ShouldEscalateFailure` to reduce flakiness when awaiting asynchronous cancellation.
+- Snapshotted mailbox statistics in `AllForOneStrategy_Should_PassExceptionOnRestart` to prevent concurrent collection modifications during assertions.

--- a/logs/log1755976135.md
+++ b/logs/log1755976135.md
@@ -1,0 +1,3 @@
+## Fix TestMailboxStats concurrency
+- replace mutable lists with immutable lists updated via `ImmutableInterlocked` for thread-safe mailbox statistics aggregation
+- remove ad-hoc snapshotting in supervision test; new concurrency support makes enumeration safe

--- a/logs/log1755977078.md
+++ b/logs/log1755977078.md
@@ -1,0 +1,3 @@
+# Log 1755977078
+- replace immutable mailbox stats lists with ConcurrentQueue for user-requested thread-safe recording
+- snapshot queues to arrays in properties to preserve IReadOnlyList API

--- a/src/Proto.TestKit/TestMailboxStats.cs
+++ b/src/Proto.TestKit/TestMailboxStats.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,22 +24,29 @@ public class TestMailboxStats : IMailboxStatistics
     }
 
     public ManualResetEventSlim Reset { get; } = new();
-    public List<object> Stats { get; } = new();
-    public List<object> Posted { get; } = new();
-    public List<object> Received { get; } = new();
 
-    public void MailboxStarted() => Stats.Add("Started");
+    // concurrent queues allow lock-free, thread-safe enumeration in tests
+    private readonly ConcurrentQueue<object> _stats = new();
+    private readonly ConcurrentQueue<object> _posted = new();
+    private readonly ConcurrentQueue<object> _received = new();
+
+    // snapshot queues as arrays to keep API compatible with IReadOnlyList
+    public IReadOnlyList<object> Stats => _stats.ToArray();
+    public IReadOnlyList<object> Posted => _posted.ToArray();
+    public IReadOnlyList<object> Received => _received.ToArray();
+
+    public void MailboxStarted() => _stats.Enqueue("Started");
 
     public void MessagePosted(object message)
     {
-        Stats.Add(message);
-        Posted.Add(message);
+        _stats.Enqueue(message);
+        _posted.Enqueue(message);
     }
 
     public void MessageReceived(object message)
     {
-        Stats.Add(message);
-        Received.Add(message);
+        _stats.Enqueue(message);
+        _received.Enqueue(message);
 
         if (_waitForReceived is not null && _waitForReceived(message))
         {
@@ -46,7 +54,7 @@ public class TestMailboxStats : IMailboxStatistics
         }
     }
 
-    public void MailboxEmpty() => Stats.Add("Empty");
+    public void MailboxEmpty() => _stats.Enqueue("Empty");
 
     /// <summary>
     /// Asynchronously waits until <see cref="Reset"/> is signaled or the <paramref name="timeout"/> elapses.

--- a/tests/Proto.Actor.Tests/Mailbox/EscalateFailureTests.cs
+++ b/tests/Proto.Actor.Tests/Mailbox/EscalateFailureTests.cs
@@ -143,8 +143,10 @@ public class EscalateFailureTests
 
         _ = Task.Run(() => msg1.TaskCompletionSource.SetCanceled());
 
-        await AwaitConditionAsync(() => mailboxHandler.EscalatedFailures.Count == 1,
-            TimeSpan.FromMilliseconds(100));
+        await AwaitConditionAsync(
+            () => mailboxHandler.EscalatedFailures.Count == 1,
+            // allow additional time for the asynchronous cancellation to propagate
+            TimeSpan.FromMilliseconds(500));
 
         Assert.Single(mailboxHandler.EscalatedFailures);
         Assert.IsType<TaskCanceledException>(mailboxHandler.EscalatedFailures[0]);

--- a/tests/Proto.Actor.Tests/Mailbox/MailboxStatisticsTests.cs
+++ b/tests/Proto.Actor.Tests/Mailbox/MailboxStatisticsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Proto.TestFixtures;
 using Proto.TestKit;

--- a/tests/Proto.Actor.Tests/SupervisionTests_AllForOne.cs
+++ b/tests/Proto.Actor.Tests/SupervisionTests_AllForOne.cs
@@ -128,6 +128,7 @@ public class SupervisionTestsAllForOne
 
         Assert.True(child1MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
         Assert.True(child2MailboxStats.Reset.Wait(TimeSpan.FromSeconds(5)));
+
         Assert.Contains(child1MailboxStats.Posted, msg => msg is Restart r && r.Reason == Exception);
         Assert.Contains(child1MailboxStats.Received, msg => msg is Restart r && r.Reason == Exception);
         Assert.Contains(child2MailboxStats.Posted, msg => msg is Restart r && r.Reason == Exception);


### PR DESCRIPTION
## Summary
- add thread-safe concurrent queues to TestMailboxStats for lock-free enumeration
- remove immutable collections while preserving IReadOnlyList API via queue snapshots

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68aa0e5863408328b0b5f76f0ade46a5