### PR TITLE
Fix Gossip composite consensus test timing

### DIFF
--- a/logs/log1755980804.md
+++ b/logs/log1755980804.md
@@ -1,0 +1,5 @@
+## Fix flakiness in CompositeConsensusWorks
+- Removed skip from the test to re-enable it.
+- Eliminated arbitrary delays and used topology consensus to wait for cluster stability.
+- Added polling loop after spawning a member to ensure topology hash updates before asserting.
+- Confirmed reliability by running targeted test multiple times and entire test suites.

--- a/logs/log1756009491.md
+++ b/logs/log1756009491.md
@@ -1,0 +1,3 @@
+- Added ExpectUpdatedTopologyConsensus helper to Proto.TestKit to wait for topology changes without manual polling.
+- Updated composite gossip consensus test to use new helper instead of inline loop, improving readability and reducing timing flakiness.
+- Exposed Proto.Cluster internals to Proto.TestKit for access to topology consensus check.

--- a/logs/log1756009684.md
+++ b/logs/log1756009684.md
@@ -1,0 +1,5 @@
+## Summary
+- Simplified gossip tests by directly disposing fixtures with `await using` instead of unused `cleanup` variables
+
+## Motivation
+- Unused `cleanup` variables were redundant and flagged in review; using `await using` on the fixture itself clarifies intent and removes dead code

--- a/logs/log1756010588.md
+++ b/logs/log1756010588.md
@@ -1,0 +1,3 @@
+# Change Log
+- Added dedicated tests for `ExpectUpdatedTopologyConsensus` to verify completion on topology changes and timeout behavior
+- Removed redundant topology hash assertion from `GossipTests.CompositeConsensusWorks` to rely solely on the helper

--- a/src/Proto.Cluster/Properties/AssemblyInfo.cs
+++ b/src/Proto.Cluster/Properties/AssemblyInfo.cs
@@ -8,3 +8,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Proto.Cluster.Tests")]
 [assembly: InternalsVisibleTo("Proto.Premium")]
+[assembly: InternalsVisibleTo("Proto.TestKit")]

--- a/src/Proto.TestKit/ClusterTestKitExtensions.cs
+++ b/src/Proto.TestKit/ClusterTestKitExtensions.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading.Tasks;
+using Proto;
+using Proto.Cluster;
+
+namespace Proto.TestKit;
+
+/// <summary>
+/// Extension methods for cluster-related test helpers.
+/// </summary>
+public static class ClusterTestKitExtensions
+{
+    /// <summary>
+    /// Waits until the cluster's topology consensus hash changes.
+    /// </summary>
+    /// <param name="cluster">Cluster to monitor.</param>
+    /// <param name="timeout">Maximum time to wait for the update. Defaults to 20 seconds.</param>
+    /// <returns>The new topology hash once it differs from the initial hash.</returns>
+    public static async Task<ulong> ExpectUpdatedTopologyConsensus(this Proto.Cluster.Cluster cluster, TimeSpan? timeout = null)
+    {
+        var waitTimeout = timeout ?? TimeSpan.FromSeconds(20);
+        // Allow each consensus check up to five seconds to complete
+        var ct = CancellationTokens.FromSeconds(5);
+
+        // Capture the initial topology hash
+        (_, var initialTopologyHash) = await cluster.MemberList.TopologyConsensus(ct).ConfigureAwait(false);
+        ulong updatedTopologyHash = initialTopologyHash;
+
+        await TestKit.AwaitConditionAsync(async () =>
+        {
+            (_, updatedTopologyHash) = await cluster.MemberList.TopologyConsensus(ct).ConfigureAwait(false);
+            return updatedTopologyHash != initialTopologyHash;
+        }, waitTimeout, $"Topology hash did not change within {waitTimeout}");
+
+        return updatedTopologyHash;
+    }
+}
+

--- a/tests/Proto.Cluster.Tests/ExpectUpdatedTopologyConsensusTests.cs
+++ b/tests/Proto.Cluster.Tests/ExpectUpdatedTopologyConsensusTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Proto.TestKit;
+using Proto.Utils;
+using Xunit;
+
+namespace Proto.Cluster.Tests;
+
+public class ExpectUpdatedTopologyConsensusTests
+{
+    [Fact]
+    public async Task Completes_when_topology_changes()
+    {
+        await using var clusterFixture = new InMemoryClusterFixture();
+        await clusterFixture.InitializeAsync();
+
+        // Capture the initial topology hash
+        (_, var initialHash) = await clusterFixture.Members.First()
+            .MemberList.TopologyConsensus(CancellationTokens.FromSeconds(5));
+
+        var updateTask = clusterFixture.Members.First().ExpectUpdatedTopologyConsensus();
+
+        await clusterFixture.SpawnMember();
+
+        var newHash = await updateTask;
+
+        newHash.Should().NotBe(initialHash);
+    }
+
+    [Fact]
+    public async Task Throws_when_topology_does_not_change()
+    {
+        await using var clusterFixture = new InMemoryClusterFixture();
+        await clusterFixture.InitializeAsync();
+
+        var updateTask = clusterFixture.Members.First()
+            .ExpectUpdatedTopologyConsensus(TimeSpan.FromMilliseconds(200));
+
+        await Assert.ThrowsAsync<TimeoutException>(() => updateTask);
+    }
+}

--- a/tests/Proto.Cluster.Tests/GossipTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using ClusterTest.Messages;
 using FluentAssertions;
 using Proto.Cluster.Gossip;
+using Proto.TestKit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -81,21 +82,11 @@ public class GossipTests
 
         afterSettingMatchingState.value.Should().Be(initialTopologyHash);
 
