### PR TITLE
testkit: share gossip partition helper

### DIFF
--- a/logs/exceptions.md
+++ b/logs/exceptions.md
@@ -6,3 +6,6 @@
 
 ### Proto.Cluster.Tests (Timeout)
 `System.TimeoutException: Request timed out` in `InMemoryPartitionActivatorClusterTests.HandlesSlowResponsesCorrectly`.
+
+### Proto.Actor.Tests.EscalateFailureTests
+`System.TimeoutException: The condition was not met within the timeout of 00:00:00.1000000` in `Proto.Mailbox.Tests.EscalateFailureTests.GivenNonCompletedSystemMessageTaskThrewException_ShouldEscalateFailure`.

--- a/logs/log1755977337.md
+++ b/logs/log1755977337.md
@@ -1,0 +1,9 @@
+# Task Log
+
+## Summary
+- Added reusable `GossipNetworkPartition` middleware under `tests/Proto.TestKit`.
+- Refactored `PartitionConsensusTests` to consume the shared middleware.
+- Wired the helper into `Proto.Cluster.Tests` so future partition tests can reuse it.
+
+## Motivation
+Centralizing the gossip partition helper avoids duplication and makes partition scenarios easier to express in tests, improving maintainability and clarity.

--- a/logs/log1755978126.md
+++ b/logs/log1755978126.md
@@ -1,0 +1,8 @@
+## Summary
+- move GossipNetworkPartition helper into Proto.TestKit project
+- remove file link from Proto.Cluster.Tests project and reference Proto.Cluster from Proto.TestKit
+
+## Testing
+- `dotnet test --no-build tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
+- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
+- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`

--- a/src/Proto.TestKit/GossipNetworkPartition.cs
+++ b/src/Proto.TestKit/GossipNetworkPartition.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Immutable;
+using Proto;
+using Proto.Cluster.Gossip;
+
+namespace Proto.TestKit;
+
+// Middleware to simulate network partitions for gossip messages in tests
+public static class GossipNetworkPartition
+{
+    private static ImmutableHashSet<string> _isolated = ImmutableHashSet<string>.Empty;
+
+    // Prevent gossip between the given address and any other nodes
+    public static void Isolate(string address) => _isolated = _isolated.Add(address);
+
+    // Clear all simulated partitions
+    public static void Clear() => _isolated = ImmutableHashSet<string>.Empty;
+
+    // Middleware that drops gossip requests to or from isolated nodes
+    public static Func<Sender, Sender> Middleware => next => async (ctx, target, envelope) =>
+    {
+        if (envelope.Message is GossipRequest && target.Id == Gossiper.GossipActorName)
+        {
+            var from = ctx.System.Address;
+            var to = target.Address;
+
+            if (_isolated.Contains(from) || _isolated.Contains(to))
+            {
+                // message dropped due to simulated partition
+                return;
+            }
+        }
+
+        await next(ctx, target, envelope);
+    };
+}

--- a/src/Proto.TestKit/Proto.TestKit.csproj
+++ b/src/Proto.TestKit/Proto.TestKit.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Proto.Actor\Proto.Actor.csproj" />
+        <ProjectReference Include="..\Proto.Cluster\Proto.Cluster.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Proto.Cluster.Tests/PartitionConsensusTests.cs
+++ b/tests/Proto.Cluster.Tests/PartitionConsensusTests.cs
@@ -1,11 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using ClusterTest.Messages;
 using FluentAssertions;
 using Proto;
 using Proto.Cluster;
 using Proto.Cluster.Gossip;
+using Proto.TestKit;
 using Xunit;
 using static Proto.TestKit.TestKit;
 
@@ -86,29 +86,5 @@ public class PartitionConsensusTests
                 .WithConfigureProps(p => baseConfig.ConfigureProps(p).WithSenderMiddleware(GossipNetworkPartition.Middleware))
                 .WithConfigureSystemProps((name, p) => baseConfig.ConfigureSystemProps(name, p).WithSenderMiddleware(GossipNetworkPartition.Middleware));
         }
-    }
-
-    private static class GossipNetworkPartition
-    {
-        private static readonly HashSet<string> Dropped = new();
-
-        public static void Isolate(string address) => Dropped.Add(address);
-        public static void Clear() => Dropped.Clear();
-
-        public static Func<Sender, Sender> Middleware => next => async (ctx, target, envelope) =>
-        {
-            if (envelope.Message is GossipRequest && target.Id == Gossiper.GossipActorName)
-            {
-                var from = ctx.System.Address;
-                var to = target.Address;
-
-                if (Dropped.Contains(from) || Dropped.Contains(to))
-                {
-                    return;
-                }
-            }
-
-            await next(ctx, target, envelope);
-        };
     }
 }

--- a/tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj
+++ b/tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj
@@ -13,6 +13,7 @@
         <ProjectReference Include="..\..\src\Proto.Remote\Proto.Remote.csproj" />
         <ProjectReference Include="..\..\src\Proto.TestKit\Proto.TestKit.csproj" />
     </ItemGroup>
+
     <ItemGroup>
         <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
         <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />


### PR DESCRIPTION
## Summary
- add GossipNetworkPartition helper to test kit
- refactor PartitionConsensusTests to use shared helper
- remove manual file link and reference helper via Proto.TestKit project

## Testing
- `dotnet test --no-build tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68aa14ec8cc083289fbc6c856afe124b