### PR TITLE
refactor: extract topology and rebalance steps

### DIFF
--- a/logs/log1756982318.md
+++ b/logs/log1756982318.md
@@ -1,0 +1,1 @@
+# PartitionIdentityActor refactor\n- Extracted topology validation and rebalance into private methods to simplify OnClusterTopology.\n- Introduced WaitForActivationsAsync to replace inline ReenterAfter lambda.\n- Added tests ensuring validation failures and rebalance invocation are covered.\n

--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -270,50 +270,72 @@ internal class PartitionIdentityActor : IActor
             return Task.CompletedTask;
         }
 
-        var timer = Stopwatch.StartNew();
+        WaitForActivationsAsync(msg, context);
 
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    ///     Waits for all activations to complete before starting a rebalance.
+    /// </summary>
+    private Task WaitForActivationsAsync(ClusterTopology msg, IContext context)
+    {
+        var timer = Stopwatch.StartNew();
         var topologyValidityToken = msg.TopologyValidityToken!.Value;
 
-        var waitUntilInFlightActivationsAreCompleted =
-            _cluster.Gossip.WaitUntilInFlightActivationsAreCompleted(_config.RebalanceActivationsCompletionTimeout,
-                topologyValidityToken);
+        var waitTask = _cluster.Gossip.WaitUntilInFlightActivationsAreCompleted(
+            _config.RebalanceActivationsCompletionTimeout, topologyValidityToken);
 
-        context.ReenterAfter(waitUntilInFlightActivationsAreCompleted, consensusResult =>
+        context.ReenterAfter(waitTask, consensusResult =>
             {
-                if (TopologyHash != msg.TopologyHash || topologyValidityToken.IsCancellationRequested)
+                if (!IsTopologyValid(TopologyHash, msg, topologyValidityToken))
                 {
-                    // Cancelled
                     return Task.CompletedTask;
                 }
 
                 timer.Stop();
-                var allNodesCompletedActivations = consensusResult.Result.consensus;
 
-                if (allNodesCompletedActivations)
-                {
-                    if (Logger.IsEnabled(LogLevel.Debug))
-                    {
-                        Logger.LogDebug(
-                            "[PartitionIdentity] {SystemId} All nodes OK, Initiating rebalance:, {CurrentTopology} {ConsensusHash} after {Duration}",
-                            _cluster.System.Id, TopologyHash, consensusResult.Result.topologyHash, timer.Elapsed
-                        );
-                    }
-                }
-                else
-                {
-                    Logger.LogWarning(
-                        "[PartitionIdentity] {SystemId} Consensus not reached, Initiating rebalance:, {CurrentTopology} {ConsensusHash} after {Duration}",
-                        _cluster.System.Id, TopologyHash, consensusResult.Result.topologyHash, timer.Elapsed
-                    );
-                }
-
-                StartPartitionPull(msg, msg.Members.Select(it => it.Address), context, _deltaTopology);
+                Rebalance(msg, consensusResult.Result.consensus, consensusResult.Result.topologyHash, timer.Elapsed,
+                    context);
 
                 return Task.CompletedTask;
             }
         );
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    ///     Validates that the topology update is still relevant.
+    /// </summary>
+    private static bool IsTopologyValid(ulong currentTopologyHash, ClusterTopology msg, CancellationToken token) =>
+        currentTopologyHash == msg.TopologyHash && !token.IsCancellationRequested;
+
+    /// <summary>
+    ///     Logs the outcome and initiates the partition pull for the topology.
+    /// </summary>
+    private void Rebalance(ClusterTopology msg, bool allNodesCompletedActivations, ulong consensusHash,
+        TimeSpan duration, IContext context)
+    {
+        if (allNodesCompletedActivations)
+        {
+            if (Logger.IsEnabled(LogLevel.Debug))
+            {
+                Logger.LogDebug(
+                    "[PartitionIdentity] {SystemId} All nodes OK, Initiating rebalance:, {CurrentTopology} {ConsensusHash} after {Duration}",
+                    _cluster.System.Id, TopologyHash, consensusHash, duration
+                );
+            }
+        }
+        else
+        {
+            Logger.LogWarning(
+                "[PartitionIdentity] {SystemId} Consensus not reached, Initiating rebalance:, {CurrentTopology} {ConsensusHash} after {Duration}",
+                _cluster.System.Id, TopologyHash, consensusHash, duration
+            );
+        }
+
+        StartPartitionPull(msg, msg.Members.Select(it => it.Address), context, _deltaTopology);
     }
 
     private Action<IdentityHandover> TakeOverIdentities(IContext context) =>
@@ -409,7 +431,7 @@ internal class PartitionIdentityActor : IActor
         }
     }
 
