### PR TITLE
Refactor MemberList into managers

### DIFF
--- a/logs/log1756064359.md
+++ b/logs/log1756064359.md
@@ -1,0 +1,5 @@
+- Refactored MemberList by introducing dedicated managers:
+  - Added ConsensusManager to encapsulate topology consensus operations.
+  - Added MemberStrategyManager to maintain per-kind member strategies and activator lookups.
+  - Simplified MemberList to delegate consensus and strategy responsibilities, reducing coupling and clarifying responsibilities.
+- All core tests (Proto.Actor, Proto.Remote, Proto.Cluster) executed successfully after the refactor.

--- a/src/Proto.Cluster/Membership/ConsensusManager.cs
+++ b/src/Proto.Cluster/Membership/ConsensusManager.cs
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------
+// <copyright file="ConsensusManager.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using Proto.Cluster.Gossip;
+
+namespace Proto.Cluster;
+
+/// <summary>
+///     Encapsulates topology consensus handling for a <see cref="MemberList" />.
+///     Moving this logic out of <see cref="MemberList" /> keeps the type focused on membership bookkeeping.
+/// </summary>
+internal class ConsensusManager
+{
+    private readonly Cluster _cluster;
+    private IConsensusHandle<ulong>? _topologyConsensus;
+
+    internal ConsensusManager(Cluster cluster) => _cluster = cluster;
+
+    /// <summary>
+    ///     Initializes the topology consensus check used to ensure all members agree on the current cluster topology.
+    /// </summary>
+    internal void InitializeTopologyConsensus() =>
+        _topologyConsensus =
+            _cluster.Gossip.RegisterConsensusCheck<ClusterTopology, ulong>(GossipKeys.Topology,
+                topology => topology.TopologyHash);
+
+    /// <summary>
+    ///     Attempts to retrieve the current consensus state for the cluster topology.
+    /// </summary>
+    /// <param name="ct">Cancellation token controlling how long to wait for consensus.</param>
+    internal Task<(bool consensus, ulong topologyHash)> TopologyConsensus(CancellationToken ct) =>
+        _topologyConsensus?.TryGetConsensus(ct) ??
+        Task.FromResult<(bool consensus, ulong topologyHash)>(default);
+}
+

--- a/src/Proto.Cluster/Membership/MemberList.cs
+++ b/src/Proto.Cluster/Membership/MemberList.cs
@@ -51,15 +51,13 @@ public record MemberList : IMemberList
 
     private ImmutableDictionary<int, Member> _membersByIndex = ImmutableDictionary<int, Member>.Empty;
 
-    private ImmutableDictionary<string, IMemberStrategy> _memberStrategyByKind =
-        ImmutableDictionary<string, IMemberStrategy>.Empty;
-
     private ImmutableDictionary<string, MetaMember> _metaMembers = ImmutableDictionary<string, MetaMember>.Empty;
 
     private int _nextMemberIndex;
 
     private TaskCompletionSource<bool> _startedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private IConsensusHandle<ulong>? _topologyConsensus;
+    private readonly ConsensusManager _consensusManager;
+    private readonly MemberStrategyManager _memberStrategyManager;
     private readonly bool _isClient;
 
     public bool IsClient => _isClient;
@@ -80,6 +78,8 @@ public record MemberList : IMemberList
             Kinds = { _cluster.GetClusterKinds() }
         };
 
+        _consensusManager = new ConsensusManager(cluster);
+        _memberStrategyManager = new MemberStrategyManager(cluster);
         _eventStream = _system.EventStream;
 
         //subscribe non synchronous to avoid recursive updates
@@ -132,27 +132,13 @@ public record MemberList : IMemberList
     /// <returns></returns>
     public ImmutableHashSet<string> GetMembers() => _activeMembers.Members.Select(m => m.Id).ToImmutableHashSet();
 
-    internal void InitializeTopologyConsensus() =>
-        _topologyConsensus =
-            _cluster.Gossip.RegisterConsensusCheck<ClusterTopology, ulong>(GossipKeys.Topology,
-                topology => topology.TopologyHash);
+    internal void InitializeTopologyConsensus() => _consensusManager.InitializeTopologyConsensus();
 
     internal Task<(bool consensus, ulong topologyHash)> TopologyConsensus(CancellationToken ct) =>
-        _topologyConsensus?.TryGetConsensus(ct) ??
-        Task.FromResult<(bool consensus, ulong topologyHash)>(default);
+        _consensusManager.TopologyConsensus(ct);
 
-    internal Member? GetActivator(string kind, string requestSourceAddress)
-    {
-        //immutable, don't lock
-        if (_memberStrategyByKind.TryGetValue(kind, out var memberStrategy))
-        {
-            return memberStrategy.GetActivator(requestSourceAddress);
-        }
-
-        Logger.DidNotFindActivatorForKind(kind);
-
-        return null;
-    }
+    internal Member? GetActivator(string kind, string requestSourceAddress) =>
+        _memberStrategyManager.GetActivator(kind, requestSourceAddress);
 
     /// <summary>
     ///     Used by clustering providers to update the member list.
