### PR TITLE
docs: document gossip architecture and testkit

### DIFF
--- a/CLUSTER_MEMBERSHIP_GOSSIP.md
+++ b/CLUSTER_MEMBERSHIP_GOSSIP.md
@@ -5,6 +5,34 @@ membership state is propagated through gossip.
 
 For a runnable demonstration, see [examples/ClusterGossip](examples/ClusterGossip).
 
+## Architecture
+
+The gossip subsystem is separated from the rest of the cluster code and
+communicates through a small set of types. The main participants are shown
+below:
+
+```mermaid
+flowchart LR
+    Provider["Cluster Provider"] --> MemberList
+    MemberList -->|topology updates| Gossiper
+    Gossiper --> GossipActor
+    GossipActor -->|build deltas| DeltaBuilder
+    DeltaBuilder --> GossipSender
+    GossipSender -->|IGossipTransport| RemoteGossipActor["Remote GossipActor"]
+```
+
+* **Gossiper** – orchestrates the gossip loop and owns a `Gossip` instance
+  that holds the replicated state.
+* **GossipActor** – receives commands from the `Gossiper` and merges incoming
+  state from other members.
+* **GossipSender** – sends built deltas to remote nodes using an
+  `IGossipTransport` implementation.
+* **MemberStateDeltaBuilder** – determines which portions of the gossip state
+  should be sent to a specific target.
+* **IGossipTransport** – abstraction over the mechanics of sending a
+  `GossipRequest`; the default `GossipTransport` simply forwards the request
+  through `IContext.RequestReenter`.
+
 ## Detecting members
 
 Cluster providers (e.g., Kubernetes) watch the environment for running nodes and
@@ -29,6 +57,16 @@ The gossip loop periodically updates heartbeat information and sends the current
 state to randomly chosen peers ([Gossiper.cs](src/Proto.Cluster/Gossip/Gossiper.cs#L232-L241), [Gossip.cs](src/Proto.Cluster/Gossip/Gossip.cs#L168-L205)).
 Peers merge received updates, which allows membership changes to spread
 throughout the cluster.
+
+## Gossip transport
+
+`GossipSender` performs the send using an `IGossipTransport` implementation.
+The default `GossipTransport` issues a `GossipRequest` via
+`IContext.RequestReenter`, invoking a continuation when a `GossipResponse`
+arrives ([IGossipTransport.cs](src/Proto.Cluster/Gossip/IGossipTransport.cs#L14-L46),
+[GossipSender.cs](src/Proto.Cluster/Gossip/GossipSender.cs#L21-L87)).
+Custom transports can wrap this interface to add metrics, retries, or other
+behaviour without modifying cluster code.
 
 ## Delta-based member state propagation
 
@@ -59,6 +97,28 @@ If no sequence numbers exceed the watermark, the member is omitted from the
 delta and its watermark remains unchanged. This prevents redundant transmissions
 but means updates may be delayed when the `gossipMaxSend` limit is hit.
 
+```mermaid
+flowchart LR
+    CurrentState --> Builder
+    Builder -->|per member| Watermark{seq > watermark?}
+    Watermark -- yes --> Delta[append to delta]
+    Watermark -- no --> Skip[skip]
+    Delta --> Commit[update offset]
+```
+
+The builder returns a `MemberStateDelta` record containing the new state and a
+callback to commit offsets once the remote peer acknowledges receipt
+([MemberStateDeltaBuilder.cs](src/Proto.Cluster/Gossip/MemberStateDeltaBuilder.cs#L19-L84),
+[MemberStateDelta.cs](src/Proto.Cluster/Gossip/MemberStateDelta.cs#L11)).
+
+## Isolation from the cluster
+
+Gossip logic can now run without direct dependencies on cluster internals.
+`Gossiper` wires the pieces together through `GossiperOptions`, supplying the
+member list, block list, event stream and timing settings. This separation
+allows testing and alternative transports by substituting implementations such
+as `IGossipTransport` ([Gossiper.cs](src/Proto.Cluster/Gossip/Gossiper.cs#L47-L95)).
+
 ## Member states
 
 - **Joined / Left** – Calculated by `MemberList.UpdateClusterTopology` and
@@ -68,9 +128,16 @@ but means updates may be delayed when the `gossipMaxSend` limit is hit.
 provider ([Cluster.cs](src/Proto.Cluster/Cluster.cs#L286-L299)). Other nodes read this key and
 block those members ([Gossiper.cs](src/Proto.Cluster/Gossip/Gossiper.cs#L262-L277)).
 - **Blocked** – Members are blocked when they leave or when their heartbeat
-expires. Heartbeat data is stored under `cluster:heartbeat`, and expired
-entries cause nodes to be added to the block list ([Gossiper.cs](src/Proto.Cluster/Gossip/Gossiper.cs#L281-L310)).
+  expires. Heartbeat data is stored under `cluster:heartbeat`, and expired
+  entries cause nodes to be added to the block list ([Gossiper.cs](src/Proto.Cluster/Gossip/Gossiper.cs#L281-L310)).
 
 The combination of provider detection, event publication, and gossip
 propagation ensures that membership changes reach all cluster nodes without
 cluster-wide broadcasts.
+
+## TestKit extensions
+
+`Proto.TestKit` provides `GossipNetworkPartition`, a sender middleware that
+drops `GossipRequest` messages to or from isolated addresses. Tests use it to
+simulate partitions and verify that gossip resumes once connectivity is
+restored ([GossipNetworkPartition.cs](src/Proto.TestKit/GossipNetworkPartition.cs#L8-L35)).

--- a/logs/exceptions.md
+++ b/logs/exceptions.md
@@ -15,3 +15,5 @@
 
 ### Proto.Tests.SupervisionTestsAllForOne.AllForOneStrategy_Should_PassExceptionOnRestart
 `System.InvalidOperationException: Collection was modified; enumeration operation may not execute.` during enumeration of mailbox statistics.
+### Proto.Cluster.Tests.GossipCoreTests.Large_cluster_should_get_topology_consensus
+`Test failure: output indicated [FAIL] but passed on rerun; no stack trace captured.`

--- a/logs/log1756014903.md
+++ b/logs/log1756014903.md
@@ -1,0 +1,5 @@
+## Documentation update
+- Documented new gossip architecture, transport abstraction, delta builder, and isolation from cluster.
+- Added notes on testkit middleware for partition simulation.
+- Scanned gossip code and existing log files to gather context.
+- Motivation: clarify new gossip design and help contributors understand interactions.


### PR DESCRIPTION
## Summary
- document gossip architecture, transport, delta builder, and cluster isolation
- note testkit middleware for gossip network partition

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -v q`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj -v q`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj -v q` *(failed: GossipCoreTests.Large_cluster_should_get_topology_consensus)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa8853c688328b45806e077b741d4