### PR TITLE
refactor: extract connection runner

### DIFF
--- a/logs/exceptions.md
+++ b/logs/exceptions.md
@@ -29,3 +29,5 @@
 
 ### Proto.Tests.SupervisionTestsOneForOne.OneForOneStrategy_Should_EscalateFailureToParent
 `System.InvalidOperationException: Sequence contains no elements` in `SupervisionTests_OneForOne.cs:line 263`.
+### Proto.Mailbox.Tests.MailboxSchedulingTests.GivenNonCompletedUserMessage_ShouldHaltProcessingUntilCompletion
+`System.TimeoutException: The condition was not met within the timeout of 00:00:00.1000000`

--- a/logs/log1756122285.md
+++ b/logs/log1756122285.md
@@ -1,0 +1,6 @@
+# Refactor ServerConnector
+- Extracted RunAsync loop into new `ConnectionRunner` handling lifecycle and retries.
+- Introduced strategy interface `IConnectionMode` with `ServerConnectionMode` and `ClientConnectionMode` to separate protocol logic.
+- Injected metric delegates from `ServerConnector` so new classes avoid direct metric or logger dependencies.
+- Updated `ServerConnector` to configure and launch `ConnectionRunner` with proper delegates.
+- Noted failing test `Proto.Mailbox.Tests.MailboxSchedulingTests.GivenNonCompletedUserMessage_ShouldHaltProcessingUntilCompletion` due to `System.TimeoutException`.

--- a/src/Proto.Remote/Endpoints/ClientConnectionMode.cs
+++ b/src/Proto.Remote/Endpoints/ClientConnectionMode.cs
@@ -1,0 +1,26 @@
+namespace Proto.Remote;
+
+using System.Threading.Tasks;
+using Grpc.Core;
+
+public sealed class ClientConnectionMode : IConnectionMode
+{
+    private readonly RemoteMessageHandler _handler;
+
+    public ClientConnectionMode(RemoteMessageHandler handler) => _handler = handler;
+
+    public Task SendConnectRequest(ActorSystem system, RemoteConfig remoteConfig, AsyncDuplexStreamingCall<RemoteMessage, RemoteMessage> call)
+        => call.RequestStream.WriteAsync(new RemoteMessage
+        {
+            ConnectRequest = new ConnectRequest
+            {
+                ClientConnection = new ClientConnection
+                {
+                    MemberId = system.Id
+                }
+            }
+        });
+
+    public void HandleMessage(RemoteMessage message, string address)
+        => _handler.HandleRemoteMessage(message, address);
+}

