### PR TITLE
testkit: add ExpectMemberToExist helper

### DIFF
--- a/logs/log1756012262.md
+++ b/logs/log1756012262.md
@@ -1,0 +1,1 @@
+- Updated GossipTransportTests to await topology consensus using ExpectUpdatedTopologyConsensus, removing manual polling via AwaitConditionAsync. This ensures tests wait for deterministic membership updates before sending gossip.

--- a/logs/log1756013526.md
+++ b/logs/log1756013526.md
@@ -1,0 +1,2 @@
+- Added ExpectMemberToExist helper in Proto.TestKit for clearer cluster membership checks.
+- Updated GossipTransportTests to use ExpectMemberToExist instead of manual AwaitConditionAsync calls.

--- a/src/Proto.TestKit/ClusterTestKitExtensions.cs
+++ b/src/Proto.TestKit/ClusterTestKitExtensions.cs
@@ -34,5 +34,21 @@ public static class ClusterTestKitExtensions
 
         return updatedTopologyHash;
     }
+
+    /// <summary>
+    /// Waits until the cluster's member list contains the specified <paramref name="member"/>.
+    /// </summary>
+    /// <param name="cluster">Cluster to inspect.</param>
+    /// <param name="member">Member expected to exist in the cluster.</param>
+    /// <param name="timeout">Maximum time to wait. Defaults to 10 seconds.</param>
+    /// <returns>A task that completes when the member is present.</returns>
+    public static Task ExpectMemberToExist(this Proto.Cluster.Cluster cluster, Member member, TimeSpan? timeout = null)
+    {
+        var waitTimeout = timeout ?? TimeSpan.FromSeconds(10);
+        return TestKit.AwaitConditionAsync(
+            () => cluster.MemberList.ContainsMemberId(member.Id),
+            waitTimeout,
+            $"Member {member.Id} was not found within {waitTimeout}");
+    }
 }
 

--- a/tests/Proto.Cluster.Tests/GossipTransportTests.cs
+++ b/tests/Proto.Cluster.Tests/GossipTransportTests.cs
@@ -10,8 +10,8 @@ using System.Threading.Tasks;
 using Proto;
 using Proto.Cluster;
 using Proto.Cluster.Gossip;
+using Proto.TestKit;
 using Xunit;
-using static Proto.TestKit.TestKit;
 
 namespace Proto.Cluster.Tests;
 
@@ -41,7 +41,8 @@ public class GossipTransportTests
         await fixture.InitializeAsync();
         var cluster = fixture.Members[0];
         var targetMember = fixture.Members[1].MemberList.Self;
-        await AwaitConditionAsync(() => cluster.MemberList.ContainsMemberId(targetMember.Id), TimeSpan.FromSeconds(10));
+        // Wait for the cluster to register the other member before proceeding
+        await cluster.ExpectMemberToExist(targetMember);
         var committed = false;
         var delta = new MemberStateDelta(targetMember.Id, true, new GossipState(), () => committed = true);
         var request = new GossipRequest { MemberId = cluster.System.Id, State = delta.State };
@@ -73,7 +74,8 @@ public class GossipTransportTests
         await fixture.InitializeAsync();
         var cluster = fixture.Members[0];
         var targetMember = fixture.Members[1].MemberList.Self;
-        await AwaitConditionAsync(() => cluster.MemberList.ContainsMemberId(targetMember.Id), TimeSpan.FromSeconds(10));
+        // Wait for the cluster to register the other member before proceeding
+        await cluster.ExpectMemberToExist(targetMember);
         var committed = false;
         var delta = new MemberStateDelta(targetMember.Id, true, new GossipState(), () => committed = true);
         var request = new GossipRequest { MemberId = cluster.System.Id, State = delta.State };
@@ -106,7 +108,8 @@ public class GossipTransportTests
         await fixture.InitializeAsync();
         var cluster = fixture.Members[0];
         var targetMember = fixture.Members[1].MemberList.Self;
-        await AwaitConditionAsync(() => cluster.MemberList.ContainsMemberId(targetMember.Id), TimeSpan.FromSeconds(10));
+        // Wait for the cluster to register the other member before proceeding
+        await cluster.ExpectMemberToExist(targetMember);
         var committed = false;
         var delta = new MemberStateDelta(targetMember.Id, true, new GossipState(), () => committed = true);
         var request = new GossipRequest { MemberId = cluster.System.Id, State = delta.State };
@@ -138,7 +141,8 @@ public class GossipTransportTests
         await fixture.InitializeAsync();
         var cluster = fixture.Members[0];
         var targetMember = fixture.Members[1].MemberList.Self;
-        await AwaitConditionAsync(() => cluster.MemberList.ContainsMemberId(targetMember.Id), TimeSpan.FromSeconds(10));
+        // Wait for the cluster to register the other member before proceeding
+        await cluster.ExpectMemberToExist(targetMember);
         var committed = false;
         var delta = new MemberStateDelta(targetMember.Id, true, new GossipState(), () => committed = true);
         var request = new GossipRequest { MemberId = cluster.System.Id, State = delta.State };


### PR DESCRIPTION
## Summary
- introduce ExpectMemberToExist helper in Proto.TestKit for membership checks
- use ExpectMemberToExist in GossipTransportTests

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68aa9d72fdfc8328b05971dd865056d4