### PR TITLE
Refactor throttling to use token bucket rate limiter

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -91,6 +91,7 @@
     <PackageVersion Include="System.Interactive.Async" Version="6.0.1" />
     <PackageVersion Include="System.Text.Json" Version="9.0.3" />
     <PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="8.0.0" />
     <PackageVersion Include="Testcontainers" Version="3.10.0" />
     <PackageVersion Include="Testcontainers.CouchDb" Version="3.10.0" />
     <PackageVersion Include="Testcontainers.DynamoDb" Version="3.10.0" />

--- a/ProtoActor.sln
+++ b/ProtoActor.sln
@@ -121,21 +121,21 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependencyInjection", "examples\actor.dependency-injection\DependencyInjection.csproj", "{779521AC-8EBB-4E2D-82EE-508A2E95AD1B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "templates", "templates", "{5C1A4C10-E037-4945-9EDC-DFBFBD501A4A}"
-ProjectSection(SolutionItems) = preProject
-	.github\ISSUE_TEMPLATE.md = .github\ISSUE_TEMPLATE.md
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		.github\ISSUE_TEMPLATE.md = .github\ISSUE_TEMPLATE.md
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{C8C3C2EE-083A-46B4-8F5A-0C0F442C14BE}"
-ProjectSection(SolutionItems) = preProject
-	Terminology.md = Terminology.md
-	README.md = README.md
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		Terminology.md = Terminology.md
+		README.md = README.md
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ci", "ci", "{8B241043-F933-4C1F-AB57-BAE8B624F133}"
-ProjectSection(SolutionItems) = preProject
-	.github\workflows\build-dev.yml = .github\workflows\build-dev.yml
-	.github\workflows\pull-request.yml = .github\workflows\pull-request.yml
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build-dev.yml = .github\workflows\build-dev.yml
+		.github\workflows\pull-request.yml = .github\workflows\pull-request.yml
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HostedService", "benchmarks\HostedService\HostedService.csproj", "{7840C651-9352-4CB2-9152-4793EC219DE9}"
 EndProject
@@ -310,6 +310,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "template", "template", "{08
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EndpointManagerTest", "benchmarks\EndpointManagerTest\EndpointManagerTest.csproj", "{B7258689-41D2-4284-AF93-050DD1DFEAC4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ThrottleBenchmarks", "benchmarks\ThrottleBenchmarks\ThrottleBenchmarks.csproj", "{0EC31C27-3733-411B-BD45-8AF627F04776}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1497,7 +1499,7 @@ Global
 		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Release|x64.Build.0 = Release|Any CPU
 		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Release|x86.ActiveCfg = Release|Any CPU
 		{B7258689-41D2-4284-AF93-050DD1DFEAC4}.Release|x86.Build.0 = Release|Any CPU
-			{BEF7AF52-F9A6-4BF8-881D-636D97234884}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BEF7AF52-F9A6-4BF8-881D-636D97234884}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BEF7AF52-F9A6-4BF8-881D-636D97234884}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BEF7AF52-F9A6-4BF8-881D-636D97234884}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{BEF7AF52-F9A6-4BF8-881D-636D97234884}.Debug|x64.Build.0 = Debug|Any CPU
@@ -1509,7 +1511,19 @@ Global
 		{BEF7AF52-F9A6-4BF8-881D-636D97234884}.Release|x64.Build.0 = Release|Any CPU
 		{BEF7AF52-F9A6-4BF8-881D-636D97234884}.Release|x86.ActiveCfg = Release|Any CPU
 		{BEF7AF52-F9A6-4BF8-881D-636D97234884}.Release|x86.Build.0 = Release|Any CPU
