### PR TITLE
refactor consensus logging helper in gossiper

### DIFF
--- a/logs/log1756071034.md
+++ b/logs/log1756071034.md
@@ -1,0 +1,4 @@
+## Log
+- Created `LogConsensus` helper inside `ConsensusCheckBuilder.Build` to consolidate debug logging for consensus evaluations.
+- Replaced duplicated `Logger.LogDebug` blocks in single-key and multi-key branches with calls to the helper, reducing repetition and improving maintainability.
+- Verified .NET 8 installation and ran core test suites (`Proto.Actor.Tests`, `Proto.Remote.Tests`, `Proto.Cluster.Tests`) to ensure no regressions.

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -391,6 +391,18 @@ public partial class Gossiper
 
         private ConsensusCheck<T> Build()
         {
+            // Logs consensus outcome together with the members contributing to each key/value pair.
+            static void LogConsensus(bool consensus, IEnumerable<(string member, string key, T value)> tuples)
+            {
+                Logger.LogDebug("consensus {Consensus}: {Values}", consensus, tuples
+                    .GroupBy(it => (it.key, it.value), tuple => tuple.member)
+                    .Select(
+                        grouping => $"{grouping.Key.key}:{grouping.Key.value}, " +
+                                    (grouping.Count() > 1 ? grouping.Count() + " nodes" : grouping.First())
+                    ).ToArray()
+                );
+            }
+
             if (_getConsensusValues.Count == 1)
             {
                 var mapToValue = MapToValue(_getConsensusValues.Single());
@@ -401,13 +413,7 @@ public partial class Gossiper
 
                     if (Logger.IsEnabled(LogLevel.Debug))
                     {
-                        Logger.LogDebug("consensus {Consensus}: {Values}", consensus, tuples
-                            .GroupBy(it => (it.key, it.value), tuple => tuple.member)
-                            .Select(
-                                grouping => $"{grouping.Key.key}:{grouping.Key.value}, " +
-                                            (grouping.Count() > 1 ? grouping.Count() + " nodes" : grouping.First())
-                            ).ToArray()
-                        );
+                        LogConsensus(consensus, tuples);
                     }
 
                     return consensus ? (consensus, value!) : default;
@@ -422,13 +428,7 @@ public partial class Gossiper
 
                 if (Logger.IsEnabled(LogLevel.Debug))
                 {
-                    Logger.LogDebug("consensus {Consensus}: {Values}", consensus, tuples
-                        .GroupBy(it => (it.key, it.value), tuple => tuple.member)
-                        .Select(
-                            grouping => $"{grouping.Key.key}:{grouping.Key.value}, " +
-                                        (grouping.Count() > 1 ? grouping.Count() + " nodes" : grouping.First())
-                        ).ToArray()
-                    );
+                    LogConsensus(consensus, tuples);
                 }
 
                 return consensus ? (consensus, value!) : default;


### PR DESCRIPTION
## Summary
- centralize gossip consensus debug logging into `LogConsensus`
- replace repeated log blocks in single and multi-key branches

## Testing
- `dotnet test tests/Proto.Actor.Tests`
- `dotnet test tests/Proto.Remote.Tests`
- `dotnet test tests/Proto.Cluster.Tests`


------
https://chatgpt.com/codex/tasks/task_e_68ab832e750083288843195d10c51546