### PR TITLE
docs: clarify gossip type relationships

### DIFF
--- a/CLUSTER_MEMBERSHIP_GOSSIP.md
+++ b/CLUSTER_MEMBERSHIP_GOSSIP.md
@@ -40,18 +40,26 @@ classDiagram
     class Gossiper
     class GossipActor
     class Gossip
+    class GossipState
     class MemberStateDeltaBuilder
     class GossipSender
+    class GossipRequest
+    class GossipResponse
     class IGossipTransport
     class GossipTransport
     Gossiper o-- Gossip
     Gossiper --> GossipActor : commands
     Gossiper --> GossipSender : uses
     GossipActor --> Gossip : merges
+    Gossip --> GossipState : holds
     Gossip --> MemberStateDeltaBuilder : uses
+    GossipSender ..> GossipRequest : sends
+    GossipSender ..> GossipResponse : receives
     GossipSender ..> IGossipTransport
     IGossipTransport <|-- GossipTransport
 ```
+
+`Gossip` maintains a `GossipState` and exchanges `GossipRequest` and `GossipResponse` messages via `IGossipTransport` to synchronize that state across nodes.
 
 ## Detecting members
 

--- a/logs/log1756021716.md
+++ b/logs/log1756021716.md
@@ -1,0 +1,6 @@
+# Update Type Relationships in Gossip Documentation
+
+- Added `GossipState`, `GossipRequest`, and `GossipResponse` to the type relationship diagram to clarify how gossip state is maintained and exchanged.
+- Installed .NET 8 SDK to satisfy repository requirements and run tests.
+
+Motivation: The `Type relationships` section omitted core message and state types, which confused the mapping between the code and documentation. Including them helps contributors and users understand how gossip messages carry state across nodes.


### PR DESCRIPTION
## Summary
- document GossipState, GossipRequest, and GossipResponse in cluster membership gossip type diagram
- log reasoning for doc addition

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -c Release --no-restore --no-build`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj -c Release`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj -c Release` *(failed: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68aac37c2e5083288506407623b783c6