-EndGlobalSection
+		{0EC31C27-3733-411B-BD45-8AF627F04776}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0EC31C27-3733-411B-BD45-8AF627F04776}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0EC31C27-3733-411B-BD45-8AF627F04776}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0EC31C27-3733-411B-BD45-8AF627F04776}.Debug|x64.Build.0 = Debug|Any CPU
+		{0EC31C27-3733-411B-BD45-8AF627F04776}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0EC31C27-3733-411B-BD45-8AF627F04776}.Debug|x86.Build.0 = Debug|Any CPU
+		{0EC31C27-3733-411B-BD45-8AF627F04776}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0EC31C27-3733-411B-BD45-8AF627F04776}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0EC31C27-3733-411B-BD45-8AF627F04776}.Release|x64.ActiveCfg = Release|Any CPU
+		{0EC31C27-3733-411B-BD45-8AF627F04776}.Release|x64.Build.0 = Release|Any CPU
+		{0EC31C27-3733-411B-BD45-8AF627F04776}.Release|x86.ActiveCfg = Release|Any CPU
+		{0EC31C27-3733-411B-BD45-8AF627F04776}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
@@ -1542,7 +1556,7 @@ EndGlobalSection
 		{9DE48E83-DF4E-4C5F-9BC8-CB05C646FC43} = {9AA2BCF0-19AB-4DD9-8D91-7D188E463806}
 		{8705E498-3F5C-41DE-9CCD-FE99104FFF2D} = {6AD72F65-94AF-49DA-BADC-5647ED48D083}
 		{6AD72F65-94AF-49DA-BADC-5647ED48D083} = {59DCCC96-DDAF-469F-9E8E-9BC733285082}
-        {F6E76800-BF17-4D9B-9AD1-2BD2A3138807} = {59DCCC96-DDAF-469F-9E8E-9BC733285082}
+		{F6E76800-BF17-4D9B-9AD1-2BD2A3138807} = {59DCCC96-DDAF-469F-9E8E-9BC733285082}
 		{DF4464D4-B411-42E2-B4DC-16EBE5ABB0EF} = {0F3AB331-C042-4371-A2F0-0AFDFA13DC9F}
 		{8849DD9F-CEB4-40D5-9DC0-EC6EDCA09E65} = {0F3AB331-C042-4371-A2F0-0AFDFA13DC9F}
 		{BD994BD6-9E3D-4221-9287-E8A1468759C5} = {0F3AB331-C042-4371-A2F0-0AFDFA13DC9F}
@@ -1644,9 +1658,10 @@ EndGlobalSection
 		{CDCE3D4C-1BDD-460F-93B8-75123A258183} = {ADE7A14E-FFE9-4137-AC25-E2F2A82B0A8C}
 		{087E5441-1582-4D55-8233-014C0FB06FF0} = {CDCE3D4C-1BDD-460F-93B8-75123A258183}
 		{B7258689-41D2-4284-AF93-050DD1DFEAC4} = {0F3AB331-C042-4371-A2F0-0AFDFA13DC9F}
-			{BCA22E13-E154-498A-9989-61639EC6B2AC} = {59DCCC96-DDAF-469F-9E8E-9BC733285082}
+		{BCA22E13-E154-498A-9989-61639EC6B2AC} = {59DCCC96-DDAF-469F-9E8E-9BC733285082}
 		{BEF7AF52-F9A6-4BF8-881D-636D97234884} = {BCA22E13-E154-498A-9989-61639EC6B2AC}
-EndGlobalSection
+		{0EC31C27-3733-411B-BD45-8AF627F04776} = {0F3AB331-C042-4371-A2F0-0AFDFA13DC9F}
+	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD0D1E44-8118-4682-8793-6B20ABFA824C}
 	EndGlobalSection

