### PR TITLE
Use ToImmutableDictionary in Gossiper.GetState

### DIFF
--- a/logs/log1756071220.md
+++ b/logs/log1756071220.md
@@ -1,0 +1,8 @@
+### Summary
+- Replaced loop with LINQ `ToImmutableDictionary` in `Gossiper.GetState` to avoid repeated allocations and simplify code.
+- Added explanatory comment.
+- Installed .NET 8 SDK and verified with `dotnet --version`.
+- Ran core test suites (`Proto.Actor.Tests`, `Proto.Remote.Tests`, `Proto.Cluster.Tests`).
+
+### Motivation
+Using `ToImmutableDictionary` constructs the resulting immutable dictionary in one allocation instead of repeatedly creating new instances via `SetItem`, improving efficiency and clarity.

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -116,12 +116,8 @@ public partial class Gossiper
             var res = await _context.RequestAsync<GetGossipStateResponse>(_pid, new GetGossipStateRequest(key)).ConfigureAwait(false);
 
             var dict = res.State;
-            var typed = ImmutableDictionary<string, T>.Empty;
-
-            foreach (var (k, value) in dict)
-            {
-                typed = typed.SetItem(k, value.Unpack<T>());
-            }
+            // Using ToImmutableDictionary avoids repeated reallocations from successive SetItem calls
+            var typed = dict.ToImmutableDictionary(kv => kv.Key, kv => kv.Value.Unpack<T>());
 
             return typed;
         }


### PR DESCRIPTION
## Summary
- Avoid repeated reallocations in `Gossiper.GetState` by converting entries to an immutable dictionary in one pass
- Document the use of `ToImmutableDictionary`

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ab8314a9948328af0c5b2a078e6c84