-    private void StartPartitionPull(
+    protected virtual void StartPartitionPull(
         ClusterTopology msg,
         IEnumerable<string> memberAddresses,
         IContext context,

--- a/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityActorTests.cs
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/PartitionIdentityActorTests.cs
@@ -1,0 +1,98 @@
+// -----------------------------------------------------------------------
+// <copyright file="PartitionIdentityActorTests.cs" company="Asynkron AB">
+//      Copyright (C) 2015-2025 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Threading;
+using FluentAssertions;
+using Proto;
+using Proto.Cluster;
+using Proto.Cluster.Partition;
+using Xunit;
+
+namespace Proto.Cluster.PartitionIdentity.Tests;
+
+public class PartitionIdentityActorTests
+{
+    [Fact]
+    public void IsTopologyValid_returns_false_when_hash_mismatch()
+    {
+        var method = typeof(PartitionIdentityActor)
+            .GetMethod("IsTopologyValid", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var msg = new ClusterTopology { TopologyHash = 2 };
+        var result = (bool)method.Invoke(null, new object[] { 1UL, msg, CancellationToken.None })!;
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Rebalance_invokes_partition_pull()
+    {
+        var actor = TestPartitionIdentityActor.Create();
+        var members = new[]
+        {
+            new Member { Host = "a", Port = 1 },
+            new Member { Host = "b", Port = 2 }
+        };
+
+        var topology = new ClusterTopology { TopologyHash = 1 };
+        topology.Members.AddRange(members);
+
+        actor.InvokeRebalance(topology, true, 1, TimeSpan.Zero);
+
+        actor.StartPartitionPullCalled.Should().BeTrue();
+        actor.CapturedAddresses.Should().BeEquivalentTo(members.Select(m => m.Address));
+    }
+
+    private class TestPartitionIdentityActor : PartitionIdentityActor
+    {
+        private TestPartitionIdentityActor() : base(null!, new PartitionConfig())
+        {
+        }
+
+        public bool StartPartitionPullCalled { get; private set; }
+        public string[] CapturedAddresses { get; private set; } = Array.Empty<string>();
+
+        public static TestPartitionIdentityActor Create()
+        {
+            var actor = (TestPartitionIdentityActor)FormatterServices
+                .GetUninitializedObject(typeof(TestPartitionIdentityActor));
+
+            var cluster = (Cluster)FormatterServices.GetUninitializedObject(typeof(Cluster));
+            var system = new ActorSystem();
+            typeof(Cluster).GetField("<System>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(cluster, system);
+            typeof(PartitionIdentityActor).GetField("_cluster", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(actor, cluster);
+            typeof(PartitionIdentityActor).GetField("_config", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(actor, new PartitionConfig());
+            typeof(PartitionIdentityActor).GetField("_myAddress", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(actor, "test");
+            typeof(PartitionIdentityActor).GetField("_currentTopology", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(actor, new ClusterTopology { TopologyHash = 1 });
+
+            return actor;
+        }
+
+        protected override void StartPartitionPull(ClusterTopology msg, IEnumerable<string> memberAddresses, IContext context,
+            ClusterTopology? deltaBaseline = null)
+        {
+            StartPartitionPullCalled = true;
+            CapturedAddresses = memberAddresses.ToArray();
+        }
+
+        public void InvokeRebalance(ClusterTopology msg, bool allNodesCompleted, ulong consensusHash, TimeSpan duration)
+        {
+            var method = typeof(PartitionIdentityActor)
+                .GetMethod("Rebalance", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            method.Invoke(this, new object[] { msg, allNodesCompleted, consensusHash, duration, null! });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor partition identity topology processing into reusable private methods
- replace inline `ReenterAfter` continuation with `WaitForActivationsAsync`
- cover validation and rebalance steps with new tests

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`
- `dotnet test tests/Proto.Cluster.PartitionIdentity.Tests/Proto.Cluster.PartitionIdentity.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b969f1146c832896d36400de402e65