@@ -210,20 +196,7 @@ public record MemberList : IMemberList
 
     private void HandleMemberLeave(Member memberThatLeft)
     {
-        foreach (var k in memberThatLeft.Kinds)
-        {
-            if (!_memberStrategyByKind.TryGetValue(k, out var ms))
-            {
-                continue;
-            }
-
-            ms.RemoveMember(memberThatLeft);
-
-            if (ms.GetAllMembers().Count == 0)
-            {
-                _memberStrategyByKind = _memberStrategyByKind.Remove(k);
-            }
-        }
+        _memberStrategyManager.RemoveMember(memberThatLeft);
 
         if (_metaMembers.TryGetValue(memberThatLeft.Id, out var meta))
         {
@@ -253,15 +226,7 @@ public record MemberList : IMemberList
             _membersByIndex = _membersByIndex.SetItem(index, newMember);
             _indexByAddress = _indexByAddress.SetItem(newMember.Address, index);
 
-            foreach (var kind in newMember.Kinds)
-            {
-                if (!_memberStrategyByKind.ContainsKey(kind))
-                {
-                    _memberStrategyByKind = _memberStrategyByKind.SetItem(kind, GetMemberStrategyByKind(kind));
-                }
-
-                _memberStrategyByKind[kind].AddMember(newMember);
-            }
+            _memberStrategyManager.AddMember(newMember);
         }
         catch (Exception x)
         {
@@ -335,22 +300,6 @@ public record MemberList : IMemberList
         }
 
         _cluster.System.EventStream.Publish(endpointTerminated);
-    }
-
-    private IMemberStrategy GetMemberStrategyByKind(string kind)
-    {
-        //Try get the cluster kind
-        var clusterKind = _cluster.TryGetClusterKind(kind);
-
-        //if it exists, and if it has a strategy
-        if (clusterKind?.Strategy != null)
-        {
-            //use that strategy
-            return clusterKind.Strategy;
-        }
-
-        //otherwise, use whatever member strategy the default builder says
-        return _cluster.Config.MemberStrategyBuilder(_cluster, kind) ?? new SimpleMemberStrategy();
     }
 
     /// <summary>

--- a/src/Proto.Cluster/Membership/MemberStrategyManager.cs
+++ b/src/Proto.Cluster/Membership/MemberStrategyManager.cs
@@ -1,0 +1,81 @@
+// -----------------------------------------------------------------------
+// <copyright file="MemberStrategyManager.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
+using Proto.Logging;
+
+namespace Proto.Cluster;
+
+/// <summary>
+///     Maintains <see cref="IMemberStrategy" /> instances for each cluster kind and provides activator lookup.
+///     Extracted from <see cref="MemberList" /> to keep membership concerns separated from activation strategy logic.
+/// </summary>
+internal class MemberStrategyManager
+{
+    private static readonly ILogger Logger = Log.CreateLogger<MemberStrategyManager>();
+    private readonly Cluster _cluster;
+    private ImmutableDictionary<string, IMemberStrategy> _memberStrategyByKind =
+        ImmutableDictionary<string, IMemberStrategy>.Empty;
+
+    internal MemberStrategyManager(Cluster cluster) => _cluster = cluster;
+
+    internal Member? GetActivator(string kind, string requestSourceAddress)
+    {
+        if (_memberStrategyByKind.TryGetValue(kind, out var memberStrategy))
+        {
+            return memberStrategy.GetActivator(requestSourceAddress);
+        }
+
+        Logger.DidNotFindActivatorForKind(kind);
+
+        return null;
+    }
+
+    internal void AddMember(Member newMember)
+    {
+        foreach (var kind in newMember.Kinds)
+        {
+            if (!_memberStrategyByKind.ContainsKey(kind))
+            {
+                _memberStrategyByKind = _memberStrategyByKind.SetItem(kind, GetMemberStrategyByKind(kind));
+            }
+
+            _memberStrategyByKind[kind].AddMember(newMember);
+        }
+    }
+
+    internal void RemoveMember(Member member)
+    {
+        foreach (var k in member.Kinds)
+        {
+            if (!_memberStrategyByKind.TryGetValue(k, out var ms))
+            {
+                continue;
+            }
+
+            ms.RemoveMember(member);
+
+            if (ms.GetAllMembers().Count == 0)
+            {
+                _memberStrategyByKind = _memberStrategyByKind.Remove(k);
+            }
+        }
+    }
+
+    private IMemberStrategy GetMemberStrategyByKind(string kind)
+    {
+        var clusterKind = _cluster.TryGetClusterKind(kind);
+
+        if (clusterKind?.Strategy != null)
+        {
+            return clusterKind.Strategy;
+        }
+
+        return _cluster.Config.MemberStrategyBuilder(_cluster, kind) ?? new SimpleMemberStrategy();
+    }
+}
+


### PR DESCRIPTION
## Summary
- Extract consensus handling into new `ConsensusManager`
- Move member strategy responsibilities into `MemberStrategyManager`
- Delegate from `MemberList` to the new managers for clearer separation of concerns

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ab68d569d88328b9808b32981bafdb