--- a/benchmarks/ThrottleBenchmarks/LegacyThrottle.cs
+++ b/benchmarks/ThrottleBenchmarks/LegacyThrottle.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ThrottleBenchmarks.Legacy;
+
+public static class LegacyThrottle
+{
+    public static ShouldThrottle Create(
+        int maxEventsInPeriod,
+        TimeSpan period,
+        Action<int>? throttledCallBack = null
+    )
+    {
+        if (maxEventsInPeriod == 0)
+        {
+            return () => Throttle.Valve.Closed;
+        }
+
+        if (period == TimeSpan.Zero || maxEventsInPeriod < 1 || maxEventsInPeriod == int.MaxValue)
+        {
+            return () => Throttle.Valve.Open;
+        }
+
+        var currentEvents = 0;
+
+        return () =>
+        {
+            var tries = Interlocked.Increment(ref currentEvents);
+
+            if (tries == 1)
+            {
+                StartTimer(throttledCallBack);
+            }
+
+            if (tries == maxEventsInPeriod)
+            {
+                return Throttle.Valve.Closing;
+            }
+
+            return tries > maxEventsInPeriod ? Throttle.Valve.Closed : Throttle.Valve.Open;
+        };
+
+        void StartTimer(Action<int>? callBack) =>
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(period).ConfigureAwait(false);
+                var timesCalled = Interlocked.Exchange(ref currentEvents, 0);
+
+                if (timesCalled > maxEventsInPeriod)
+                {
+                    callBack?.Invoke(timesCalled - maxEventsInPeriod);
+                }
+            });
+    }
+}

--- a/benchmarks/ThrottleBenchmarks/Program.cs
+++ b/benchmarks/ThrottleBenchmarks/Program.cs
@@ -1,0 +1,9 @@
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+
+var config = DefaultConfig.Instance
+    .AddJob(Job.ShortRun.WithToolchain(InProcessNoEmitToolchain.Instance));
+
+BenchmarkRunner.Run<ThrottleBenchmarks.ThrottleBenchmarks>(config);

--- a/benchmarks/ThrottleBenchmarks/Throttle.cs
+++ b/benchmarks/ThrottleBenchmarks/Throttle.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading.RateLimiting;
+
+namespace ThrottleBenchmarks;
+
+public delegate Throttle.Valve ShouldThrottle();
+
+public static class Throttle
+{
+    public enum Valve
+    {
+        Open,
+        Closing,
+        Closed
+    }
+
+    public static ShouldThrottle Create(
+        int maxEventsInPeriod,
+        TimeSpan period,
+        Action<int>? throttledCallBack = null
+    )
+    {
+        if (maxEventsInPeriod == 0)
+        {
+            return () => Valve.Closed;
+        }
+
+        if (period == TimeSpan.Zero || maxEventsInPeriod < 1 || maxEventsInPeriod == int.MaxValue)
+        {
+            return () => Valve.Open;
+        }
+
+        var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+        {
+            TokenLimit = maxEventsInPeriod,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            QueueLimit = 0,
+            ReplenishmentPeriod = period,
+            TokensPerPeriod = maxEventsInPeriod,
+            AutoReplenishment = true
+        });
+
+        var dropped = 0;
+
+        return () =>
+        {
+            var lease = limiter.AttemptAcquire(1);
+
+            if (lease.IsAcquired)
+            {
+                if (dropped > 0)
+                {
+                    throttledCallBack?.Invoke(dropped);
+                    dropped = 0;
+                }
+
+                var stats = limiter.GetStatistics();
+                return stats.CurrentAvailablePermits == 0 ? Valve.Closing : Valve.Open;
+            }
+
+            dropped++;
+            return Valve.Closed;
+        };
+    }
+
+    public static bool IsOpen(this Valve valve) => valve != Valve.Closed;
+}

--- a/benchmarks/ThrottleBenchmarks/ThrottleBenchmarks.cs
+++ b/benchmarks/ThrottleBenchmarks/ThrottleBenchmarks.cs
@@ -1,0 +1,39 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using ThrottleBenchmarks.Legacy;
+
+namespace ThrottleBenchmarks;
+
+[MemoryDiagnoser]
+public class ThrottleBenchmarks
+{
+    private ShouldThrottle _new = null!;
+    private ShouldThrottle _old = null!;
+
+    [Params(10)]
+    public int Limit;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // verify behaviour equivalence
+        var testNew = Throttle.Create(Limit, TimeSpan.FromSeconds(1));
+        var testOld = LegacyThrottle.Create(Limit, TimeSpan.FromSeconds(1));
+        for (var i = 0; i < Limit * 2; i++)
+        {
+            if (testNew() != testOld())
+            {
+                throw new InvalidOperationException("Implementations differ");
+            }
+        }
+
+        _new = Throttle.Create(Limit, TimeSpan.FromSeconds(1));
+        _old = LegacyThrottle.Create(Limit, TimeSpan.FromSeconds(1));
+    }
+
+    [Benchmark]
+    public Throttle.Valve NewThrottle() => _new();
+
+    [Benchmark]
+    public Throttle.Valve OldThrottle() => _old();
+}