+        var updatedTopology = clusterFixture.Members.First().ExpectUpdatedTopologyConsensus();
+
         await clusterFixture.SpawnMember();
 
-        // Wait until the new member is included in the topology consensus
-        var updatedTopologyHash = initialTopologyHash;
-        var waitUntil = DateTime.UtcNow + TimeSpan.FromSeconds(20);
-        while (updatedTopologyHash == initialTopologyHash && DateTime.UtcNow < waitUntil)
-        {
-            (_, updatedTopologyHash) = await clusterFixture.Members.First().MemberList.TopologyConsensus(timeout);
-            if (updatedTopologyHash == initialTopologyHash)
-            {
-                // Small delay to avoid tight polling while waiting for topology to update
-                await Task.Delay(100);
-            }
-        }
-
+        var updatedTopologyHash = await updatedTopology;
         updatedTopologyHash.Should().NotBe(initialTopologyHash);
 
         var afterChangingTopology =

--- a/tests/Proto.Cluster.Tests/GossipTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTests.cs
@@ -35,8 +35,7 @@ public class GossipTests
     [Fact]
     public async Task CanGetConsensus()
     {
-        var clusterFixture = new InMemoryClusterFixture();
-        await using var cleanup = clusterFixture;
+        await using var clusterFixture = new InMemoryClusterFixture();
         await clusterFixture.InitializeAsync();
 
         const string initialValue = "hello consensus";
@@ -55,8 +54,7 @@ public class GossipTests
     public async Task CompositeConsensusWorks()
     {
         var timeout = CancellationTokens.FromSeconds(20);
-        var clusterFixture = new InMemoryClusterFixture();
-        await using var cleanup = clusterFixture;
+        await using var clusterFixture = new InMemoryClusterFixture();
         await clusterFixture.InitializeAsync();
 
         // Wait for the cluster to reach topology consensus before performing checks
@@ -99,8 +97,7 @@ public class GossipTests
     [Fact]
     public async Task CanFallOutOfConsensus()
     {
-        var clusterFixture = new InMemoryClusterFixture();
-        await using var _ = clusterFixture;
+        await using var clusterFixture = new InMemoryClusterFixture();
         await clusterFixture.InitializeAsync();
 
         const string initialValue = "hello consensus";
@@ -149,8 +146,7 @@ public class GossipTests
         const int maxSend = 2;
         const int keysPerMember = 5;
 
-        var clusterFixture = new GossipClusterFixture(memberCount, fanout, maxSend);
-        await using var _ = clusterFixture;
+        await using var clusterFixture = new GossipClusterFixture(memberCount, fanout, maxSend);
         await clusterFixture.InitializeAsync();
 
         var expected = clusterFixture.Members.ToDictionary(

--- a/tests/Proto.Cluster.Tests/GossipTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTests.cs
@@ -84,8 +84,7 @@ public class GossipTests
 
         await clusterFixture.SpawnMember();
 
-        var updatedTopologyHash = await updatedTopology;
-        updatedTopologyHash.Should().NotBe(initialTopologyHash);
+        await updatedTopology;
 
         var afterChangingTopology =
             await firstNodeCheck.TryGetConsensus(TimeSpan.FromMilliseconds(500), timeout);

--- a/tests/Proto.Cluster.Tests/GossipTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTests.cs
@@ -35,7 +35,7 @@ public class GossipTests
     public async Task CanGetConsensus()
     {
         var clusterFixture = new InMemoryClusterFixture();
-        await using var _ = clusterFixture;
+        await using var cleanup = clusterFixture;
         await clusterFixture.InitializeAsync();
 
         const string initialValue = "hello consensus";
@@ -50,17 +50,15 @@ public class GossipTests
 
     }
 
-    [Fact(Skip = "Flaky")]
+    [Fact]
     public async Task CompositeConsensusWorks()
     {
         var timeout = CancellationTokens.FromSeconds(20);
         var clusterFixture = new InMemoryClusterFixture();
-        await using var _ = clusterFixture;
+        await using var cleanup = clusterFixture;
         await clusterFixture.InitializeAsync();
 
-        // Allow cluster to settle before verifying consensus
-        await Task.Delay(1000);
-
+        // Wait for the cluster to reach topology consensus before performing checks
         var (consensus, initialTopologyHash) =
             await clusterFixture.Members.First().MemberList.TopologyConsensus(timeout);
 
@@ -84,7 +82,21 @@ public class GossipTests
         afterSettingMatchingState.value.Should().Be(initialTopologyHash);
 
         await clusterFixture.SpawnMember();
-        await Task.Delay(2000); // Allow topology state to propagate
+
+        // Wait until the new member is included in the topology consensus
+        var updatedTopologyHash = initialTopologyHash;
+        var waitUntil = DateTime.UtcNow + TimeSpan.FromSeconds(20);
+        while (updatedTopologyHash == initialTopologyHash && DateTime.UtcNow < waitUntil)
+        {
+            (_, updatedTopologyHash) = await clusterFixture.Members.First().MemberList.TopologyConsensus(timeout);
+            if (updatedTopologyHash == initialTopologyHash)
+            {
+                // Small delay to avoid tight polling while waiting for topology to update
+                await Task.Delay(100);
+            }
+        }
+
+        updatedTopologyHash.Should().NotBe(initialTopologyHash);
 
         var afterChangingTopology =
             await firstNodeCheck.TryGetConsensus(TimeSpan.FromMilliseconds(500), timeout);


### PR DESCRIPTION
## Summary
- Re-enable composite gossip consensus test
- Wait for topology consensus instead of fixed delays

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -c Release`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj -c Release`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68aa21e9272c8328910ae288e90f4205