### PR TITLE
Clarify remote endpoint type names

### DIFF
--- a/EVENTSTREAM_EVENTS.md
+++ b/EVENTSTREAM_EVENTS.md
@@ -14,7 +14,7 @@ components subscribe to it.
 ## EndpointTerminatedEvent
 - **Published by:**
   - `ServerConnector` when a remote connection is refused or fails ([src/Proto.Remote/Endpoints/ServerConnector.cs](src/Proto.Remote/Endpoints/ServerConnector.cs#L141-L166) and [src/Proto.Remote/Endpoints/ServerConnector.cs](src/Proto.Remote/Endpoints/ServerConnector.cs#L199-L229))
-  - `EndpointReader` when a channel closes ([src/Proto.Remote/Endpoints/EndpointReader.cs](src/Proto.Remote/Endpoints/EndpointReader.cs#L238-L241))
+  - `RemotingGrpcService` when a channel closes ([src/Proto.Remote/Endpoints/RemotingGrpcService.cs](src/Proto.Remote/Endpoints/RemotingGrpcService.cs#L228-L229))
   - `MemberList` when a cluster member leaves ([src/Proto.Cluster/Membership/MemberList.cs](src/Proto.Cluster/Membership/MemberList.cs#L355-L365))
 - **Subscribed by:** `EndpointManager` which disposes the endpoint and optionally
   blocks the address or system ID ([src/Proto.Remote/Endpoints/EndpointManager.cs](src/Proto.Remote/Endpoints/EndpointManager.cs#L25-L44) and [src/Proto.Remote/Endpoints/EndpointManager.cs](src/Proto.Remote/Endpoints/EndpointManager.cs#L91-L110))

--- a/logs/log1756149439.md
+++ b/logs/log1756149439.md
@@ -1,0 +1,3 @@
+- Renamed core remote endpoint types for clarity and consistency: `IEndpoint`->`IRemoteEndpoint`, `Endpoint`->`RemoteEndpointBase`, `ServerEndpoint`->`ServerRemoteEndpoint`, `ServerSideClientEndpoint`->`ClientRemoteEndpoint`, and `EndpointReader`->`RemotingGrpcService`.
+- Updated all references in source, tests, and documentation, including gRPC registration and endpoint README.
+- Documented event source link and ensured compilation by running Proto.Actor, Proto.Remote, and Proto.Cluster test suites.

--- a/src/Proto.Remote/Endpoints/BlockedEndpoint.cs
+++ b/src/Proto.Remote/Endpoints/BlockedEndpoint.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace Proto.Remote;
 
-public sealed class BlockedEndpoint : IEndpoint
+public sealed class BlockedEndpoint : IRemoteEndpoint
 {
     private readonly ActorSystem _system;
 

--- a/src/Proto.Remote/Endpoints/ClientRemoteEndpoint.cs
+++ b/src/Proto.Remote/Endpoints/ClientRemoteEndpoint.cs
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-//   <copyright file="ServerSideClientEndpoint.cs" company="Asynkron AB">
+//   <copyright file="ClientRemoteEndpoint.cs" company="Asynkron AB">
 //       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
@@ -9,9 +9,9 @@ namespace Proto.Remote;
 /// <summary>
 ///     Handles connection to a client actor system.
 /// </summary>
-public sealed class ServerSideClientEndpoint : Endpoint
+public sealed class ClientRemoteEndpoint : RemoteEndpointBase
 {
-    public ServerSideClientEndpoint(ActorSystem system, RemoteConfig remoteConfig, string remoteAddress) : base(
+    public ClientRemoteEndpoint(ActorSystem system, RemoteConfig remoteConfig, string remoteAddress) : base(
         remoteAddress, system, remoteConfig)
     {
     }

--- a/src/Proto.Remote/Endpoints/EndpointManager.cs
+++ b/src/Proto.Remote/Endpoints/EndpointManager.cs
@@ -22,12 +22,12 @@ public sealed class EndpointManager : IDiagnosticsProvider
     private static readonly ILogger Logger = Log.CreateLogger<EndpointManager>();
     private readonly ConcurrentDictionary<string, DateTime> _blockedAddresses = new();
     private readonly ConcurrentDictionary<string, DateTime> _blockedClientSystemIds = new();
-    private readonly IEndpoint _blockedEndpoint;
+    private readonly IRemoteEndpoint _blockedEndpoint;
     private readonly CancellationTokenSource _cancellationTokenSource = new();
-    private readonly ConcurrentDictionary<string, IEndpoint> _clientEndpoints = new();
+    private readonly ConcurrentDictionary<string, IRemoteEndpoint> _clientEndpoints = new();
     private readonly EventStreamSubscription<object>? _endpointTerminatedEvnSub;
     private readonly RemoteConfig _remoteConfig;
-    private readonly ConcurrentDictionary<string, IEndpoint> _serverEndpoints = new();
+    private readonly ConcurrentDictionary<string, IRemoteEndpoint> _serverEndpoints = new();
     private readonly object _synLock = new();
     private readonly ActorSystem _system;
 
@@ -94,7 +94,7 @@ public sealed class EndpointManager : IDiagnosticsProvider
         Action? unblock = null;
         try
         {
-            IEndpoint? endpoint = null;
+            IRemoteEndpoint? endpoint = null;
             lock (_synLock)
             {
                 if (_cancellationTokenSource.IsCancellationRequested)
@@ -148,7 +148,7 @@ public sealed class EndpointManager : IDiagnosticsProvider
         }
     }
 
-    internal IEndpoint GetOrAddServerEndpoint(string? address)
+    internal IRemoteEndpoint GetOrAddServerEndpoint(string? address)
     {
         if (address is null)
         {
@@ -183,24 +183,24 @@ public sealed class EndpointManager : IDiagnosticsProvider
             {
                 if (Logger.IsEnabled(LogLevel.Debug))
                 {
-                    Logger.LogDebug("[{SystemAddress}] Requesting new client side ServerEndpoint for {Address}",
+                    Logger.LogDebug("[{SystemAddress}] Requesting new client side ServerRemoteEndpoint for {Address}",
                         _system.Address, address);
                 }
 
                 endpoint = _serverEndpoints.GetOrAdd(address,
-                    v => new ServerEndpoint(_system, _remoteConfig, v,
+                    v => new ServerRemoteEndpoint(_system, _remoteConfig, v,
                         ServerConnector.Type.ClientSide, RemoteMessageHandler));
             }
             else
             {
                 if (Logger.IsEnabled(LogLevel.Debug))
                 {
-                    Logger.LogDebug("[{SystemAddress}] Requesting new server side ServerEndpoint for {Address}",
+                    Logger.LogDebug("[{SystemAddress}] Requesting new server side ServerRemoteEndpoint for {Address}",
                         _system.Address, address);
                 }
 
                 endpoint = _serverEndpoints.GetOrAdd(address,
-                    v => new ServerEndpoint(_system, _remoteConfig, v,
+                    v => new ServerRemoteEndpoint(_system, _remoteConfig, v,
                         ServerConnector.Type.ServerSide, RemoteMessageHandler));
             }
 
@@ -208,7 +208,7 @@ public sealed class EndpointManager : IDiagnosticsProvider
         }
     }
 
-    internal IEndpoint GetOrAddClientEndpoint(string systemId)
+    internal IRemoteEndpoint GetOrAddClientEndpoint(string systemId)
     {
         if (systemId is null)
         {
@@ -241,16 +241,16 @@ public sealed class EndpointManager : IDiagnosticsProvider
 
             if (Logger.IsEnabled(LogLevel.Debug))
             {
-                Logger.LogDebug("[{SystemAddress}] Requesting new ServerSideClientEndpoint for {SystemId}",
+                Logger.LogDebug("[{SystemAddress}] Requesting new ClientRemoteEndpoint for {SystemId}",
                     _system.Address, systemId);
             }
 
             return _clientEndpoints.GetOrAdd(systemId,
-                address => new ServerSideClientEndpoint(_system, _remoteConfig, address));
+                address => new ClientRemoteEndpoint(_system, _remoteConfig, address));
         }
     }
 
-    internal IEndpoint GetServerEndpoint(string address)
+    internal IRemoteEndpoint GetServerEndpoint(string address)
     {
         if (_cancellationTokenSource.IsCancellationRequested || _blockedAddresses.ContainsKey(address))
         {
@@ -265,7 +265,7 @@ public sealed class EndpointManager : IDiagnosticsProvider
         return _blockedEndpoint;
     }
 
-    internal IEndpoint GetClientEndpoint(string systemId)
+    internal IRemoteEndpoint GetClientEndpoint(string systemId)
     {
         if (_cancellationTokenSource.IsCancellationRequested || _blockedClientSystemIds.ContainsKey(systemId))
         {

--- a/src/Proto.Remote/Endpoints/IRemoteEndpoint.cs
+++ b/src/Proto.Remote/Endpoints/IRemoteEndpoint.cs
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-//   <copyright file="IEndpoint.cs" company="Asynkron AB">
+//   <copyright file="IRemoteEndpoint.cs" company="Asynkron AB">
 //       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
@@ -10,7 +10,7 @@ using System.Threading.Channels;
 
 namespace Proto.Remote;
 
-public interface IEndpoint : IAsyncDisposable
+public interface IRemoteEndpoint : IAsyncDisposable
 {
     Channel<RemoteDeliver[]> Outgoing { get; }
     ConcurrentStack<RemoteDeliver[]> OutgoingStash { get; }

--- a/src/Proto.Remote/Endpoints/README.md
+++ b/src/Proto.Remote/Endpoints/README.md
@@ -6,21 +6,20 @@ Each type below plays a specific role in accepting connections, reading and writ
 ## Types
 
 ### Interfaces and Base Classes
-- **`IEndpoint`** – contract for endpoint implementations; exposes outgoing channels and lifecycle hooks for remote messaging.
-- **`Endpoint`** – abstract base implementing `IEndpoint`; queues outgoing messages, tracks watchers, and handles message delivery.
+- **`IRemoteEndpoint`** – contract for endpoint implementations; exposes outgoing channels and lifecycle hooks for remote messaging.
+- **`RemoteEndpointBase`** – abstract base implementing `IRemoteEndpoint`; queues outgoing messages, tracks watchers, and handles message delivery.
 
 ### Concrete Endpoints
-- **`ServerEndpoint`** – `Endpoint` with an associated `ServerConnector` used for connections to other servers.
-- **`ServerSideClientEndpoint`** – `Endpoint` representing a connection to a remote client actor system.
-- **`BlockedEndpoint`** – inert `IEndpoint` used when an address is temporarily blocked; replies with dead‑letter or termination notices.
+- **`ServerRemoteEndpoint`** – `RemoteEndpointBase` with an associated `ServerConnector` used for connections to other servers.
+- **`ClientRemoteEndpoint`** – `RemoteEndpointBase` representing a connection to a remote client actor system.
+- **`BlockedEndpoint`** – inert `IRemoteEndpoint` used when an address is temporarily blocked; replies with dead‑letter or termination notices.
 
-### Connection Management
-- **`EndpointManager`** – central registry creating, tracking, and disposing `IEndpoint` instances. Handles block lists and endpoint lifecycle events.
-- **`EndpointReader`** – gRPC service accepting incoming connections. Negotiates handshakes and starts per‑connection readers and writers.
+- **`EndpointManager`** – central registry creating, tracking, and disposing `IRemoteEndpoint` instances. Handles block lists and endpoint lifecycle events.
+- **`RemotingGrpcService`** – gRPC service accepting incoming connections. Negotiates handshakes and starts per‑connection readers and writers.
 - **`ServerConnector`** – sets up a `ConnectionRunner` for an address and chooses a `ClientConnectionMode` or `ServerConnectionMode`.
 - **`ConnectionRunner`** – drives a bidirectional gRPC stream: performs the handshake, spawns a `ConnectionWriter` and `ConnectionReader`, and handles reconnection backoff.
 - **`ConnectionReader`** – per‑connection task that processes incoming `RemoteMessage` instances using an `IConnectionMode`.
-- **`ConnectionWriter`** – per‑connection task that batches and sends outgoing messages from an `IEndpoint`.
+- **`ConnectionWriter`** – per‑connection task that batches and sends outgoing messages from an `IRemoteEndpoint`.
 - **`RemoteStreamProcessor`** – helper with shared logic for reading, writing, and disconnecting gRPC streams.
 
 ### Connection Modes
@@ -39,16 +38,16 @@ Each type below plays a specific role in accepting connections, reading and writ
 ## Relationships
 ```mermaid
 classDiagram
-    IEndpoint <|-- Endpoint
-    Endpoint <|-- ServerEndpoint
-    Endpoint <|-- ServerSideClientEndpoint
-    IEndpoint <|-- BlockedEndpoint
+    IRemoteEndpoint <|-- RemoteEndpointBase
+    RemoteEndpointBase <|-- ServerRemoteEndpoint
+    RemoteEndpointBase <|-- ClientRemoteEndpoint
+    IRemoteEndpoint <|-- BlockedEndpoint
 
-    EndpointManager --> IEndpoint
+    EndpointManager --> IRemoteEndpoint
     EndpointManager --> RemoteMessageHandler
-    EndpointReader --> EndpointManager
-    EndpointReader --> IEndpoint
-    ServerEndpoint --> ServerConnector
+    RemotingGrpcService --> EndpointManager
+    RemotingGrpcService --> IRemoteEndpoint
+    ServerRemoteEndpoint --> ServerConnector
     ServerConnector --> ConnectionRunner
     ConnectionRunner --> ConnectionReader
     ConnectionRunner --> ConnectionWriter
@@ -56,7 +55,7 @@ classDiagram
     IConnectionMode <|-- ClientConnectionMode
     IConnectionMode <|-- ServerConnectionMode
     ConnectionReader --> IConnectionMode
-    ConnectionWriter --> IEndpoint
+    ConnectionWriter --> IRemoteEndpoint
     RemoteMessageHandler --> EndpointManager
 ```
 

--- a/src/Proto.Remote/Endpoints/RemoteEndpointBase.cs
+++ b/src/Proto.Remote/Endpoints/RemoteEndpointBase.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-//   <copyright file="Endpoint.cs" company="Asynkron AB">
+//   <copyright file="RemoteEndpointBase.cs" company="Asynkron AB">
 //       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
@@ -16,12 +16,12 @@ using Proto.Extensions;
 
 namespace Proto.Remote;
 
-public abstract class Endpoint : IEndpoint
+public abstract class RemoteEndpointBase : IRemoteEndpoint
 {
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly LogLevel _deserializationErrorLogLevel;
 #pragma warning disable CS0618 // Type or member is obsolete
-    private readonly ILogger _logger = Log.CreateLogger<Endpoint>();
+    private readonly ILogger _logger = Log.CreateLogger<RemoteEndpointBase>();
 #pragma warning restore CS0618 // Type or member is obsolete
     private readonly Channel<RemoteDeliver> _remoteDelivers = Channel.CreateUnbounded<RemoteDeliver>();
     private readonly Channel<RemoteDeliver> _remotePriorityDelivers = Channel.CreateUnbounded<RemoteDeliver>();
@@ -32,7 +32,7 @@ public abstract class Endpoint : IEndpoint
     protected readonly RemoteConfig RemoteConfig;
     protected readonly ActorSystem System;
 
-    internal Endpoint(string remoteAddress, ActorSystem system, RemoteConfig remoteConfig)
+    internal RemoteEndpointBase(string remoteAddress, ActorSystem system, RemoteConfig remoteConfig)
     {
         RemoteAddress = remoteAddress;
         System = system;

--- a/src/Proto.Remote/Endpoints/RemotingGrpcService.cs
+++ b/src/Proto.Remote/Endpoints/RemotingGrpcService.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-//   <copyright file="EndpointReader.cs" company="Asynkron AB">
+//   <copyright file="RemotingGrpcService.cs" company="Asynkron AB">
 //       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
@@ -15,15 +15,15 @@ using Proto.Diagnostics;
 
 namespace Proto.Remote;
 
-public sealed class EndpointReader : Remoting.RemotingBase
+public sealed class RemotingGrpcService : Remoting.RemotingBase
 {
-    private static readonly ILogger Logger = Log.CreateLogger<EndpointReader>();
+    private static readonly ILogger Logger = Log.CreateLogger<RemotingGrpcService>();
     private readonly EndpointManager _endpointManager;
     private readonly ActorSystem _system;
 
-    private readonly record struct NegotiationResult(IEndpoint Endpoint, string SystemId, string? Address, bool StartWriter);
+    private readonly record struct NegotiationResult(IRemoteEndpoint Endpoint, string SystemId, string? Address, bool StartWriter);
 
-    public EndpointReader(ActorSystem system, EndpointManager endpointManager)
+    public RemotingGrpcService(ActorSystem system, EndpointManager endpointManager)
     {
         _system = system;
         _endpointManager = endpointManager;
@@ -38,7 +38,7 @@ public sealed class EndpointReader : Remoting.RemotingBase
         if (_endpointManager.CancellationToken.IsCancellationRequested)
         {
             Logger.LogWarning(
-                "[EndpointReader][{SystemAddress}] Attempt to connect to the suspended reader has been rejected",
+                "[RemotingGrpcService][{SystemAddress}] Attempt to connect to the suspended reader has been rejected",
                 _system.Address);
 
             throw new RpcException(Status.DefaultCancelled, "Suspended");
@@ -53,7 +53,7 @@ public sealed class EndpointReader : Remoting.RemotingBase
             }).ConfigureAwait(false))
         {
             Logger.LogInformation(
-                "[EndpointReader][{SystemAddress}] Accepted connection request from {Remote} to {Local}",
+                "[RemotingGrpcService][{SystemAddress}] Accepted connection request from {Remote} to {Local}",
                 _system.Address, context.Peer, context.Host
             );
 
@@ -105,7 +105,7 @@ public sealed class EndpointReader : Remoting.RemotingBase
         if (_system.Remote().BlockList.IsBlocked(clientConnection.MemberId))
         {
             Logger.LogWarning(
-                "[EndpointReader][{SystemAddress}] Attempt to connect from a blocked endpoint was rejected",
+                "[RemotingGrpcService][{SystemAddress}] Attempt to connect from a blocked endpoint was rejected",
                 _system.Address);
 
             await responseStream.WriteAsync(new RemoteMessage
@@ -143,7 +143,7 @@ public sealed class EndpointReader : Remoting.RemotingBase
         if (_system.Remote().BlockList.IsBlocked(serverConnection.MemberId))
         {
             Logger.LogWarning(
-                "[EndpointReader][{SystemAddress}] Connection Refused from remote member {MemberId} address {Address}, they are blocked",
+                "[RemotingGrpcService][{SystemAddress}] Connection Refused from remote member {MemberId} address {Address}, they are blocked",
                 _system.Address, serverConnection.MemberId,
                 serverConnection.Address);
 
@@ -162,7 +162,7 @@ public sealed class EndpointReader : Remoting.RemotingBase
         if (blocked.Contains(_system.Id))
         {
             Logger.LogWarning(
-                "[EndpointReader][{SystemAddress}] Connection Refused from remote member {MemberId} address {Address}, we are blocked",
+                "[RemotingGrpcService][{SystemAddress}] Connection Refused from remote member {MemberId} address {Address}, we are blocked",
                 _system.Address, serverConnection.MemberId,
                 serverConnection.Address);
 
@@ -193,7 +193,7 @@ public sealed class EndpointReader : Remoting.RemotingBase
         if (!endpoint.IsActive)
         {
             Logger.LogWarning(
-                "[EndpointReader][{SystemAddress}] Failed to connect back to remote member {MemberId} address {Address} for writes",
+                "[RemotingGrpcService][{SystemAddress}] Failed to connect back to remote member {MemberId} address {Address} for writes",
                 _system.Address, serverConnection.MemberId,
                 serverConnection.Address);
         }
@@ -231,7 +231,7 @@ public sealed class EndpointReader : Remoting.RemotingBase
     }
 
     private async Task RunClientWriter(IServerStreamWriter<RemoteMessage> responseStream,
-        CancellationTokenSource cancellationTokenSource, IEndpoint endpoint, string systemId)
+        CancellationTokenSource cancellationTokenSource, IRemoteEndpoint endpoint, string systemId)
     {
         try
         {
@@ -246,14 +246,14 @@ public sealed class EndpointReader : Remoting.RemotingBase
         }
         catch (OperationCanceledException)
         {
-            Logger.LogDebug("[EndpointReader][{SystemAddress}] Writer closed for {SystemId}", _system.Address,
+            Logger.LogDebug("[RemotingGrpcService][{SystemAddress}] Writer closed for {SystemId}", _system.Address,
                 systemId);
         }
         catch (Exception e)
         {
             e.CheckFailFast();
 
-            Logger.LogWarning(e, "[EndpointReader][{SystemAddress}] Writing error to {SystemId}", _system.Address,
+            Logger.LogWarning(e, "[RemotingGrpcService][{SystemAddress}] Writing error to {SystemId}", _system.Address,
                 systemId);
         }
     }

--- a/src/Proto.Remote/Endpoints/Runner/ConnectionRunner.cs
+++ b/src/Proto.Remote/Endpoints/Runner/ConnectionRunner.cs
@@ -11,7 +11,7 @@ using Proto.Extensions;
 public sealed class ConnectionRunner
 {
     private readonly string _address;
-    private readonly IEndpoint _endpoint;
+    private readonly IRemoteEndpoint _endpoint;
     private readonly TimeSpan _backoff;
     private readonly int _maxRetries;
     private readonly IConnectionMode _mode;
@@ -26,7 +26,7 @@ public sealed class ConnectionRunner
     private readonly ConnectionWriter _writer;
     private readonly ConnectionReader _reader;
 
-    public ConnectionRunner(string address, IEndpoint endpoint, ActorSystem system, RemoteConfig remoteConfig,
+    public ConnectionRunner(string address, IRemoteEndpoint endpoint, ActorSystem system, RemoteConfig remoteConfig,
         IConnectionMode mode, TimeSpan backoff, int maxRetries, Random random, CancellationToken stopToken,
         Action onConnected, Action onDisconnected, Action<double> recordWriteDuration, ILogger logger)
     {

--- a/src/Proto.Remote/Endpoints/Runner/ConnectionWriter.cs
+++ b/src/Proto.Remote/Endpoints/Runner/ConnectionWriter.cs
@@ -13,13 +13,13 @@ using Proto.Extensions;
 internal sealed class ConnectionWriter
 {
     private readonly string _address;
-    private readonly IEndpoint _endpoint;
+    private readonly IRemoteEndpoint _endpoint;
     private readonly RemoteConfig _remoteConfig;
     private readonly ActorSystem _system;
     private readonly Action<double> _recordWriteDuration;
     private readonly ILogger _logger;
 
-    public ConnectionWriter(string address, IEndpoint endpoint, ActorSystem system, RemoteConfig remoteConfig, Action<double> recordWriteDuration, ILogger logger)
+    public ConnectionWriter(string address, IRemoteEndpoint endpoint, ActorSystem system, RemoteConfig remoteConfig, Action<double> recordWriteDuration, ILogger logger)
     {
         _address = address;
         _endpoint = endpoint;

--- a/src/Proto.Remote/Endpoints/Runner/RemoteStreamProcessor.cs
+++ b/src/Proto.Remote/Endpoints/Runner/RemoteStreamProcessor.cs
@@ -41,7 +41,7 @@ internal static class RemoteStreamProcessor
     /// Writes outgoing message batches for an endpoint to the provided stream writer.
     /// </summary>
     public static async Task RunWriterAsync(
-        IEndpoint endpoint,
+        IRemoteEndpoint endpoint,
         ActorSystem system,
         RemoteConfig remoteConfig,
         Func<RemoteMessage, CancellationToken, Task> write,

--- a/src/Proto.Remote/Endpoints/ServerConnector.cs
+++ b/src/Proto.Remote/Endpoints/ServerConnector.cs
@@ -23,13 +23,13 @@ public sealed class ServerConnector
 
     private readonly string _address;
     private readonly CancellationTokenSource _cts = new();
-    private readonly IEndpoint _endpoint;
+    private readonly IRemoteEndpoint _endpoint;
     private readonly ILogger _logger = Log.CreateLogger<ServerConnector>();
     private readonly KeyValuePair<string, object?>[] _metricTags = Array.Empty<KeyValuePair<string, object?>>();
     private readonly Task _runner;
     private readonly ActorSystem _system;
 
-    public ServerConnector(string address, Type connectorType, IEndpoint endpoint,
+    public ServerConnector(string address, Type connectorType, IRemoteEndpoint endpoint,
         ActorSystem system, RemoteConfig remoteConfig, RemoteMessageHandler remoteMessageHandler)
     {
         _system = system;

--- a/src/Proto.Remote/Endpoints/ServerRemoteEndpoint.cs
+++ b/src/Proto.Remote/Endpoints/ServerRemoteEndpoint.cs
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-//   <copyright file="ServerEndpoint.cs" company="Asynkron AB">
+//   <copyright file="ServerRemoteEndpoint.cs" company="Asynkron AB">
 //       Copyright (C) 2015-2025 Asynkron AB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
@@ -12,15 +12,15 @@ namespace Proto.Remote;
 /// <summary>
 ///     Handles a connection to a remote endpoint.
 /// </summary>
-    public sealed class ServerEndpoint : Endpoint
+public sealed class ServerRemoteEndpoint : RemoteEndpointBase
+{
+    public ServerRemoteEndpoint(ActorSystem system, RemoteConfig remoteConfig, string remoteAddress,
+        ServerConnector.Type type, RemoteMessageHandler remoteMessageHandler) : base(remoteAddress, system, remoteConfig)
     {
-        public ServerEndpoint(ActorSystem system, RemoteConfig remoteConfig, string remoteAddress,
-            ServerConnector.Type type, RemoteMessageHandler remoteMessageHandler) : base(remoteAddress, system, remoteConfig)
-        {
-            Connector = new ServerConnector(RemoteAddress, type, this, System, remoteConfig, remoteMessageHandler);
-        }
+        Connector = new ServerConnector(RemoteAddress, type, this, System, remoteConfig, remoteMessageHandler);
+    }
 
-        public ServerConnector Connector { get; }
+    public ServerConnector Connector { get; }
 
     public override async ValueTask DisposeAsync()
     {

--- a/src/Proto.Remote/GrpcNet/GrpcNetExtensions.cs
+++ b/src/Proto.Remote/GrpcNet/GrpcNetExtensions.cs
@@ -101,9 +101,9 @@ public static class Extensions
         services.AddSingleton<IRemote, HostedGrpcNetRemote>(sp => sp.GetRequiredService<HostedGrpcNetRemote>());
         services.AddSingleton<EndpointManager>();
 
-        services.AddSingleton<EndpointReader, EndpointReader>();
+        services.AddSingleton<RemotingGrpcService, RemotingGrpcService>();
         services.AddSingleton(sp => sp.GetRequiredService<RemoteConfig>().Serialization);
-        services.AddSingleton<Remoting.RemotingBase, EndpointReader>(sp => sp.GetRequiredService<EndpointReader>());
+        services.AddSingleton<Remoting.RemotingBase, RemotingGrpcService>(sp => sp.GetRequiredService<RemotingGrpcService>());
     }
 
     private static GrpcServiceEndpointConventionBuilder AddProtoRemoteEndpoint(IEndpointRouteBuilder endpoints)

--- a/src/Proto.Remote/GrpcNet/GrpcNetRemote.cs
+++ b/src/Proto.Remote/GrpcNet/GrpcNetRemote.cs
@@ -20,7 +20,7 @@ public class GrpcNetRemote : IRemote
     private readonly object _lock = new();
     private readonly ILogger _logger = Log.CreateLogger<GrpcNetRemote>();
     private EndpointManager _endpointManager = null!;
-    private EndpointReader _endpointReader = null!;
+    private RemotingGrpcService _remotingGrpcService = null!;
     private HealthServiceImpl _healthCheck = null!;
     private IWebHost? _host;
 
@@ -57,7 +57,7 @@ public class GrpcNetRemote : IRemote
             }
 
             _endpointManager = new EndpointManager(System, Config);
-            _endpointReader = new EndpointReader(System, _endpointManager);
+            _remotingGrpcService = new RemotingGrpcService(System, _endpointManager);
             _healthCheck = new HealthServiceImpl();
 
             if (!IPAddress.TryParse(Config.Host, out var ipAddress))
@@ -96,7 +96,7 @@ public class GrpcNetRemote : IRemote
                             }
                         );
 
-                        serviceCollection.AddSingleton<Remoting.RemotingBase>(_endpointReader);
+                        serviceCollection.AddSingleton<Remoting.RemotingBase>(_remotingGrpcService);
                         serviceCollection.AddSingleton<Health.HealthBase>(_healthCheck);
                         serviceCollection.AddSingleton<IRemote>(this);
                     }

--- a/src/Proto.Remote/RemoteProcess.cs
+++ b/src/Proto.Remote/RemoteProcess.cs
@@ -13,7 +13,7 @@ public class RemoteProcess : Process
 {
     private readonly EndpointManager _endpointManager;
     private readonly string? _systemId;
-    private IEndpoint? _endpoint;
+    private IRemoteEndpoint? _endpoint;
 
     public RemoteProcess(ActorSystem system, EndpointManager endpointManager, PID pid) : base(system)
     {
@@ -52,7 +52,7 @@ public class RemoteProcess : Process
         LastUsedTick = Stopwatch.GetTimestamp();
     }
 
-    private IEndpoint GetEndpoint(PID pid)
+    private IRemoteEndpoint GetEndpoint(PID pid)
     {
         if (_endpoint?.IsActive == true)
         {

--- a/tests/Proto.Remote.Tests/RemoteStreamProcessorTests.cs
+++ b/tests/Proto.Remote.Tests/RemoteStreamProcessorTests.cs
@@ -14,7 +14,7 @@ namespace Proto.Remote.Tests;
 
 public class RemoteStreamProcessorTests
 {
-    private sealed class TestEndpoint : IEndpoint
+    private sealed class TestEndpoint : IRemoteEndpoint
     {
         public Channel<RemoteDeliver[]> Outgoing { get; } = Channel.CreateUnbounded<RemoteDeliver[]>();
         public ConcurrentStack<RemoteDeliver[]> OutgoingStash { get; } = new();


### PR DESCRIPTION
## Summary
- rename core remote endpoint abstractions for clarity (`IRemoteEndpoint`, `RemoteEndpointBase`)
- rename concrete endpoints to `ServerRemoteEndpoint` and `ClientRemoteEndpoint`
- rename gRPC service to `RemotingGrpcService` and update docs

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68aca3ea84b48328a0fae3d9378ca45d