--- a/benchmarks/ThrottleBenchmarks/ThrottleBenchmarks.csproj
+++ b/benchmarks/ThrottleBenchmarks/ThrottleBenchmarks.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="System.Threading.RateLimiting" />
+  </ItemGroup>
+</Project>

--- a/logs/log1756107959.md
+++ b/logs/log1756107959.md
@@ -1,0 +1,6 @@
+# Log 1756107959
+
+- Replaced custom `Throttle` implementation with `TokenBucketRateLimiter` from `System.Threading.RateLimiting` to rely on built-in rate limiting and drop manual timers.
+- Removed `ThrottleOptions` record and related extension method as the new limiter handles scheduling internally.
+- Updated `LocalAffinityOptions` and `LocalAffinityExtensions` to accept a pre-built `ShouldThrottle` delegate instead of options.
+- Added package references for `System.Threading.RateLimiting` and ran core test suites to verify behaviour.

--- a/logs/log1756109973.md
+++ b/logs/log1756109973.md
@@ -1,0 +1,7 @@
+# Benchmarking legacy vs token bucket throttle
+
+- Added ThrottleBenchmarks project to compare previous timer-based throttle against new token bucket implementation.
+- Copied legacy throttle code and current token bucket version into benchmark project.
+- Implemented BenchmarkDotNet benchmarks validating both approaches produce identical valve transitions and measuring call overhead.
+- Ran benchmarks locally (token bucket ~46ns/op, legacy ~9ns/op).
+- Executed core tests (Proto.Actor.Tests, Proto.Remote.Tests, Proto.Cluster.Tests).

--- a/src/Proto.Actor/Proto.Actor.csproj
+++ b/src/Proto.Actor/Proto.Actor.csproj
@@ -17,6 +17,7 @@
         <PackageReference Include="System.Diagnostics.DiagnosticSource" />
         <PackageReference Include="System.Text.Json" />
         <PackageReference Include="System.Threading.Channels" />
+        <PackageReference Include="System.Threading.RateLimiting" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Proto.Actor/Utils/Throttle.cs
+++ b/src/Proto.Actor/Utils/Throttle.cs
@@ -1,12 +1,11 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="Throttle.cs" company="Asynkron AB">
 //      Copyright (C) 2015-2025 Asynkron AB All rights reserved
 // </copyright>
 // -----------------------------------------------------------------------
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Threading.RateLimiting;
 
 namespace Proto.Utils;
 
@@ -39,15 +38,12 @@ public static class Throttle
     }
 
     /// <summary>
-    ///     Creates a new throttle with the given window and rate. After first event is recorded, a timer starts to reset the
-    ///     number of events back to 0.
-    ///     If the number of events in the meantime exceeds the limit, the valve will be closed.
-    ///     This has no guarantees that the throttle opens exactly after the period, since it is reset asynchronously
-    ///     Throughput has been prioritized over exact re-opening
+    ///     Creates a new throttle with the given window and rate using a token bucket rate limiter.
+    ///     Tokens are replenished automatically, removing the need for external timers.
     /// </summary>
     /// <param name="maxEventsInPeriod">Event limit</param>
     /// <param name="period">Time window to verify event limit</param>
-    /// <param name="throttledCallBack">This will be called with the number of events that was throttled after the period</param>
+    /// <param name="throttledCallBack">Invoked with the number of throttled events once the limiter opens again</param>
     /// <returns>
     ///     <see cref="ShouldThrottle" /> delegate that records an event when called, and returns current state of the
     ///     throttle valve
