### PR TITLE
refactor: clarify variable naming

### DIFF
--- a/logs/log1756098266.md
+++ b/logs/log1756098266.md
@@ -1,0 +1,5 @@
+## Variable name audit
+
+- Renamed ambiguous variables like `t`, `t1`, `t2`, and `tcs` across actor, remote, and cluster core libraries to descriptive names (e.g., `receiveTask`, `gracefullyLeftEntries`, `completionSource`).
+- Updated foreach loop variables to meaningful names (`stat`, `terminated`, etc.) to improve readability.
+- Motivation: clearer intent of local variables simplifies maintenance and reduces cognitive load.

--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -235,13 +235,13 @@ public class ActorContext : IMessageInvoker, IContext, ISupervisor
             return;
         }
 
-        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var registration = token.Register(() => tcs.SetResult(true));
+        var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var registration = token.Register(() => completionSource.SetResult(true));
 
         // Ensures registration is disposed with the actor
         var inceptionRegistration = CancellationToken.Register(() => registration.Dispose());
 
-        ((IContext)this).ReenterAfter(tcs.Task, () =>
+        ((IContext)this).ReenterAfter(completionSource.Task, () =>
         {
             inceptionRegistration.Dispose();
             onCancelled();

--- a/src/Proto.Actor/Context/DeadlineContextDecorator.cs
+++ b/src/Proto.Actor/Context/DeadlineContextDecorator.cs
@@ -49,16 +49,16 @@ public class DeadlineContextDecorator : ActorContextDecorator
 
     public override async Task Receive(MessageEnvelope envelope)
     {
-        var t = base.Receive(envelope);
+        var receiveTask = base.Receive(envelope);
 
-        if (t.IsCompleted)
+        if (receiveTask.IsCompleted)
         {
             return;
         }
 
         try
         {
-            await t.WaitAsync(_deadline).ConfigureAwait(false);
+            await receiveTask.WaitAsync(_deadline).ConfigureAwait(false);
         }
         catch (TimeoutException)
         {
@@ -66,7 +66,7 @@ public class DeadlineContextDecorator : ActorContextDecorator
 
             // keep waiting, we cannot just ignore and continue as an async task might still be running and updating state of the actor
             // if we return here, actor concurrency guarantees could break
-            await t.ConfigureAwait(false);
+            await receiveTask.ConfigureAwait(false);
         }
     }
 }

--- a/src/Proto.Actor/Context/StartupDeadlineContextDecorator.cs
+++ b/src/Proto.Actor/Context/StartupDeadlineContextDecorator.cs
@@ -52,16 +52,16 @@ public class StartupDeadlineContextDecorator : ActorContextDecorator
         var (m,_,_) = MessageEnvelope.Unwrap(envelope);
         if (m is Started)
         {
-            var t = base.Receive(envelope);
+            var receiveTask = base.Receive(envelope);
 
-            if (t.IsCompleted)
+            if (receiveTask.IsCompleted)
             {
                 return;
             }
 
             try
             {
-                await t.WaitAsync(_deadline).ConfigureAwait(false);
+                await receiveTask.WaitAsync(_deadline).ConfigureAwait(false);
             }
             catch (TimeoutException)
             {
@@ -69,7 +69,7 @@ public class StartupDeadlineContextDecorator : ActorContextDecorator
 
                 // keep waiting, we cannot just ignore and continue as an async task might still be running and updating state of the actor
                 // if we return here, actor concurrency guarantees could break
-                await t.ConfigureAwait(false);
+                await receiveTask.ConfigureAwait(false);
             }
         }
     }

--- a/src/Proto.Actor/Diagnostics/DiagnosticTools.cs
+++ b/src/Proto.Actor/Diagnostics/DiagnosticTools.cs
@@ -21,10 +21,10 @@ public static class DiagnosticTools
     /// <returns></returns>
     public static async Task<string> GetDiagnosticsString(ActorSystem system, PID pid)
     {
-        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var request = new ProcessDiagnosticsRequest(tcs);
+        var completionSource = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var request = new ProcessDiagnosticsRequest(completionSource);
         pid.SendSystemMessage(system, request);
-        var res = await tcs.Task.ConfigureAwait(false);
+        var res = await completionSource.Task.ConfigureAwait(false);
 
         return res;
     }

--- a/src/Proto.Actor/Future/FutureBatch.cs
+++ b/src/Proto.Actor/Future/FutureBatch.cs
@@ -53,9 +53,9 @@ public sealed class FutureBatchProcess : Process, IDisposable
         {
             _cancellation = ct.Register(() =>
                 {
-                    foreach (var tcs in _completionSources)
+                    foreach (var completionSource in _completionSources)
                     {
-                        if (tcs?.TrySetException(
+                        if (completionSource?.TrySetException(
                                 new TimeoutException("Request didn't receive any Response within the expected time.")
                             ) == true)
                         {
@@ -82,15 +82,15 @@ public sealed class FutureBatchProcess : Process, IDisposable
 
         if (index < _completionSources.Length)
         {
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _completionSources[index] = tcs;
+            var completionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _completionSources[index] = completionSource;
 
             if (System.Metrics.Enabled)
             {
                 ActorMetrics.FuturesStartedCount.Add(1, _metricTags);
             }
 
-            return new SimpleFutureHandle(Pid.WithRequestId(ToRequestId(index)), tcs, _onTimeout);
+            return new SimpleFutureHandle(Pid.WithRequestId(ToRequestId(index)), completionSource, _onTimeout);
         }
 
         return null;
@@ -98,14 +98,14 @@ public sealed class FutureBatchProcess : Process, IDisposable
 
     protected internal override void SendUserMessage(PID pid, object message)
     {
-        if (!TryGetTaskCompletionSource(pid.RequestId, out var index, out var tcs))
+        if (!TryGetTaskCompletionSource(pid.RequestId, out var index, out var completionSource))
         {
             return;
         }
 
         try
         {
-            tcs.TrySetResult(message);
+            completionSource.TrySetResult(message);
             _completionSources[index] = default;
         }
         finally
@@ -126,14 +126,14 @@ public sealed class FutureBatchProcess : Process, IDisposable
             return;
         }
 
-        if (!TryGetTaskCompletionSource(pid.RequestId, out var index, out var tcs))
+        if (!TryGetTaskCompletionSource(pid.RequestId, out var index, out var completionSource))
         {
             return;
         }
 
         try
         {
-            tcs.TrySetResult(default!);
+            completionSource.TrySetResult(default!);
             _completionSources[index] = default;
         }
         finally
@@ -154,35 +154,35 @@ public sealed class FutureBatchProcess : Process, IDisposable
 
     private static uint ToRequestId(int index) => (uint)(index + 1);
 
-    private bool TryGetTaskCompletionSource(uint requestId, out int index, out TaskCompletionSource<object> tcs)
+    private bool TryGetTaskCompletionSource(uint requestId, out int index, out TaskCompletionSource<object> completionSource)
     {
         if (!TryGetIndex(requestId, out index))
         {
-            tcs = default!;
+            completionSource = default!;
 
             return false;
         }
 
-        tcs = _completionSources[index]!;
+        completionSource = _completionSources[index]!;
 
-        return tcs != default!;
+        return completionSource != default!;
     }
 
     private sealed class SimpleFutureHandle : IFuture
     {
         private readonly Action? _onTimeout;
 
-        public SimpleFutureHandle(PID pid, TaskCompletionSource<object> tcs, Action? onTimeout)
+        public SimpleFutureHandle(PID pid, TaskCompletionSource<object> completionSource, Action? onTimeout)
         {
             _onTimeout = onTimeout;
             Pid = pid;
-            Tcs = tcs;
+            CompletionSource = completionSource;
         }
 
-        internal TaskCompletionSource<object> Tcs { get; }
+        internal TaskCompletionSource<object> CompletionSource { get; }
 
         public PID Pid { get; }
-        public Task<object> Task => Tcs.Task;
+        public Task<object> Task => CompletionSource.Task;
 
         public async Task<object> GetTask(CancellationToken cancellationToken)
         {
@@ -190,12 +190,12 @@ public sealed class FutureBatchProcess : Process, IDisposable
             {
                 if (cancellationToken == default)
                 {
-                    return await Tcs.Task.ConfigureAwait(false);
+                    return await CompletionSource.Task.ConfigureAwait(false);
                 }
 
-                await using (cancellationToken.Register(() => Tcs.TrySetCanceled()).ConfigureAwait(false))
+                await using (cancellationToken.Register(() => CompletionSource.TrySetCanceled()).ConfigureAwait(false))
                 {
-                    return await Tcs.Task.ConfigureAwait(false);
+                    return await CompletionSource.Task.ConfigureAwait(false);
                 }
             }
             catch

--- a/src/Proto.Actor/Future/SharedFuture.cs
+++ b/src/Proto.Actor/Future/SharedFuture.cs
@@ -215,17 +215,17 @@ public sealed class SharedFutureProcess : Process, IDisposable
     {
         private readonly SharedFutureProcess _parent;
 
-        private readonly TaskCompletionSource<object> _tcs;
+        private readonly TaskCompletionSource<object> _completionSource;
 
-        public SharedFutureHandle(SharedFutureProcess parent, PID pid, TaskCompletionSource<object> tcs)
+        public SharedFutureHandle(SharedFutureProcess parent, PID pid, TaskCompletionSource<object> completionSource)
         {
             _parent = parent;
             Pid = pid;
-            _tcs = tcs;
+            _completionSource = completionSource;
         }
 
         public PID Pid { get; }
-        public Task<object> Task => _tcs.Task;
+        public Task<object> Task => _completionSource.Task;
 
         public async Task<object> GetTask(CancellationToken cancellationToken)
         {
@@ -233,12 +233,12 @@ public sealed class SharedFutureProcess : Process, IDisposable
             {
                 if (cancellationToken == default)
                 {
-                    return await _tcs.Task.ConfigureAwait(false);
+                    return await _completionSource.Task.ConfigureAwait(false);
                 }
 
-                await using (cancellationToken.Register(() => _tcs.TrySetCanceled()).ConfigureAwait(false))
+                await using (cancellationToken.Register(() => _completionSource.TrySetCanceled()).ConfigureAwait(false))
                 {
-                    return await _tcs.Task.ConfigureAwait(false);
+                    return await _completionSource.Task.ConfigureAwait(false);
                 }
             }
             catch

--- a/src/Proto.Actor/Mailbox/DefaultMailbox.cs
+++ b/src/Proto.Actor/Mailbox/DefaultMailbox.cs
@@ -69,9 +69,9 @@ public sealed class DefaultMailbox : IMailbox, IThreadPoolWorkItem
             {
                 _userMailbox.Push(message);
 
-                foreach (var t in _stats)
+                foreach (var stat in _stats)
                 {
-                    t.MessagePosted(message);
+                    stat.MessagePosted(message);
                 }
             }
 
@@ -82,9 +82,9 @@ public sealed class DefaultMailbox : IMailbox, IThreadPoolWorkItem
                 _userMailbox.Push(msg);
             }
 
-            foreach (var t in _stats)
+            foreach (var stat in _stats)
             {
-                t.MessagePosted(msg);
+                stat.MessagePosted(msg);
             }
 
             Schedule();
@@ -93,9 +93,9 @@ public sealed class DefaultMailbox : IMailbox, IThreadPoolWorkItem
         {
             _userMailbox.Push(msg);
 
-            foreach (var t in _stats)
+            foreach (var stat in _stats)
             {
-                t.MessagePosted(msg);
+                stat.MessagePosted(msg);
             }
 
             Schedule();
@@ -111,9 +111,9 @@ public sealed class DefaultMailbox : IMailbox, IThreadPoolWorkItem
             _invoker?.CancellationTokenSource?.Cancel();
         }
 
-        foreach (var t in _stats)
+        foreach (var stat in _stats)
         {
-            t.MessagePosted(msg);
+            stat.MessagePosted(msg);
         }
 
         Schedule();
@@ -127,9 +127,9 @@ public sealed class DefaultMailbox : IMailbox, IThreadPoolWorkItem
 
     public void Start()
     {
-        foreach (var t in _stats)
+        foreach (var stat in _stats)
         {
-            t.MailboxStarted();
+            stat.MailboxStarted();
         }
     }
 
@@ -150,9 +150,9 @@ public sealed class DefaultMailbox : IMailbox, IThreadPoolWorkItem
         }
         else
         {
-            foreach (var t in mailbox._stats)
+            foreach (var stat in mailbox._stats)
             {
-                t.MailboxEmpty();
+                stat.MailboxEmpty();
             }
         }
 
@@ -170,9 +170,9 @@ public sealed class DefaultMailbox : IMailbox, IThreadPoolWorkItem
             }
             else
             {
-                foreach (var t in self._stats)
+                foreach (var stat in self._stats)
                 {
-                    t.MailboxEmpty();
+                    stat.MailboxEmpty();
                 }
             }
         }
@@ -197,16 +197,16 @@ public sealed class DefaultMailbox : IMailbox, IThreadPoolWorkItem
                         _              => _suspended
                     };
 
-                    var t = _invoker.InvokeSystemMessageAsync(sys);
+                    var systemMessageTask = _invoker.InvokeSystemMessageAsync(sys);
 
-                    if (!t.IsCompletedSuccessfully)
+                    if (!systemMessageTask.IsCompletedSuccessfully)
                     {
-                        return Await(msg, t, this);
+                        return Await(msg, systemMessageTask, this);
                     }
 
-                    foreach (var t1 in _stats)
+                    foreach (var stat in _stats)
                     {
-                        t1.MessageReceived(msg);
+                        stat.MessageReceived(msg);
                     }
 
                     continue;
@@ -221,16 +221,16 @@ public sealed class DefaultMailbox : IMailbox, IThreadPoolWorkItem
 
                 if (msg is not null)
                 {
-                    var t = _invoker.InvokeUserMessageAsync(msg);
+                    var userMessageTask = _invoker.InvokeUserMessageAsync(msg);
 
-                    if (!t.IsCompletedSuccessfully)
+                    if (!userMessageTask.IsCompletedSuccessfully)
                     {
-                        return Await(msg, t, this);
+                        return Await(msg, userMessageTask, this);
                     }
 
-                    foreach (var t1 in _stats)
+                    foreach (var stat in _stats)
                     {
-                        t1.MessageReceived(msg);
+                        stat.MessageReceived(msg);
                     }
                 }
                 else
@@ -253,9 +253,9 @@ public sealed class DefaultMailbox : IMailbox, IThreadPoolWorkItem
             {
                 await task.ConfigureAwait(false);
 
-                foreach (var t1 in self._stats)
+                foreach (var stat in self._stats)
                 {
-                    t1.MessageReceived(msg);
+                    stat.MessageReceived(msg);
                 }
             }
             catch (Exception e)

--- a/src/Proto.Actor/Metrics/MetricsExtensions.cs
+++ b/src/Proto.Actor/Metrics/MetricsExtensions.cs
@@ -20,8 +20,8 @@ public static class MetricsExtensions
         params KeyValuePair<string, object?>[] tags)
     {
         var sw = Stopwatch.StartNew();
-        var t = factory();
-        var res = await t.ConfigureAwait(false);
+        var operationTask = factory();
+        var res = await operationTask.ConfigureAwait(false);
         sw.Stop();
 
         histogram.Record(sw.Elapsed.TotalSeconds, tags);
@@ -33,8 +33,8 @@ public static class MetricsExtensions
         params KeyValuePair<string, object?>[] tags)
     {
         var sw = Stopwatch.StartNew();
-        var t = factory();
-        await t.ConfigureAwait(false);
+        var operationTask = factory();
+        await operationTask.ConfigureAwait(false);
         sw.Stop();
         histogram.Record(sw.Elapsed.TotalSeconds, tags);
     }

--- a/src/Proto.Actor/Utils/ThreadPoolStats.cs
+++ b/src/Proto.Actor/Utils/ThreadPoolStats.cs
@@ -23,9 +23,9 @@ public static class ThreadPoolStats
         {
             // Wait for the configured sampling interval before measuring again
             await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
-            var t1 = DateTime.UtcNow;
+            var startTime = DateTime.UtcNow;
 
-            var t2 = await Task.Run(async () =>
+            var endTime = await Task.Run(async () =>
                 {
                     await Task.Yield();
 
@@ -33,7 +33,7 @@ public static class ThreadPoolStats
                 }, cancellationToken
             ).ConfigureAwait(false);
 
-            var delta = t2 - t1;
+            var delta = endTime - startTime;
             callback(delta);
         }
     }

--- a/src/Proto.Cluster/Cluster.cs
+++ b/src/Proto.Cluster/Cluster.cs
@@ -47,9 +47,9 @@ public class Cluster : IActorSystemExtension<Cluster>
         var blocked = new DiagnosticsEntry("Cluster", "Blocked", System.Remote().BlockList.BlockedMembers.ToArray());
         res.Add(blocked);
         
-        var t = await Gossip.GetState<ClusterTopology>(GossipKeys.Topology).ConfigureAwait(false);
+        var topologyState = await Gossip.GetState<ClusterTopology>(GossipKeys.Topology).ConfigureAwait(false);
 
-        var topology = new DiagnosticsEntry("Cluster", "Topology", t);
+        var topology = new DiagnosticsEntry("Cluster", "Topology", topologyState);
         res.Add(topology);
         
         var h = await Gossip.GetStateEntry(GossipKeys.Heartbeat).ConfigureAwait(false);

--- a/src/Proto.Cluster/Gossip/Consensus.cs
+++ b/src/Proto.Cluster/Gossip/Consensus.cs
@@ -31,14 +31,14 @@ internal class GossipConsensusHandle<T> : IConsensusHandle<T> where T : notnull
     {
         while (!ct.IsCancellationRequested)
         {
-            var t = Volatile.Read(ref _consensusTcs).Task;
+            var consensusTask = Volatile.Read(ref _consensusTcs).Task;
             // ReSharper disable once MethodSupportsCancellation
             // Poll for consensus completion or timeout to periodically check cancellation
-            await Task.WhenAny(t, Task.Delay(500)).ConfigureAwait(false);
+            await Task.WhenAny(consensusTask, Task.Delay(500)).ConfigureAwait(false);
 
-            if (t.IsCompleted)
+            if (consensusTask.IsCompleted)
             {
-                return (true, t.Result);
+                return (true, consensusTask.Result);
             }
         }
 
@@ -68,15 +68,15 @@ internal class GossipConsensusHandle<T> : IConsensusHandle<T> where T : notnull
 
     internal void TrySetConsensus(object consensus)
     {
-        var tcs = Volatile.Read(ref _consensusTcs);
+        var consensusSource = Volatile.Read(ref _consensusTcs);
 
-        if (tcs.Task.IsCompleted && tcs.Task.Result?.Equals(consensus) != true)
+        if (consensusSource.Task.IsCompleted && consensusSource.Task.Result?.Equals(consensus) != true)
         {
             TryResetConsensus();
         }
 
         //if not set, set it, if already set, keep it set
-        tcs.TrySetResult((T)consensus);
+        consensusSource.TrySetResult((T)consensus);
     }
 
     public void TryResetConsensus()

--- a/src/Proto.Cluster/Gossip/GossipActor.cs
+++ b/src/Proto.Cluster/Gossip/GossipActor.cs
@@ -49,7 +49,7 @@ public class GossipActor : IActor
         try
         {
          //   Logger.LogInformation("GossipActor Received {MessageType}", context.Message.GetMessageTypeName());
-            var t = context.Message switch
+            var handlerTask = context.Message switch
             {
                 Started => OnStarted(context),
                 ReceiveTimeout => OnReceiveTimeout(context),
@@ -63,7 +63,7 @@ public class GossipActor : IActor
                 ClusterTopology clusterTopology => OnClusterTopology(clusterTopology),
                 _ => Task.CompletedTask
             };
-            await t;
+            await handlerTask;
          //   Logger.LogInformation("GossipActor Done {MessageType}", context.Message.GetMessageTypeName());
         }
         catch (Exception x)

--- a/src/Proto.Cluster/Gossip/Gossiper.cs
+++ b/src/Proto.Cluster/Gossip/Gossiper.cs
@@ -300,14 +300,14 @@ public partial class Gossiper
 
     private async Task BlockGracefullyLeft()
     {
-        var t2 = await GetStateEntry(GossipKeys.GracefullyLeft).ConfigureAwait(false);
+        var gracefullyLeftEntries = await GetStateEntry(GossipKeys.GracefullyLeft).ConfigureAwait(false);
 
         var alreadyBlocked = _blockList.BlockedMembers;
 
         var gracefullyLeft = new List<string>();
 
         // Collect members that left gracefully but are neither already blocked nor this system
-        foreach (var memberId in t2.Keys)
+        foreach (var memberId in gracefullyLeftEntries.Keys)
         {
             if (!alreadyBlocked.Contains(memberId) && memberId != _systemId)
             {

--- a/src/Proto.Cluster/PubSub/BatchingProducer.cs
+++ b/src/Proto.Cluster/PubSub/BatchingProducer.cs
@@ -309,9 +309,9 @@ public class BatchingProducer : IAsyncDisposable
     /// <exception cref="ProducerQueueFullException">Thrown when producer max queue size is reached.</exception>
     public Task ProduceAsync(object message, CancellationToken ct = default)
     {
-        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        if (!_publisherChannel.Writer.TryWrite(new ProduceMessage(message, tcs, ct)))
+        if (!_publisherChannel.Writer.TryWrite(new ProduceMessage(message, completionSource, ct)))
         {
             if (_publisherChannel.Reader.Completion.IsCompleted)
             {
@@ -322,7 +322,7 @@ public class BatchingProducer : IAsyncDisposable
             throw new ProducerQueueFullException(_topic);
         }
 
-        return tcs.Task;
+        return completionSource.Task;
     }
 
     private record ProduceMessage(object Message, TaskCompletionSource<bool> TaskCompletionSource,

--- a/src/Proto.Remote/Endpoints/Endpoint.cs
+++ b/src/Proto.Remote/Endpoints/Endpoint.cs
@@ -199,7 +199,7 @@ public abstract class Endpoint : IEndpoint
                     continue;
                 }
 
-                foreach (var t in pidSet.Select(
+                foreach (var terminated in pidSet.Select(
                              pid => new Terminated
                              {
                                  Who = pid,
@@ -208,7 +208,7 @@ public abstract class Endpoint : IEndpoint
                          ))
                 {
                     //send the address Terminated event to the Watcher
-                    watcherPid.SendSystemMessage(System, t);
+                    watcherPid.SendSystemMessage(System, terminated);
                 }
             }
 


### PR DESCRIPTION
## Summary
- rename ambiguous local variables in actor, remote, and cluster libraries
- use descriptive names in foreach loops and task handling

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj` *(fails: command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68abeb7419c48328ad2eca65b67c2861