--- a/src/Proto.Remote/Endpoints/ConnectionRunner.cs
+++ b/src/Proto.Remote/Endpoints/ConnectionRunner.cs
@@ -1,0 +1,270 @@
+namespace Proto.Remote;
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Proto.Extensions;
+
+public sealed class ConnectionRunner
+{
+    private readonly string _address;
+    private readonly IEndpoint _endpoint;
+    private readonly TimeSpan _backoff;
+    private readonly int _maxRetries;
+    private readonly IConnectionMode _mode;
+    private readonly Random _random;
+    private readonly RemoteConfig _remoteConfig;
+    private readonly ActorSystem _system;
+    private readonly CancellationToken _stopToken;
+    private readonly Action _onConnected;
+    private readonly Action _onDisconnected;
+    private readonly Action<double> _recordWriteDuration;
+    private readonly Action<string> _logInfo;
+    private readonly Action<string> _logDebug;
+    private readonly Action<string> _logWarning;
+    private readonly Action<Exception, string> _logError;
+
+    public ConnectionRunner(string address, IEndpoint endpoint, ActorSystem system, RemoteConfig remoteConfig,
+        IConnectionMode mode, TimeSpan backoff, int maxRetries, Random random, CancellationToken stopToken,
+        Action onConnected, Action onDisconnected, Action<double> recordWriteDuration,
+        Action<string> logInfo, Action<string> logDebug, Action<string> logWarning,
+        Action<Exception, string> logError)
+    {
+        _address = address;
+        _endpoint = endpoint;
+        _system = system;
+        _remoteConfig = remoteConfig;
+        _mode = mode;
+        _backoff = backoff;
+        _maxRetries = maxRetries;
+        _random = random;
+        _stopToken = stopToken;
+        _onConnected = onConnected;
+        _onDisconnected = onDisconnected;
+        _recordWriteDuration = recordWriteDuration;
+        _logInfo = logInfo;
+        _logDebug = logDebug;
+        _logWarning = logWarning;
+        _logError = logError;
+    }
+
+    public async Task RunAsync()
+    {
+        string? actorSystemId = null;
+        var rs = new RestartStatistics(0, null);
+
+        while (!_stopToken.IsCancellationRequested)
+        {
+            var cts = new CancellationTokenSource();
+            try
+            {
+                _logInfo($"[ServerConnector][{_system.Address}] Connecting to {_address}");
+
+                var addressWithProtocol = $"{(_remoteConfig.UseHttps ? "https://" : "http://")}{_address}";
+                var channel = GrpcChannel.ForAddress(addressWithProtocol, _remoteConfig.ChannelOptions);
+                var client = new Remoting.RemotingClient(channel);
+                using var call = client.Receive(_remoteConfig.CallOptions);
+
+                _onConnected();
+
+                await _mode.SendConnectRequest(_system, _remoteConfig, call).ConfigureAwait(false);
+
+                await call.ResponseStream.MoveNext().ConfigureAwait(false);
+                var response = call.ResponseStream.Current;
+                if (response?.MessageTypeCase != RemoteMessage.MessageTypeOneofCase.ConnectResponse)
+                {
+                    throw new Exception("Expected ConnectResponse");
+                }
+
+                var connectResponse = response.ConnectResponse;
+                if (connectResponse.Blocked)
+                {
+                    _logError(new Exception("Blocked"), $"[ServerConnector][{_system.Address}] Connection Refused to remote member {connectResponse.MemberId} address {_address}, we are blocked");
+                    _system.Remote().BlockList.Block(new[] { _system.Id }, "Blocked by remote member");
+                    var terminated = new EndpointTerminatedEvent(false, _address, _system.Id);
+                    _system.EventStream.Publish(terminated);
+                    return;
+                }
+
+                actorSystemId = connectResponse.MemberId;
+                if (_system.Remote().BlockList.IsBlocked(actorSystemId))
+                {
+                    _logError(new Exception("Blocked"), $"[ServerConnector][{_system.Address}] Connection Refused to remote member {connectResponse.MemberId} address {_address}, they are blocked");
+                    var terminated = new EndpointTerminatedEvent(false, _address, _system.Id);
+                    _system.EventStream.Publish(terminated);
+                    return;
+                }
+
+                rs.Reset();
+
+                var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(_stopToken, cts.Token).Token;
+
+                var writer = StartWriter(combinedToken, call, cts);
+                var reader = StartReader(combinedToken, call, actorSystemId, cts);
+
+                _logInfo($"[ServerConnector][{_system.Address}] Connected to {_address}");
+
+                await writer.ConfigureAwait(false);
+                cts.Cancel();
+                await call.RequestStream.CompleteAsync().ConfigureAwait(false);
+                await reader.ConfigureAwait(false);
+
+                _onDisconnected();
+                _logInfo($"[ServerConnector][{_system.Address}] Disconnected from {_address}");
+            }
+            catch (Exception e)
+            {
+                e.CheckFailFast();
+
+                if (actorSystemId is not null && _system.Remote().BlockList.IsBlocked(actorSystemId))
+                {
+                    _logDebug($"[ServerConnector][{_system.Address}] dropped connection to blocked member {actorSystemId}/{_address}");
+                    var terminated = new EndpointTerminatedEvent(true, _address, actorSystemId);
+                    _system.EventStream.Publish(terminated);
+                    break;
+                }
+
+                if (ShouldStop(rs))
+                {
+                    if (e is RpcException { StatusCode: StatusCode.Unavailable })
+                    {
+                        _logInfo($"[ServerConnector][{_system.Address}] Stopping connection to {_address} after retries expired because the endpoint is unavailable");
+                    }
+                    else
+                    {
+                        _logError(e, $"[ServerConnector][{_system.Address}] Stopping connection to {_address} after retries expired because of {e.GetType().Name}");
+                    }
+
+                    var terminated = new EndpointTerminatedEvent(true, _address, actorSystemId);
+                    _system.EventStream.Publish(terminated);
+                    break;
+                }
+
+                var backoff = rs.FailureCount * (int)_backoff.TotalMilliseconds;
+                var noise = _random.Next(500);
+                var duration = TimeSpan.FromMilliseconds(backoff + noise);
+                await Task.Delay(duration).ConfigureAwait(false);
+                _logWarning($"[ServerConnector][{_system.Address}] Restarting endpoint connection to {_address} after {duration} because of {e.GetType().Name} ({rs.FailureCount} / {_maxRetries})");
+            }
+            finally
+            {
+                cts.Cancel();
+            }
+        }
+    }
+
+    private Task StartWriter(CancellationToken token, AsyncDuplexStreamingCall<RemoteMessage, RemoteMessage> call, CancellationTokenSource cts)
+    {
+        return Task.Run(async () =>
+        {
+            while (!token.IsCancellationRequested)
+            {
+                while (_endpoint.OutgoingStash.TryPop(out var messages))
+                {
+                    var batch = MessageBatchFactory.CreateBatch(_system, _remoteConfig, messages);
+                    try
+                    {
+                        var sw = Stopwatch.StartNew();
+                        await call.RequestStream.WriteAsync(new RemoteMessage { MessageBatch = batch }, token).ConfigureAwait(false);
+                        sw.Stop();
+                        _recordWriteDuration(sw.Elapsed.TotalSeconds);
+                    }
+                    catch (Exception)
+                    {
+                        _ = _endpoint.OutgoingStash.Append(messages);
+                        cts.Cancel();
+                        throw;
+                    }
+                }
+
+                try
+                {
+                    await foreach (var messages in _endpoint.Outgoing.Reader.ReadAllAsync(token).ConfigureAwait(false))
+                    {
+                        var batch = MessageBatchFactory.CreateBatch(_system, _remoteConfig, messages);
+                        try
+                        {
+                            var sw = Stopwatch.StartNew();
+                            await call.RequestStream.WriteAsync(new RemoteMessage { MessageBatch = batch }, token).ConfigureAwait(false);
+                            sw.Stop();
+                            _recordWriteDuration(sw.Elapsed.TotalSeconds);
+                        }
+                        catch (Exception)
+                        {
+                            _ = _endpoint.OutgoingStash.Append(messages);
+                            cts.Cancel();
+                            throw;
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    _logDebug($"[ServerConnector][{_system.Address}] Writer cancelled for {_address}");
+                }
+            }
+        });
+    }
+
+    private Task StartReader(CancellationToken token, AsyncDuplexStreamingCall<RemoteMessage, RemoteMessage> call, string actorSystemId, CancellationTokenSource cts)
+    {
+        return Task.Run(async () =>
+        {
+            try
+            {
+                while (await call.ResponseStream.MoveNext(token).ConfigureAwait(false))
+                {
+                    var currentMessage = call.ResponseStream.Current;
+                    switch (currentMessage.MessageTypeCase)
+                    {
+                        case RemoteMessage.MessageTypeOneofCase.DisconnectRequest:
+                            _logDebug($"[ServerConnector][{_system.Address}] Received disconnection request from {_address}");
+                            var terminated = new EndpointTerminatedEvent(false, _address, actorSystemId);
+                            _system.EventStream.Publish(terminated);
+                            break;
+                        default:
+                            _mode.HandleMessage(currentMessage, _address);
+                            break;
+                    }
+                }
+
+                _logDebug($"[ServerConnector][{_system.Address}] Reader finished for {_address}");
+            }
+            catch (OperationCanceledException)
+            {
+                _logDebug($"[ServerConnector][{_system.Address}] Reader cancelled for {_address}");
+            }
+            catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
+            {
+                _logWarning($"[ServerConnector][{_system.Address}] Reader cancelled for {_address}");
+            }
+            catch (Exception e)
+            {
+                _logWarning($"[ServerConnector][{_system.Address}] Error in reader for {_address} {e.GetType().Name}");
+                cts.Cancel();
+                throw;
+            }
+        });
+    }
+
+    private bool ShouldStop(RestartStatistics rs)
+    {
+        if (_maxRetries == 0)
+        {
+            return true;
+        }
+
+        rs.Fail();
+
+        if (rs.FailureCount > _maxRetries)
+        {
+            rs.Reset();
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Proto.Remote/Endpoints/IConnectionMode.cs
+++ b/src/Proto.Remote/Endpoints/IConnectionMode.cs
@@ -1,0 +1,10 @@
+namespace Proto.Remote;
+
+using System.Threading.Tasks;
+using Grpc.Core;
+
+public interface IConnectionMode
+{
+    Task SendConnectRequest(ActorSystem system, RemoteConfig remoteConfig, AsyncDuplexStreamingCall<RemoteMessage, RemoteMessage> call);
+    void HandleMessage(RemoteMessage message, string address);
+}

--- a/src/Proto.Remote/Endpoints/ServerConnectionMode.cs
+++ b/src/Proto.Remote/Endpoints/ServerConnectionMode.cs
@@ -1,0 +1,30 @@
+namespace Proto.Remote;
+
+using System;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+public sealed class ServerConnectionMode : IConnectionMode
+{
+    private readonly Action<RemoteMessage, string> _onUnexpectedMessage;
+
+    public ServerConnectionMode(Action<RemoteMessage, string> onUnexpectedMessage)
+        => _onUnexpectedMessage = onUnexpectedMessage;
+
+    public Task SendConnectRequest(ActorSystem system, RemoteConfig remoteConfig, AsyncDuplexStreamingCall<RemoteMessage, RemoteMessage> call)
+        => call.RequestStream.WriteAsync(new RemoteMessage
+        {
+            ConnectRequest = new ConnectRequest
+            {
+                ServerConnection = new ServerConnection
+                {
+                    Address = system.Address,
+                    MemberId = system.Id,
+                    BlockList = { system.Remote().BlockList.BlockedMembers }
+                }
+            }
+        });
+
+    public void HandleMessage(RemoteMessage message, string address)
+        => _onUnexpectedMessage(message, address);
+}

--- a/src/Proto.Remote/Endpoints/ServerConnector.cs
+++ b/src/Proto.Remote/Endpoints/ServerConnector.cs
@@ -6,12 +6,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Grpc.Core;
-using Grpc.Net.Client;
 using Microsoft.Extensions.Logging;
 using Proto.Remote.Metrics;
 
@@ -26,17 +22,10 @@ public sealed class ServerConnector
     }
 
     private readonly string _address;
-    private readonly TimeSpan _backoff;
-    private readonly Type _connectorType;
     private readonly CancellationTokenSource _cts = new();
     private readonly IEndpoint _endpoint;
-
     private readonly ILogger _logger = Log.CreateLogger<ServerConnector>();
-    private readonly int _maxNrOfRetries;
     private readonly KeyValuePair<string, object?>[] _metricTags = Array.Empty<KeyValuePair<string, object?>>();
-    private readonly Random _random = new();
-    private readonly RemoteConfig _remoteConfig;
-    private readonly RemoteMessageHandler _remoteMessageHandler;
     private readonly Task _runner;
     private readonly ActorSystem _system;
 
@@ -44,361 +33,61 @@ public sealed class ServerConnector
         ActorSystem system, RemoteConfig remoteConfig, RemoteMessageHandler remoteMessageHandler)
     {
         _system = system;
-        _remoteConfig = remoteConfig;
-        _remoteMessageHandler = remoteMessageHandler;
         _address = address;
-        _connectorType = connectorType;
         _endpoint = endpoint;
-        _maxNrOfRetries = remoteConfig.EndpointWriterOptions.MaxRetries;
-        _backoff = remoteConfig.EndpointWriterOptions.RetryBackOff;
-        _runner = Task.Run(RunAsync);
 
         if (_system.Metrics.Enabled)
         {
             _metricTags = new KeyValuePair<string, object?>[]
-                { new("id", _system.Id), new("address", _system.Address) };
+            {
+                new("id", _system.Id),
+                new("address", _system.Address)
+            };
         }
+
+        IConnectionMode mode = connectorType switch
+        {
+            Type.ServerSide => new ServerConnectionMode((msg, addr) =>
+                _logger.LogWarning("[ServerConnector][{SystemAddress}] Received {MessagePayload} from {Address}",
+                    _system.Address, msg, addr)),
+            Type.ClientSide => new ClientConnectionMode(remoteMessageHandler),
+            _ => throw new ArgumentOutOfRangeException(nameof(connectorType), connectorType, null)
+        };
+
+        Action onConnected = _system.Metrics.Enabled
+            ? () => RemoteMetrics.RemoteEndpointConnectedCount.Add(1,
+                new KeyValuePair<string, object?>("id", _system.Id),
+                new KeyValuePair<string, object?>("address", _system.Address),
+                new KeyValuePair<string, object?>("destinationaddress", _address))
+            : () => { };
+
+        Action onDisconnected = _system.Metrics.Enabled
+            ? () => RemoteMetrics.RemoteEndpointDisconnectedCount.Add(1, _metricTags)
+            : () => { };
+
+        Action<double> recordWrite = _system.Metrics.Enabled
+            ? s => RemoteMetrics.RemoteWriteDuration.Record(s, _metricTags)
+            : _ => { };
+
+        var runner = new ConnectionRunner(_address, _endpoint, _system, remoteConfig, mode,
+            remoteConfig.EndpointWriterOptions.RetryBackOff,
+            remoteConfig.EndpointWriterOptions.MaxRetries,
+            new Random(),
+            _cts.Token,
+            onConnected,
+            onDisconnected,
+            recordWrite,
+            msg => _logger.LogInformation(msg),
+            msg => _logger.LogDebug(msg),
+            msg => _logger.LogWarning(msg),
+            (ex, msg) => _logger.LogError(ex, msg));
+
+        _runner = Task.Run(runner.RunAsync);
     }
 
     public async Task Stop()
     {
         _cts.Cancel();
         await _runner.ConfigureAwait(false);
-    }
-
-    private async Task RunAsync()
-    {
-        string? actorSystemId = null;
-        var rs = new RestartStatistics(0, null);
-
-        while (!_cts.IsCancellationRequested)
-        {
-            var cancellationTokenSource = new CancellationTokenSource();
-            try
-            {
-                _logger.LogInformation("[ServerConnector][{SystemAddress}] Connecting to {Address}", _system.Address,
-                    _address);
-
-                var addressWithProtocol =
-                    $"{(_remoteConfig.UseHttps ? "https://" : "http://")}{_address}";
-                var channel = GrpcChannel.ForAddress(addressWithProtocol, _remoteConfig.ChannelOptions);
-                var client = new Remoting.RemotingClient(channel);
-                using var call = client.Receive(_remoteConfig.CallOptions);
-
-                if (_system.Metrics.Enabled)
-                {
-                    RemoteMetrics.RemoteEndpointConnectedCount
-                        .Add(1, new KeyValuePair<string, object?>("id", _system.Id),
-                            new KeyValuePair<string, object?>("address", _system.Address),
-                            new KeyValuePair<string, object?>("destinationaddress", _address));
-                }
-
-                switch (_connectorType)
-                {
-                    case Type.ServerSide:
-                        await call.RequestStream.WriteAsync(new RemoteMessage
-                            {
-                                ConnectRequest = new ConnectRequest
-                                {
-                                    ServerConnection = new ServerConnection
-                                    {
-                                        Address = _system.Address,
-                                        MemberId = _system.Id,
-                                        BlockList = { _system.Remote().BlockList.BlockedMembers }
-                                    }
-                                }
-                            })
-                            .ConfigureAwait(false);
-
-                        break;
-                    case Type.ClientSide:
-                        await call.RequestStream.WriteAsync(new RemoteMessage
-                            {
-                                ConnectRequest = new ConnectRequest
-                                {
-                                    ClientConnection = new ClientConnection
-                                    {
-                                        MemberId = _system.Id
-                                    }
-                                }
-                            })
-                            .ConfigureAwait(false);
-
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-
-                await call.ResponseStream.MoveNext().ConfigureAwait(false);
-                var response = call.ResponseStream.Current;
-
-                if (response?.MessageTypeCase != RemoteMessage.MessageTypeOneofCase.ConnectResponse)
-                {
-                    throw new Exception("Expected ConnectResponse");
-                }
-
-                var connectResponse = response.ConnectResponse;
-
-                if (connectResponse.Blocked)
-                {
-                    _logger.LogError(
-                        "[ServerConnector][{SystemAddress}] Connection Refused to remote member {MemberId} address {Address}, we are blocked",
-                        _system.Address, connectResponse.MemberId, _address);
-
-                    //block self
-                    _system.Remote().BlockList.Block(new[] { _system.Id }, "Blocked by remote member");
-                    var terminated = new EndpointTerminatedEvent(false, _address, _system.Id);
-                    _system.EventStream.Publish(terminated);
-
-                    return;
-                }
-
-                actorSystemId = connectResponse.MemberId;
-
-                if (_system.Remote().BlockList.IsBlocked(actorSystemId))
-                {
-                    _logger.LogError(
-                        "[ServerConnector][{SystemAddress}] Connection Refused to remote member {MemberId} address {Address}, they are blocked",
-                        _system.Address, connectResponse.MemberId, _address);
-
-                    var terminated = new EndpointTerminatedEvent(false, _address, _system.Id);
-                    _system.EventStream.Publish(terminated);
-
-                    return;
-                }
-
-                rs.Reset();
-
-                var combinedToken = CancellationTokenSource
-                    .CreateLinkedTokenSource(_cts.Token, cancellationTokenSource.Token)
-                    .Token;
-
-                var writer = StartWriter(combinedToken, call, cancellationTokenSource);
-
-                var reader = StartReader(combinedToken, call, actorSystemId, cancellationTokenSource);
-
-                _logger.LogInformation("[ServerConnector][{SystemAddress}] Connected to {Address}", _system.Address,
-                    _address);
-
-                await writer.ConfigureAwait(false);
-                cancellationTokenSource.Cancel();
-                await call.RequestStream.CompleteAsync().ConfigureAwait(false);
-                await reader.ConfigureAwait(false);
-
-                if (_system.Metrics.Enabled)
-                {
-                    RemoteMetrics.RemoteEndpointDisconnectedCount.Add(1, _metricTags);
-                }
-
-                _logger.LogInformation("[ServerConnector][{SystemAddress}] Disconnected from {Address}",
-                    _system.Address, _address);
-            }
-            catch (Exception e)
-            {
-                e.CheckFailFast();
-
-                if (actorSystemId is not null && _system.Remote().BlockList.IsBlocked(actorSystemId))
-                {
-                    _logger.LogDebug(
-                        "[ServerConnector][{SystemAddress}] dropped connection to blocked member {ActorSystemId}/{Address}",
-                        _system.Address, actorSystemId, _address);
-
-                    var terminated = new EndpointTerminatedEvent(true, _address, actorSystemId);
-                    _system.EventStream.Publish(terminated);
-
-                    break;
-                }
-
-                if (ShouldStop(rs))
-                {
-                    if (e is RpcException { StatusCode: StatusCode.Unavailable })
-                    {
-                        _logger.LogInformation(
-                            "[ServerConnector][{SystemAddress}] Stopping connection to {Address} after retries expired because the endpoint is unavailable",
-                            _system.Address, _address);
-                    }
-                    else
-                    {
-                        _logger.LogError(e,
-                            "[ServerConnector][{SystemAddress}] Stopping connection to {Address} after retries expired because of {Reason}",
-                            _system.Address, _address, e.GetType().Name);
-                    }
-
-                    var terminated = new EndpointTerminatedEvent(true, _address, actorSystemId);
-                    _system.EventStream.Publish(terminated);
-
-                    break;
-                }
-
-                var backoff = rs.FailureCount * (int)_backoff.TotalMilliseconds;
-                var noise = _random.Next(500);
-                var duration = TimeSpan.FromMilliseconds(backoff + noise);
-                // Exponential backoff before attempting to reconnect to the remote endpoint
-                await Task.Delay(duration).ConfigureAwait(false);
-
-                _logger.LogWarning(
-                    "[ServerConnector][{SystemAddress}] Restarting endpoint connection to {Address} after {Duration} because of {Reason} ({Retries} / {MaxRetries})",
-                    _system.Address, _address, duration, e.GetType().Name, rs.FailureCount, _maxNrOfRetries);
-            }
-            finally
-            {
-                // always cancel the token for this writer/reader, otherwise their loops can continue
-                // running indefinitely, depending on how we got here. the call does get disposed via
-                // a using above, but we want to be certain these loops don't continue running, especially
-                // since these can build up when there are multiple reconnect attempts
-                cancellationTokenSource.Cancel();
-            }
-        }
-    }
-
-    private Task StartWriter(CancellationToken combinedToken, AsyncDuplexStreamingCall<RemoteMessage, RemoteMessage> call, CancellationTokenSource cancellationTokenSource)
-    {
-        return Task.Run(async () =>
-        {
-            while (!combinedToken.IsCancellationRequested)
-            {
-                while (_endpoint.OutgoingStash.TryPop(out var messages))
-                {
-                    var batch = MessageBatchFactory.CreateBatch(_system, _remoteConfig, messages);
-
-                    try
-                    {
-                        await call.RequestStream.WriteAsync(new RemoteMessage { MessageBatch = batch }, combinedToken)
-                            .ConfigureAwait(false);
-                    }
-                    catch (Exception)
-                    {
-                        _ = _endpoint.OutgoingStash.Append(messages);
-                        cancellationTokenSource.Cancel();
-
-                        throw;
-                    }
-                }
-
-                try
-                {
-                    await foreach (var messages in _endpoint.Outgoing.Reader.ReadAllAsync(combinedToken)
-                                       .ConfigureAwait(false))
-                    {
-                        var batch = MessageBatchFactory.CreateBatch(_system, _remoteConfig, messages);
-
-                        try
-                        {
-                            if (_system.Metrics.Enabled)
-                            {
-                                var sw = Stopwatch.StartNew();
-                                await call.RequestStream
-                                    .WriteAsync(new RemoteMessage { MessageBatch = batch }, combinedToken)
-                                    .ConfigureAwait(false);
-                                sw.Stop();
-                                RemoteMetrics.RemoteWriteDuration.Record(sw.Elapsed.TotalSeconds, _metricTags);
-                            }
-                            else
-                            {
-                                await call.RequestStream
-                                    .WriteAsync(new RemoteMessage { MessageBatch = batch }, combinedToken)
-                                    .ConfigureAwait(false);
-                            }
-                        }
-                        catch (Exception)
-                        {
-                            _ = _endpoint.OutgoingStash.Append(messages);
-                            cancellationTokenSource.Cancel();
-
-                            throw;
-                        }
-                    }
-                }
-                catch (OperationCanceledException)
-                {
-                    _logger.LogDebug("[ServerConnector][{SystemAddress}] Writer cancelled for {Address}",
-                        _system.Address, _address);
-                }
-            }
-        });
-    }
-
-    private Task StartReader(CancellationToken combinedToken, AsyncDuplexStreamingCall<RemoteMessage, RemoteMessage> call, string actorSystemId, CancellationTokenSource cancellationTokenSource)
-    {
-        return Task.Run(async () =>
-        {
-            try
-            {
-                while (await call.ResponseStream.MoveNext(combinedToken).ConfigureAwait(false))
-                {
-                    // if (_endpoint.CancellationToken.IsCancellationRequested) continue;
-                    var currentMessage = call.ResponseStream.Current;
-
-                    switch (currentMessage.MessageTypeCase)
-                    {
-                        case RemoteMessage.MessageTypeOneofCase.DisconnectRequest:
-                        {
-                            _logger.LogDebug(
-                                "[ServerConnector][{SystemAddress}] Received disconnection request from {Address}",
-                                _system.Address, _address);
-
-                            var terminated = new EndpointTerminatedEvent(false, _address, actorSystemId);
-                            _system.EventStream.Publish(terminated);
-
-                            break;
-                        }
-                        default:
-                            if (_connectorType == Type.ServerSide)
-                            {
-                                _logger.LogWarning(
-                                    "[ServerConnector][{SystemAddress}] Received {MessagePayload} from {Addres}",
-                                    _system.Address, currentMessage, _address);
-                            }
-                            else
-                            {
-                                _remoteMessageHandler.HandleRemoteMessage(currentMessage, _address);
-                            }
-
-                            break;
-                    }
-                }
-
-                _logger.LogDebug("[ServerConnector][{SystemAddress}] Reader finished for {Address}",
-                    _system.Address, _address);
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.LogDebug("[ServerConnector][{SystemAddress}] Reader cancelled for {Address}",
-                    _system.Address, _address);
-            }
-            catch (RpcException e) when (e.StatusCode == StatusCode.Cancelled)
-            {
-                _logger.LogWarning("[ServerConnector][{SystemAddress}] Reader cancelled for {Address}",
-                    _system.Address, _address);
-            }
-            catch (Exception e)
-            {
-                _logger.LogWarning("[ServerConnector][{SystemAddress}] Error in reader for {Address} {Reason}",
-                    _system.Address, _address, e.GetType().Name);
-
-                cancellationTokenSource.Cancel();
-
-                throw;
-            }
-        });
-    }
-
-    private bool ShouldStop(RestartStatistics rs)
-    {
-        if (_maxNrOfRetries == 0)
-        {
-            return true;
-        }
-
-        rs.Fail();
-
-        if (rs.FailureCount > _maxNrOfRetries)
-        {
-            rs.Reset();
-
-            return true;
-        }
-
-        return false;
     }
 }


### PR DESCRIPTION
## Summary
- extract connection lifecycle into ConnectionRunner
- introduce IConnectionMode strategies for server and client
- decouple metrics via delegates in ServerConnector

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj` *(fails: Proto.Mailbox.Tests.MailboxSchedulingTests.GivenNonCompletedUserMessage_ShouldHaltProcessingUntilCompletion)*
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ac4a6f9dfc83289cda5ece0c4acab4