@@ -68,52 +64,38 @@ public static class Throttle
             return () => Valve.Open;
         }
 
-        var currentEvents = 0;
+        var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+        {
+            TokenLimit = maxEventsInPeriod,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            QueueLimit = 0,
+            ReplenishmentPeriod = period,
+            TokensPerPeriod = maxEventsInPeriod,
+            AutoReplenishment = true
+        });
+
+        var dropped = 0;
 
         return () =>
         {
-            var tries = Interlocked.Increment(ref currentEvents);
+            var lease = limiter.AttemptAcquire(1);
 
-            if (tries == 1)
+            if (lease.IsAcquired)
             {
-                StartTimer(throttledCallBack);
-            }
-
-            if (tries == maxEventsInPeriod)
-            {
-                return Valve.Closing;
-            }
-
-            return tries > maxEventsInPeriod ? Valve.Closed : Valve.Open;
-        };
-
-        void StartTimer(Action<int>? callBack) =>
-            _ = SafeTask.Run(async () =>
+                if (dropped > 0)
                 {
-                    // Pause for the throttling period before resetting the counter
-                    await Task.Delay(period).ConfigureAwait(false);
-                    var timesCalled = Interlocked.Exchange(ref currentEvents, 0);
-
-                    if (timesCalled > maxEventsInPeriod)
-                    {
-                        callBack?.Invoke(timesCalled - maxEventsInPeriod);
-                    }
+                    throttledCallBack?.Invoke(dropped);
+                    dropped = 0;
                 }
-            );
-    }
 
-    public static ShouldThrottle Create(
-        this ThrottleOptions options,
-        Action<int>? throttledCallBack = null
-    ) =>
-        Create(options.MaxEventsInPeriod, options.Period, throttledCallBack);
+                var stats = limiter.GetStatistics();
+                return stats.CurrentAvailablePermits == 0 ? Valve.Closing : Valve.Open;
+            }
+
+            dropped++;
+            return Valve.Closed;
+        };
+    }
 
     public static bool IsOpen(this Valve valve) => valve != Valve.Closed;
 }
-
-/// <summary>
-///     Throttling options
-/// </summary>
-/// <param name="MaxEventsInPeriod">Max events in a period</param>
-/// <param name="Period">Period to check the threshold in</param>
-public record ThrottleOptions(int MaxEventsInPeriod, TimeSpan Period);

--- a/src/Proto.Cluster/Membership/LocalAffinityExtensions.cs
+++ b/src/Proto.Cluster/Membership/LocalAffinityExtensions.cs
@@ -29,7 +29,7 @@ public static class LocalAffinityExtensions
         LocalAffinityOptions? options = null) =>
         clusterKind with
         {
-            Props = clusterKind.Props.WithRelocateOnRemoteSender(options?.RelocationThroughput?.Create(),
+            Props = clusterKind.Props.WithRelocateOnRemoteSender(options?.RelocationThrottle,
                 options?.TriggersLocalAffinity),
             StrategyBuilder = cluster => new LocalAffinityStrategy(cluster)
         };

--- a/src/Proto.Cluster/Membership/LocalAffinityOptions.cs
+++ b/src/Proto.Cluster/Membership/LocalAffinityOptions.cs
@@ -14,7 +14,7 @@ public sealed record LocalAffinityOptions
     /// <summary>
     ///     Throttle the number of relocations in a window of time to avoid slowdowns in the system.
     /// </summary>
-    public ThrottleOptions? RelocationThroughput { get; init; }
+    public ShouldThrottle? RelocationThrottle { get; init; }
 
     /// <summary>
     ///     A predicate that should return true for messages that trigger local affinity mechanism. If you also


### PR DESCRIPTION
## Summary
- replace custom Throttle with TokenBucketRateLimiter and simplify API
- remove ThrottleOptions in favor of supplying a ShouldThrottle delegate
- wire System.Threading.RateLimiting package and update local affinity helpers

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ac12bcb7d88328b4950a91857fce3e