### PR TITLE
Fix StopActorWithLongRunningTask test race

### DIFF
--- a/logs/exceptions.md
+++ b/logs/exceptions.md
@@ -31,3 +31,6 @@
 `System.InvalidOperationException: Sequence contains no elements` in `SupervisionTests_OneForOne.cs:line 263`.
 ### Proto.Mailbox.Tests.MailboxSchedulingTests.GivenNonCompletedUserMessage_ShouldHaltProcessingUntilCompletion
 `System.TimeoutException: The condition was not met within the timeout of 00:00:00.1000000`
+
+### Proto.Tests.ActorTests.StopActorWithLongRunningTask
+`Proto.TestKit.TestKitException: Expected user message of type System.Threading.Tasks.TaskCanceledException, but received system message of type Proto.Stopping`

--- a/logs/log1756123592.md
+++ b/logs/log1756123592.md
@@ -1,0 +1,5 @@
+# Log
+- Investigated failing test `StopActorWithLongRunningTask`.
+- The actor was stopped before it began processing the user message, so `TaskCanceledException` was never sent.
+- Added a handshake message to confirm processing started before stopping, ensuring cancellation is observed.
+- Updated test accordingly and confirmed `Proto.Actor.Tests`, `Proto.Remote.Tests`, and `Proto.Cluster.Tests` pass.

--- a/tests/Proto.Actor.Tests/ActorTests.cs
+++ b/tests/Proto.Actor.Tests/ActorTests.cs
@@ -253,6 +253,8 @@ public class ActorTests
             {
                 if (ctx.Message is string)
                 {
+                    // Signal that processing has started so the test can safely stop the actor
+                    ctx.Send(probePid, "processing");
                     try
                     {
                         // Simulate long-running work that should be cancellable
@@ -270,6 +272,7 @@ public class ActorTests
 
         context.Send(pid, "hello");
         await probe.ExpectNextSystemMessageAsync<Started>();
+        await probe.ExpectNextUserMessageAsync<string>(s => s == "processing");
         await context.StopAsync(pid);
         await probe.ExpectNextUserMessageAsync<TaskCanceledException>();
         await probe.ExpectNextUserMessageAsync<string>(s => s == "hello");


### PR DESCRIPTION
## Summary
- ensure actor signals work start before stopping to avoid race
- record test failure in logs

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj -c Release`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj -c Release`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68ac502f86a48328955c507ba78f8938