### PR TITLE
Add AI-oriented context guides

### DIFF
--- a/.github/ISSUE_TEMPLATE/context.md
+++ b/.github/ISSUE_TEMPLATE/context.md
@@ -1,0 +1,18 @@
+# ISSUE TEMPLATE Context
+
+## Overview
+ISSUE TEMPLATE directory within the Proto.Actor repository.
+
+_Parent context: [Github](../context.md)_
+
+## Key Files
+* `ask_question.md` – Markdown documentation.
+* `bug_report.md` – Markdown documentation.
+* `feature_request.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/.github/context.md
+++ b/.github/context.md
@@ -1,0 +1,21 @@
+# Github Context
+
+## Overview
+Github directory within the Proto.Actor repository.
+
+_Parent context: [Repository Root](../context.md)_
+
+## Key Files
+* `CONTRIBUTING.md` – Markdown documentation.
+* `FUNDING.yml` – YAML configuration.
+* `PULL_REQUEST_TEMPLATE.md` – Markdown documentation.
+* `SUPPORT.md` – Markdown documentation.
+* `dependabot.yml` – YAML configuration.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [ISSUE TEMPLATE](ISSUE_TEMPLATE/context.md) – See the nested context for details.
+* [Workflows](workflows/context.md) – See the nested context for details.
+

--- a/.github/workflows/context.md
+++ b/.github/workflows/context.md
@@ -1,0 +1,18 @@
+# Workflows Context
+
+## Overview
+Workflows directory within the Proto.Actor repository.
+
+_Parent context: [Github](../context.md)_
+
+## Key Files
+* `build-dev.yml` – YAML configuration.
+* `dev-tests.yml` – YAML configuration.
+* `pull-request.yml` – YAML configuration.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/.images/context.md
+++ b/.images/context.md
@@ -1,0 +1,19 @@
+# Images Context
+
+## Overview
+Images directory within the Proto.Actor repository.
+
+_Parent context: [Repository Root](../context.md)_
+
+## Key Files
+* `ahoy.svg` – Image asset.
+* `asynkron.png` – Image asset.
+* `etteplan.png` – Image asset.
+* `ubiquitous.png` – Image asset.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@
 
 ## Always follow these coding guidelines
 - Always add a detailed log of what you have done, and a strong motivation why the change was required. add this log to /logs with a filename of "log" + unixtimestamp + ".md".
+- Every directory now contains a `context.md` knowledge card. Before working in any area, review the closest `context.md` files to understand the subsystem, and keep them up to date with any relevant changes.
+- When touching any files in a directory, update that directory's `context.md` (and parent contexts if the change alters their overview) to reflect the new information.
 - Whenever a prompt contains an .NET exception, document this specific exception in /logs/exceptions.md, failed test name as ### header, important details about the failure as `code`, so we can keep track of failures. if exceptions.md already exists, just append at the end
 - Prefer immutable data structures over mutable variants
 - Prefer Concurrent collections over Immutable collections when dealing with concurrent code, but don´t replace for no reason.

--- a/benchmarks/AutoClusterBenchmark/context.md
+++ b/benchmarks/AutoClusterBenchmark/context.md
@@ -1,0 +1,25 @@
+# Auto Cluster Benchmark Context
+
+## Overview
+Auto-clustering benchmark scenarios.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* `AutoClusterBenchmark.csproj` – Project file configuring compilation targets and dependencies.
+* `Configuration.cs` – C# source defining Configuration behavior.
+* `Program.cs` – C# source defining Program behavior.
+* `Runner.cs` – C# source defining Runner behavior.
+* `WorkerActor.cs` – C# source defining Worker Actor behavior.
+* `messages.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* `Class Configuration` defined in `Configuration.cs`
+* `Class Program` defined in `Program.cs`
+* `Interface IRunMember` defined in `Runner.cs`
+* `Class RunMemberInProcGraceful` defined in `Runner.cs`
+* `Class WorkerActor` defined in `WorkerActor.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/ClusterBenchmark/context.md
+++ b/benchmarks/ClusterBenchmark/context.md
@@ -1,0 +1,34 @@
+# Cluster Benchmark Context
+
+## Overview
+Cluster behavior benchmark harness.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* `ClrMessages.cs` – C# source defining Clr Messages behavior.
+* `ClusterBenchmark.csproj` – Project file configuring compilation targets and dependencies.
+* `Configuration.cs` – C# source defining Configuration behavior.
+* `DockerSupport.cs` – C# source defining Docker Support behavior.
+* `Program.cs` – C# source defining Program behavior.
+* `Runner.cs` – C# source defining Runner behavior.
+* `WorkerActor.cs` – C# source defining Worker Actor behavior.
+* `docker-compose.yml` – YAML configuration.
+* `messages.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* `Record HelloRequestPoco` defined in `ClrMessages.cs`
+* `Record HelloResponsePoco` defined in `ClrMessages.cs`
+* `Class Configuration` defined in `Configuration.cs`
+* `Class DockerSupport` defined in `DockerSupport.cs`
+* `Class Program` defined in `Program.cs`
+* `Interface IRunMember` defined in `Runner.cs`
+* `Class RunMemberInProcGraceful` defined in `Runner.cs`
+* `Class RunMemberInProc` defined in `Runner.cs`
+* `Class RunMemberExternalProcGraceful` defined in `Runner.cs`
+* `Class RunMemberExternalProc` defined in `Runner.cs`
+* `Class WorkerActor` defined in `WorkerActor.cs`
+
+## Related Subcontexts
+* [Logs](logs/context.md) – See the nested context for details.
+

--- a/benchmarks/ClusterBenchmark/logs/context.md
+++ b/benchmarks/ClusterBenchmark/logs/context.md
@@ -1,0 +1,18 @@
+# Logs Context
+
+## Overview
+Logs directory within the Proto.Actor repository.
+
+_Parent context: [Cluster Benchmark](../context.md)_
+
+## Key Files
+* `log1756153512.md` – Markdown documentation.
+* `log1756153664.md` – Markdown documentation.
+* `log1756154034.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/ClusterMicroBenchmarks/context.md
+++ b/benchmarks/ClusterMicroBenchmarks/context.md
@@ -1,0 +1,30 @@
+# Cluster Micro Benchmarks Context
+
+## Overview
+Micro-benchmarks targeting specific cluster subsystems.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* `ClusterMicroBenchmarks.csproj` – Project file configuring compilation targets and dependencies.
+* `ConcurrentSpawnBenchmark.cs` – C# source defining Concurrent Spawn Benchmark behavior.
+* `InProcessClusterBatchRequestBenchmark.cs` – C# source defining In Process Cluster Batch Request Benchmark behavior.
+* `InProcessClusterRequestBenchmark.cs` – C# source defining In Process Cluster Request Benchmark behavior.
+* `InProcessRequestAsyncBenchmark.cs` – C# source defining In Process Request Async Benchmark behavior.
+* `ObjectPoolBenchmarks.cs` – C# source defining Object Pool Benchmarks behavior.
+* `Program.cs` – C# source defining Program behavior.
+* `RendezvousBenchmark.cs` – C# source defining Rendezvous Benchmark behavior.
+
+## Primary Types and Contracts
+* `Class ConcurrentSpawnBenchmark` defined in `ConcurrentSpawnBenchmark.cs`
+* `Enum IdentityLookup` defined in `ConcurrentSpawnBenchmark.cs`
+* `Class InProcessClusterBatchRequestBenchmark` defined in `InProcessClusterBatchRequestBenchmark.cs`
+* `Class InProcessClusterRequestBenchmark` defined in `InProcessClusterRequestBenchmark.cs`
+* `Class InProcessRequestAsyncBenchmark` defined in `InProcessRequestAsyncBenchmark.cs`
+* `Class ObjectPoolBenchmarks` defined in `ObjectPoolBenchmarks.cs`
+* `Class Program` defined in `Program.cs`
+* `Class RendezvousBenchmark` defined in `RendezvousBenchmark.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/EndpointManagerTest/context.md
+++ b/benchmarks/EndpointManagerTest/context.md
@@ -1,0 +1,19 @@
+# Endpoint Manager Test Context
+
+## Overview
+Endpoint Manager Test directory within the Proto.Actor repository.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* `Dockerfile` – Repository asset.
+* `EndpointManagerTest.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+* `Class NoopActor` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/GossipBenchmark/Messages/context.md
+++ b/benchmarks/GossipBenchmark/Messages/context.md
@@ -1,0 +1,17 @@
+# Messages Context
+
+## Overview
+Messages directory within the Proto.Actor repository.
+
+_Parent context: [Gossip Benchmark](../context.md)_
+
+## Key Files
+* `Messages.csproj` – Project file configuring compilation targets and dependencies.
+* `Protos.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/GossipBenchmark/Node1/context.md
+++ b/benchmarks/GossipBenchmark/Node1/context.md
@@ -1,0 +1,17 @@
+# Node1 Context
+
+## Overview
+Node1 directory within the Proto.Actor repository.
+
+_Parent context: [Gossip Benchmark](../context.md)_
+
+## Key Files
+* `Node1.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/GossipBenchmark/Node2/context.md
+++ b/benchmarks/GossipBenchmark/Node2/context.md
@@ -1,0 +1,18 @@
+# Node2 Context
+
+## Overview
+Node2 directory within the Proto.Actor repository.
+
+_Parent context: [Gossip Benchmark](../context.md)_
+
+## Key Files
+* `Node2.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* `Class HelloGrain` defined in `Program.cs`
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/GossipBenchmark/context.md
+++ b/benchmarks/GossipBenchmark/context.md
@@ -1,0 +1,20 @@
+# Gossip Benchmark Context
+
+## Overview
+Gossip Benchmark directory within the Proto.Actor repository.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* `GossipBenchmark.sln` – Solution file grouping related projects.
+* `docker-compose.yml` – YAML configuration.
+* `run.sh` – Script file.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Messages](Messages/context.md) – See the nested context for details.
+* [Node1](Node1/context.md) – See the nested context for details.
+* [Node2](Node2/context.md) – See the nested context for details.
+

--- a/benchmarks/GossipDecoder/context.md
+++ b/benchmarks/GossipDecoder/context.md
@@ -1,0 +1,17 @@
+# Gossip Decoder Context
+
+## Overview
+Gossip Decoder directory within the Proto.Actor repository.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* `GossipDecoder.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/HostedService/Properties/context.md
+++ b/benchmarks/HostedService/Properties/context.md
@@ -1,0 +1,16 @@
+# Properties Context
+
+## Overview
+Assembly metadata for hosted service benchmark.
+
+_Parent context: [Hosted Service](../context.md)_
+
+## Key Files
+* `launchSettings.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/HostedService/context.md
+++ b/benchmarks/HostedService/context.md
@@ -1,0 +1,23 @@
+# Hosted Service Context
+
+## Overview
+Hosted service benchmark sample.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* `HostedService.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `ProtoHost.cs` – C# source defining Proto Host behavior.
+* `Startup.cs` – C# source defining Startup behavior.
+* `appsettings.Development.json` – Configuration or metadata in JSON format.
+* `appsettings.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+* `Class ProtoHost` defined in `ProtoHost.cs`
+* `Class Startup` defined in `Startup.cs`
+
+## Related Subcontexts
+* [Properties](Properties/context.md) – See the nested context for details.
+

--- a/benchmarks/InprocessBenchmark/context.md
+++ b/benchmarks/InprocessBenchmark/context.md
@@ -1,0 +1,21 @@
+# Inprocess Benchmark Context
+
+## Overview
+In-process benchmarking harness for actors.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* `InprocessBenchmark.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+* `Class Msg` defined in `Program.cs`
+* `Class Start` defined in `Program.cs`
+* `Class PongActor` defined in `Program.cs`
+* `Class PingActor` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/KubernetesDiagnostics/context.md
+++ b/benchmarks/KubernetesDiagnostics/context.md
@@ -1,0 +1,21 @@
+# Kubernetes Diagnostics Context
+
+## Overview
+Diagnostics collection for Kubernetes deployments.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* `KubernetesDiagnostics.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `build.sh` – Script file.
+* `build2.sh` – Script file.
+* `redis.yaml` – YAML configuration.
+* `service.yaml` – YAML configuration.
+
+## Primary Types and Contracts
+* `Class DummyHostedService` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/MailboxBenchmark/context.md
+++ b/benchmarks/MailboxBenchmark/context.md
@@ -1,0 +1,19 @@
+# Mailbox Benchmark Context
+
+## Overview
+Mailbox throughput benchmarks.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* `MailboxBenchmark.cs` – C# source defining Mailbox Benchmark behavior.
+* `MailboxBenchmark.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* `Class MailboxBenchmark` defined in `MailboxBenchmark.cs`
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/PingPongBenchmark/context.md
+++ b/benchmarks/PingPongBenchmark/context.md
@@ -1,0 +1,24 @@
+# Ping Pong Benchmark Context
+
+## Overview
+Ping-pong actor benchmark measuring latency.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* `LocalPingPong.csproj` – Project file configuring compilation targets and dependencies.
+* `PingActor.cs` – C# source defining Ping Actor behavior.
+* `PongActor.cs` – C# source defining Pong Actor behavior.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* `Record PingMsg` defined in `PingActor.cs`
+* `Record PongMsg` defined in `PingActor.cs`
+* `Class PingActor` defined in `PingActor.cs`
+* `Class Start` defined in `PingActor.cs`
+* `Class PongActor` defined in `PongActor.cs`
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/PropsBenchmark/context.md
+++ b/benchmarks/PropsBenchmark/context.md
@@ -1,0 +1,18 @@
+# Props Benchmark Context
+
+## Overview
+Props Benchmark directory within the Proto.Actor repository.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* `Program.cs` – C# source defining Program behavior.
+* `PropsBenchmark.csproj` – Project file configuring compilation targets and dependencies.
+* `SomeState.cs` – C# source defining Some State behavior.
+
+## Primary Types and Contracts
+* `Record SomeState` defined in `SomeState.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/ProtoActorBenchmarks/context.md
+++ b/benchmarks/ProtoActorBenchmarks/context.md
@@ -1,0 +1,32 @@
+# Proto Actor Benchmarks Context
+
+## Overview
+BenchmarkDotNet suite for Proto.Actor primitives.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* `LongBenchmark.cs` – C# source defining Long Benchmark behavior.
+* `Program.cs` – C# source defining Program behavior.
+* `ProtoActorBenchmarks.csproj` – Project file configuring compilation targets and dependencies.
+* `ShortBenchmark.cs` – C# source defining Short Benchmark behavior.
+* `SkyNetBenchmark.cs` – C# source defining Sky Net Benchmark behavior.
+* `TestActors.cs` – C# source defining Test Actors behavior.
+
+## Primary Types and Contracts
+* `Class LongBenchmark` defined in `LongBenchmark.cs`
+* `Class Program` defined in `Program.cs`
+* `Class ShortBenchmark` defined in `ShortBenchmark.cs`
+* `Class SkyNetBenchmark` defined in `SkyNetBenchmark.cs`
+* `Class SkyNetRequestResponseActor` defined in `SkyNetBenchmark.cs`
+* `Class SkynetActor` defined in `SkyNetBenchmark.cs`
+* `Class Request` defined in `SkyNetBenchmark.cs`
+* `Class PingActor` defined in `TestActors.cs`
+* `Class EchoActor` defined in `TestActors.cs`
+* `Class EchoActor2` defined in `TestActors.cs`
+* `Class Start` defined in `TestActors.cs`
+* `Class Msg` defined in `TestActors.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/RemoteBenchmark/Messages/context.md
+++ b/benchmarks/RemoteBenchmark/Messages/context.md
@@ -1,0 +1,19 @@
+# Messages Context
+
+## Overview
+Messages directory within the Proto.Actor repository.
+
+_Parent context: [Remote Benchmark](../context.md)_
+
+## Key Files
+* `Messages.cs` – C# source defining Messages behavior.
+* `Messages.csproj` – Project file configuring compilation targets and dependencies.
+* `Protos.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* `Class Ping` defined in `Messages.cs`
+* `Class Pong` defined in `Messages.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/RemoteBenchmark/Node1/context.md
+++ b/benchmarks/RemoteBenchmark/Node1/context.md
@@ -1,0 +1,18 @@
+# Node1 Context
+
+## Overview
+Primary node for remote benchmark harness.
+
+_Parent context: [Remote Benchmark](../context.md)_
+
+## Key Files
+* `Node1.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+* `Class LocalActor` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/RemoteBenchmark/Node2/context.md
+++ b/benchmarks/RemoteBenchmark/Node2/context.md
@@ -1,0 +1,18 @@
+# Node2 Context
+
+## Overview
+Secondary node for remote benchmark harness.
+
+_Parent context: [Remote Benchmark](../context.md)_
+
+## Key Files
+* `Node2.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* `Class EchoActor` defined in `Program.cs`
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/RemoteBenchmark/context.md
+++ b/benchmarks/RemoteBenchmark/context.md
@@ -1,0 +1,18 @@
+# Remote Benchmark Context
+
+## Overview
+Remote messaging performance benchmarks across nodes.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* No direct files; primary content is nested in subdirectories.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Messages](Messages/context.md) – See the nested context for details.
+* [Node1](Node1/context.md) – See the nested context for details.
+* [Node2](Node2/context.md) – See the nested context for details.
+

--- a/benchmarks/SkyriseMini/Client/Properties/context.md
+++ b/benchmarks/SkyriseMini/Client/Properties/context.md
@@ -1,0 +1,16 @@
+# Properties Context
+
+## Overview
+Assembly metadata for client benchmark.
+
+_Parent context: [Client](../context.md)_
+
+## Key Files
+* `launchSettings.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/SkyriseMini/Client/Tests/context.md
+++ b/benchmarks/SkyriseMini/Client/Tests/context.md
@@ -1,0 +1,21 @@
+# Tests Context
+
+## Overview
+Tests verifying the SkyriseMini client benchmark components.
+
+_Parent context: [Client](../context.md)_
+
+## Key Files
+* `ActivationTest.cs` – C# source defining Activation Test behavior.
+* `MessagingTest.cs` – C# source defining Messaging Test behavior.
+* `TestManager.cs` – C# source defining Test Manager behavior.
+* `TestServices.cs` – C# source defining Test Services behavior.
+
+## Primary Types and Contracts
+* `Class ActivationTest` defined in `ActivationTest.cs`
+* `Class MessagingTest` defined in `MessagingTest.cs`
+* `Class TestManager` defined in `TestManager.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/SkyriseMini/Client/context.md
+++ b/benchmarks/SkyriseMini/Client/context.md
@@ -1,0 +1,29 @@
+# Client Context
+
+## Overview
+Client application for SkyriseMini benchmark.
+
+_Parent context: [Skyrise Mini](../context.md)_
+
+## Key Files
+* `ActorSystemHostedService.cs` – C# source defining Actor System Hosted Service behavior.
+* `PingPongActorRaw.cs` – C# source defining Ping Pong Actor Raw behavior.
+* `Program.cs` – C# source defining Program behavior.
+* `ProtoActorExtensions.cs` – C# source defining Proto Actor Extensions behavior.
+* `ProtoActorTestServicesRaw.cs` – C# source defining Proto Actor Test Services Raw behavior.
+* `SkyriseMiniClient.csproj` – Project file configuring compilation targets and dependencies.
+* `appsettings.Development.json` – Configuration or metadata in JSON format.
+* `appsettings.json` – Configuration or metadata in JSON format.
+* `docker-compose.yml` – YAML configuration.
+* `protos.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* `Class ActorSystemHostedService` defined in `ActorSystemHostedService.cs`
+* `Class PingPongActorRaw` defined in `PingPongActorRaw.cs`
+* `Class ProtoActorExtensions` defined in `ProtoActorExtensions.cs`
+* `Class ProtoActorTestServicesRaw` defined in `ProtoActorTestServicesRaw.cs`
+
+## Related Subcontexts
+* [Properties](Properties/context.md) – See the nested context for details.
+* [Tests](Tests/context.md) – See the nested context for details.
+

--- a/benchmarks/SkyriseMini/Server/Monitoring/context.md
+++ b/benchmarks/SkyriseMini/Server/Monitoring/context.md
@@ -1,0 +1,16 @@
+# Monitoring Context
+
+## Overview
+Monitoring helpers for SkyriseMini server benchmark.
+
+_Parent context: [Server](../context.md)_
+
+## Key Files
+* `TestMetrics.cs` – C# source defining Test Metrics behavior.
+
+## Primary Types and Contracts
+* `Class TestMetrics` defined in `TestMetrics.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/SkyriseMini/Server/Properties/context.md
+++ b/benchmarks/SkyriseMini/Server/Properties/context.md
@@ -1,0 +1,16 @@
+# Properties Context
+
+## Overview
+Assembly metadata for server benchmark.
+
+_Parent context: [Server](../context.md)_
+
+## Key Files
+* `launchSettings.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/SkyriseMini/Server/Tests/context.md
+++ b/benchmarks/SkyriseMini/Server/Tests/context.md
@@ -1,0 +1,21 @@
+# Tests Context
+
+## Overview
+Tests for the SkyriseMini server benchmark components.
+
+_Parent context: [Server](../context.md)_
+
+## Key Files
+* `ActivationTest.cs` – C# source defining Activation Test behavior.
+* `MessagingTest.cs` – C# source defining Messaging Test behavior.
+* `TestManager.cs` – C# source defining Test Manager behavior.
+* `TestServices.cs` – C# source defining Test Services behavior.
+
+## Primary Types and Contracts
+* `Class ActivationTest` defined in `ActivationTest.cs`
+* `Class MessagingTest` defined in `MessagingTest.cs`
+* `Class TestManager` defined in `TestManager.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/SkyriseMini/Server/context.md
+++ b/benchmarks/SkyriseMini/Server/context.md
@@ -1,0 +1,28 @@
+# Server Context
+
+## Overview
+Server application for SkyriseMini benchmark.
+
+_Parent context: [Skyrise Mini](../context.md)_
+
+## Key Files
+* `ActorSystemHostedService.cs` – C# source defining Actor System Hosted Service behavior.
+* `PingPongActorRaw.cs` – C# source defining Ping Pong Actor Raw behavior.
+* `Program.cs` – C# source defining Program behavior.
+* `ProtoActorExtensions.cs` – C# source defining Proto Actor Extensions behavior.
+* `SkyriseMiniServer.csproj` – Project file configuring compilation targets and dependencies.
+* `appsettings.Development.json` – Configuration or metadata in JSON format.
+* `appsettings.json` – Configuration or metadata in JSON format.
+* `docker-compose.yml` – YAML configuration.
+* `protos.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* `Class ActorSystemHostedService` defined in `ActorSystemHostedService.cs`
+* `Class PingPongActorRaw` defined in `PingPongActorRaw.cs`
+* `Class ProtoActorExtensions` defined in `ProtoActorExtensions.cs`
+
+## Related Subcontexts
+* [Monitoring](Monitoring/context.md) – See the nested context for details.
+* [Properties](Properties/context.md) – See the nested context for details.
+* [Tests](Tests/context.md) – See the nested context for details.
+

--- a/benchmarks/SkyriseMini/context.md
+++ b/benchmarks/SkyriseMini/context.md
@@ -1,0 +1,17 @@
+# Skyrise Mini Context
+
+## Overview
+SkyriseMini sample benchmark solution with client/server projects.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* No direct files; primary content is nested in subdirectories.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Client](Client/context.md) – See the nested context for details.
+* [Server](Server/context.md) – See the nested context for details.
+

--- a/benchmarks/SpawnBenchmark/context.md
+++ b/benchmarks/SpawnBenchmark/context.md
@@ -1,0 +1,19 @@
+# Spawn Benchmark Context
+
+## Overview
+Actor spawn throughput benchmarks.
+
+_Parent context: [Benchmarks](../context.md)_
+
+## Key Files
+* `Program.cs` – C# source defining Program behavior.
+* `SpawnBenchmark.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* `Class Request` defined in `Program.cs`
+* `Class MyActor` defined in `Program.cs`
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/benchmarks/context.md
+++ b/benchmarks/context.md
@@ -1,0 +1,33 @@
+# Benchmarks Context
+
+## Overview
+Benchmark harnesses and performance experiments for actors, remoting, clustering, and infrastructure integrations.
+
+These projects stress the same primitives defined in [`src/context.md`](../src/context.md); compare results with functionality-focused samples in [`examples/context.md`](../examples/context.md) to understand both performance and behavior.
+
+_Parent context: [Repository Root](../context.md)_
+
+## Key Files
+* `Directory.Build.props` – MSBuild configuration.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Auto Cluster Benchmark](AutoClusterBenchmark/context.md) – See the nested context for details.
+* [Cluster Benchmark](ClusterBenchmark/context.md) – See the nested context for details.
+* [Cluster Micro Benchmarks](ClusterMicroBenchmarks/context.md) – See the nested context for details.
+* [Endpoint Manager Test](EndpointManagerTest/context.md) – See the nested context for details.
+* [Gossip Benchmark](GossipBenchmark/context.md) – See the nested context for details.
+* [Gossip Decoder](GossipDecoder/context.md) – See the nested context for details.
+* [Hosted Service](HostedService/context.md) – See the nested context for details.
+* [Inprocess Benchmark](InprocessBenchmark/context.md) – See the nested context for details.
+* [Kubernetes Diagnostics](KubernetesDiagnostics/context.md) – See the nested context for details.
+* [Mailbox Benchmark](MailboxBenchmark/context.md) – See the nested context for details.
+* [Ping Pong Benchmark](PingPongBenchmark/context.md) – See the nested context for details.
+* [Props Benchmark](PropsBenchmark/context.md) – See the nested context for details.
+* [Proto Actor Benchmarks](ProtoActorBenchmarks/context.md) – See the nested context for details.
+* [Remote Benchmark](RemoteBenchmark/context.md) – See the nested context for details.
+* [Skyrise Mini](SkyriseMini/context.md) – See the nested context for details.
+* [Spawn Benchmark](SpawnBenchmark/context.md) – See the nested context for details.
+

--- a/context.md
+++ b/context.md
@@ -1,0 +1,46 @@
+# Repository Root Context
+
+## Overview
+Root of the Proto.Actor for .NET repository. Hosts the runtime, clustering, remote communication, persistence providers, tooling, tests, and numerous samples.
+
+Start here, but also read [`README.md`](README.md) for project onboarding, then dive into [`src/context.md`](src/context.md), [`tests/context.md`](tests/context.md), and [`examples/context.md`](examples/context.md) for subsystem-specific guides.
+
+## Key Files
+* `.all-contributorsrc` – Repository asset.
+* `.dockerignore` – Repository asset.
+* `.gitignore` – Repository asset.
+* `.mergify.yml` – YAML configuration.
+* `AGENTS.md` – Markdown documentation.
+* `CLUSTER_MEMBERSHIP_GOSSIP.md` – Markdown documentation.
+* `CODEBASE_OVERVIEW.md` – Markdown documentation.
+* `Directory.Packages.props` – MSBuild configuration.
+* `EVENTSTREAM_EVENTS.md` – Markdown documentation.
+* `LICENSE` – Repository asset.
+* `ProtoActor.sln` – Solution file grouping related projects.
+* `ProtoActor.sln.DotSettings` – Repository asset.
+* `ProtoActor.snk` – Repository asset.
+* `ProtoActorCoreOnly.sln` – Solution file grouping related projects.
+* `README.md` – Markdown documentation.
+* `SECURITY.md` – Markdown documentation.
+* `Terminology.md` – Markdown documentation.
+* `build-docker.sh` – Script file.
+* `cluster.drawio` – Repository asset.
+* `dockerfile-reader` – Repository asset.
+* `dockerfile-sender` – Repository asset.
+* `global.json` – Configuration or metadata in JSON format.
+* `logo.png` – Image asset.
+* `runtimeconfig.template.dev.json` – Configuration or metadata in JSON format.
+* `service.yaml` – YAML configuration.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Github](.github/context.md) – See the nested context for details.
+* [Images](.images/context.md) – See the nested context for details.
+* [Benchmarks](benchmarks/context.md) – See the nested context for details.
+* [Examples](examples/context.md) – See the nested context for details.
+* [Logs](logs/context.md) – See the nested context for details.
+* [Src](src/context.md) – See the nested context for details.
+* [Tests](tests/context.md) – See the nested context for details.
+

--- a/examples/actor.context-decorators/context.md
+++ b/examples/actor.context-decorators/context.md
@@ -1,0 +1,20 @@
+# Actor Context Decorators Context
+
+## Overview
+Demonstrates how to decorate actor contexts and middleware.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `ContextDecorators.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* `Class LoggingRootDecorator` defined in `Program.cs`
+* `Class LoggingDecorator` defined in `Program.cs`
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.deadletter-throttling/context.md
+++ b/examples/actor.deadletter-throttling/context.md
@@ -1,0 +1,18 @@
+# Actor Deadletter Throttling Context
+
+## Overview
+Shows deadletter throttling behavior.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `DeadLetterThrottling.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.dependency-injection/Controllers/context.md
+++ b/examples/actor.dependency-injection/Controllers/context.md
@@ -1,0 +1,19 @@
+# Controllers Context
+
+## Overview
+ASP.NET controllers hosting Proto actors for DI example.
+
+_Parent context: [Actor Dependency Injection](../context.md)_
+
+## Key Files
+* `ActorController.cs` – C# source defining Actor Controller behavior.
+
+## Primary Types and Contracts
+* `Class DependencyInjectedActor` defined in `ActorController.cs`
+* `Record HelloRequest` defined in `ActorController.cs`
+* `Record HelloResponse` defined in `ActorController.cs`
+* `Class ActorController` defined in `ActorController.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.dependency-injection/Properties/context.md
+++ b/examples/actor.dependency-injection/Properties/context.md
@@ -1,0 +1,16 @@
+# Properties Context
+
+## Overview
+Project metadata for DI example.
+
+_Parent context: [Actor Dependency Injection](../context.md)_
+
+## Key Files
+* `launchSettings.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.dependency-injection/context.md
+++ b/examples/actor.dependency-injection/context.md
@@ -1,0 +1,23 @@
+# Actor Dependency Injection Context
+
+## Overview
+Demonstrates actor DI integration in ASP.NET Core.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `DependencyInjection.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+* `Startup.cs` – C# source defining Startup behavior.
+* `appsettings.Development.json` – Configuration or metadata in JSON format.
+* `appsettings.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+* `Class Startup` defined in `Startup.cs`
+
+## Related Subcontexts
+* [Controllers](Controllers/context.md) – See the nested context for details.
+* [Properties](Properties/context.md) – See the nested context for details.
+

--- a/examples/actor.event-stream-topics/context.md
+++ b/examples/actor.event-stream-topics/context.md
@@ -1,0 +1,21 @@
+# Actor Event Stream Topics Context
+
+## Overview
+Topic-based event stream sample.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `EventStreamTopics.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* `Record SomeMessage` defined in `Program.cs`
+* `Interface ITopicMessage` defined in `Program.cs`
+* `Class Program` defined in `Program.cs`
+* `Class Extensions` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.event-stream/context.md
+++ b/examples/actor.event-stream/context.md
@@ -1,0 +1,19 @@
+# Actor Event Stream Context
+
+## Overview
+Event stream usage example.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `EventStream.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* `Record SomeMessage` defined in `Program.cs`
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.futures/context.md
+++ b/examples/actor.futures/context.md
@@ -1,0 +1,18 @@
+# Actor Futures Context
+
+## Overview
+Showcases using futures to await actor responses.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `Futures.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.hello-world-fsharp/context.md
+++ b/examples/actor.hello-world-fsharp/context.md
@@ -1,0 +1,18 @@
+# Actor Hello World Fsharp Context
+
+## Overview
+F# version of the hello world actor example.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `HelloWorld.fsproj` – Repository asset.
+* `Program.fs` – F# source module Program.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.hello-world/context.md
+++ b/examples/actor.hello-world/context.md
@@ -1,0 +1,19 @@
+# Actor Hello World Context
+
+## Overview
+Minimal actor example showing spawn and message handling.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `HelloWorld.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* `Record Hello` defined in `Program.cs`
+* `Class HelloActor` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.lifecycle-events/context.md
+++ b/examples/actor.lifecycle-events/context.md
@@ -1,0 +1,20 @@
+# Actor Lifecycle Events Context
+
+## Overview
+Illustrates actor lifecycle callbacks.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `LifecycleEvents.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+* `Class ChildActor` defined in `Program.cs`
+* `Class Hello` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.message-headers/context.md
+++ b/examples/actor.message-headers/context.md
@@ -1,0 +1,19 @@
+# Actor Message Headers Context
+
+## Overview
+Shows message header usage.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `MessageHeaders.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* `Record MyMessage` defined in `Program.cs`
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.metrics/Controllers/context.md
+++ b/examples/actor.metrics/Controllers/context.md
@@ -1,0 +1,16 @@
+# Controllers Context
+
+## Overview
+ASP.NET controllers exporting metrics in the example.
+
+_Parent context: [Actor Metrics](../context.md)_
+
+## Key Files
+* `WeatherForecastController.cs` – C# source defining Weather Forecast Controller behavior.
+
+## Primary Types and Contracts
+* `Class WeatherForecastController` defined in `WeatherForecastController.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.metrics/Properties/context.md
+++ b/examples/actor.metrics/Properties/context.md
@@ -1,0 +1,16 @@
+# Properties Context
+
+## Overview
+Project metadata for metrics example.
+
+_Parent context: [Actor Metrics](../context.md)_
+
+## Key Files
+* `launchSettings.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.metrics/context.md
+++ b/examples/actor.metrics/context.md
@@ -1,0 +1,33 @@
+# Actor Metrics Context
+
+## Overview
+Actor metrics integration with Prometheus/Grafana.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `ActorMetrics.csproj` – Project file configuring compilation targets and dependencies.
+* `Messages.proto` – Protocol Buffers schema.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+* `RunDummyCluster.cs` – C# source defining Run Dummy Cluster behavior.
+* `Startup.cs` – C# source defining Startup behavior.
+* `WeatherForecast.cs` – C# source defining Weather Forecast behavior.
+* `appsettings.Development.json` – Configuration or metadata in JSON format.
+* `appsettings.json` – Configuration or metadata in JSON format.
+* `docker-compose.yaml` – YAML configuration.
+* `prometheus.yml` – YAML configuration.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+* `Class RunDummyCluster` defined in `RunDummyCluster.cs`
+* `Record MyMessage` defined in `RunDummyCluster.cs`
+* `Class MyActor` defined in `RunDummyCluster.cs`
+* `Class Startup` defined in `Startup.cs`
+* `Class WeatherForecast` defined in `WeatherForecast.cs`
+
+## Related Subcontexts
+* [Controllers](Controllers/context.md) – See the nested context for details.
+* [Properties](Properties/context.md) – See the nested context for details.
+* [Grafana](grafana/context.md) – See the nested context for details.
+

--- a/examples/actor.metrics/grafana/context.md
+++ b/examples/actor.metrics/grafana/context.md
@@ -1,0 +1,16 @@
+# Grafana Context
+
+## Overview
+Grafana dashboards for the actor metrics example.
+
+_Parent context: [Actor Metrics](../context.md)_
+
+## Key Files
+* `datasources.yml` – YAML configuration.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Dashboards](dashboards/context.md) – See the nested context for details.
+

--- a/examples/actor.metrics/grafana/dashboards/context.md
+++ b/examples/actor.metrics/grafana/dashboards/context.md
@@ -1,0 +1,17 @@
+# Dashboards Context
+
+## Overview
+Dashboard definitions for Grafana.
+
+_Parent context: [Grafana](../context.md)_
+
+## Key Files
+* `dashboard.yml` – YAML configuration.
+* `proto-actor-sample-dashboard.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.middleware/context.md
+++ b/examples/actor.middleware/context.md
@@ -1,0 +1,18 @@
+# Actor Middleware Context
+
+## Overview
+Middleware pipeline customization example.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `Middleware.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.open-telemetry/context.md
+++ b/examples/actor.open-telemetry/context.md
@@ -1,0 +1,18 @@
+# Actor Open Telemetry Context
+
+## Overview
+OpenTelemetry tracing sample for actors.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `ActorOpenTelemetry.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.receive-timeout/context.md
+++ b/examples/actor.receive-timeout/context.md
@@ -1,0 +1,19 @@
+# Actor Receive Timeout Context
+
+## Overview
+Receive timeout handling example.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+* `ReceiveTimeout.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+* `Class NoInfluence` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.router/context.md
+++ b/examples/actor.router/context.md
@@ -1,0 +1,20 @@
+# Actor Router Context
+
+## Overview
+Router actor configuration sample.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+* `Router.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* `Class Message` defined in `Program.cs`
+* `Class MyActor` defined in `Program.cs`
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.saga/Factories/context.md
+++ b/examples/actor.saga/Factories/context.md
@@ -1,0 +1,16 @@
+# Factories Context
+
+## Overview
+Factories directory within the Proto.Actor repository.
+
+_Parent context: [Actor Saga](../context.md)_
+
+## Key Files
+* `TransferFactory.cs` – C# source defining Transfer Factory behavior.
+
+## Primary Types and Contracts
+* `Class TransferFactory` defined in `TransferFactory.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.saga/Internal/context.md
+++ b/examples/actor.saga/Internal/context.md
@@ -1,0 +1,16 @@
+# Internal Context
+
+## Overview
+Internal directory within the Proto.Actor repository.
+
+_Parent context: [Actor Saga](../context.md)_
+
+## Key Files
+* `ForWithProgress.cs` – C# source defining For With Progress behavior.
+
+## Primary Types and Contracts
+* `Class ForWithProgress` defined in `ForWithProgress.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.saga/Messages/context.md
+++ b/examples/actor.saga/Messages/context.md
@@ -1,0 +1,38 @@
+# Messages Context
+
+## Overview
+Contracts shared across saga example actors.
+
+_Parent context: [Actor Saga](../context.md)_
+
+## Key Files
+* `Messages.cs` – C# source defining Messages behavior.
+
+## Primary Types and Contracts
+* `Record Result` defined in `Messages.cs`
+* `Record SuccessResult` defined in `Messages.cs`
+* `Record FailedAndInconsistent` defined in `Messages.cs`
+* `Record FailedButConsistentResult` defined in `Messages.cs`
+* `Record ChangeBalance` defined in `Messages.cs`
+* `Record Credit` defined in `Messages.cs`
+* `Record Debit` defined in `Messages.cs`
+* `Record UnknownResult` defined in `Messages.cs`
+* `Record TransferCompleted` defined in `Messages.cs`
+* `Record TransferFailed` defined in `Messages.cs`
+* `Record AccountCredited` defined in `Messages.cs`
+* `Record AccountDebited` defined in `Messages.cs`
+* `Record CreditRefused` defined in `Messages.cs`
+* `Record DebitRolledBack` defined in `Messages.cs`
+* `Record EscalateTransfer` defined in `Messages.cs`
+* `Record GetBalance` defined in `Messages.cs`
+* `Record InsufficientFunds` defined in `Messages.cs`
+* `Record InternalServerError` defined in `Messages.cs`
+* `Record OK` defined in `Messages.cs`
+* `Record Refused` defined in `Messages.cs`
+* `Record ServiceUnavailable` defined in `Messages.cs`
+* `Record StatusUnknown` defined in `Messages.cs`
+* `Record TransferStarted` defined in `Messages.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.saga/context.md
+++ b/examples/actor.saga/context.md
@@ -1,0 +1,31 @@
+# Actor Saga Context
+
+## Overview
+Saga orchestration example with state machines.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `Account.cs` – C# source defining Account behavior.
+* `AccountProxy.cs` – C# source defining Account Proxy behavior.
+* `InMemoryProvider.cs` – C# source defining In Memory Provider behavior.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+* `Runner.cs` – C# source defining Runner behavior.
+* `Saga.csproj` – Project file configuring compilation targets and dependencies.
+* `TransferProcess.cs` – C# source defining Transfer Process behavior.
+
+## Primary Types and Contracts
+* `Class Account` defined in `Account.cs`
+* `Enum Behavior` defined in `Account.cs`
+* `Class AccountProxy` defined in `AccountProxy.cs`
+* `Class InMemoryProvider` defined in `InMemoryProvider.cs`
+* `Class Program` defined in `Program.cs`
+* `Class Runner` defined in `Runner.cs`
+* `Class TransferProcess` defined in `TransferProcess.cs`
+
+## Related Subcontexts
+* [Factories](Factories/context.md) – See the nested context for details.
+* [Internal](Internal/context.md) – See the nested context for details.
+* [Messages](Messages/context.md) – See the nested context for details.
+

--- a/examples/actor.scheduled-messages/context.md
+++ b/examples/actor.scheduled-messages/context.md
@@ -1,0 +1,18 @@
+# Actor Scheduled Messages Context
+
+## Overview
+Scheduling future messages example.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+* `ScheduledMessages.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.supervision-escalate/context.md
+++ b/examples/actor.supervision-escalate/context.md
@@ -1,0 +1,18 @@
+# Actor Supervision Escalate Context
+
+## Overview
+Supervision escalation demonstration.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `EscalateSupervision.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/actor.supervision/context.md
+++ b/examples/actor.supervision/context.md
@@ -1,0 +1,26 @@
+# Actor Supervision Context
+
+## Overview
+Supervision strategies example.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+* `Supervision.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+* `Class Decider` defined in `Program.cs`
+* `Class ParentActor` defined in `Program.cs`
+* `Class ChildActor` defined in `Program.cs`
+* `Class Hello` defined in `Program.cs`
+* `Class RecoverableException` defined in `Program.cs`
+* `Class FatalException` defined in `Program.cs`
+* `Class Fatal` defined in `Program.cs`
+* `Class Recoverable` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.aspnet-grains/Messages/context.md
+++ b/examples/cluster.aspnet-grains/Messages/context.md
@@ -1,0 +1,17 @@
+# Messages Context
+
+## Overview
+Messages directory within the Proto.Actor repository.
+
+_Parent context: [Cluster Aspnet Grains](../context.md)_
+
+## Key Files
+* `Messages.csproj` – Project file configuring compilation targets and dependencies.
+* `Protos.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.aspnet-grains/Node1/Properties/context.md
+++ b/examples/cluster.aspnet-grains/Node1/Properties/context.md
@@ -1,0 +1,16 @@
+# Properties Context
+
+## Overview
+Properties directory within the Proto.Actor repository.
+
+_Parent context: [Node1](../context.md)_
+
+## Key Files
+* `launchSettings.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.aspnet-grains/Node1/context.md
+++ b/examples/cluster.aspnet-grains/Node1/context.md
@@ -1,0 +1,19 @@
+# Node1 Context
+
+## Overview
+Node1 directory within the Proto.Actor repository.
+
+_Parent context: [Cluster Aspnet Grains](../context.md)_
+
+## Key Files
+* `Node1.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `appsettings.Development.json` – Configuration or metadata in JSON format.
+* `appsettings.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Properties](Properties/context.md) – See the nested context for details.
+

--- a/examples/cluster.aspnet-grains/Node2/Properties/context.md
+++ b/examples/cluster.aspnet-grains/Node2/Properties/context.md
@@ -1,0 +1,16 @@
+# Properties Context
+
+## Overview
+Properties directory within the Proto.Actor repository.
+
+_Parent context: [Node2](../context.md)_
+
+## Key Files
+* `launchSettings.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.aspnet-grains/Node2/context.md
+++ b/examples/cluster.aspnet-grains/Node2/context.md
@@ -1,0 +1,20 @@
+# Node2 Context
+
+## Overview
+Node2 directory within the Proto.Actor repository.
+
+_Parent context: [Cluster Aspnet Grains](../context.md)_
+
+## Key Files
+* `HelloGrain.cs` – C# source defining Hello Grain behavior.
+* `Node2.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `appsettings.Development.json` – Configuration or metadata in JSON format.
+* `appsettings.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* `Class HelloGrain` defined in `HelloGrain.cs`
+
+## Related Subcontexts
+* [Properties](Properties/context.md) – See the nested context for details.
+

--- a/examples/cluster.aspnet-grains/context.md
+++ b/examples/cluster.aspnet-grains/context.md
@@ -1,0 +1,18 @@
+# Cluster Aspnet Grains Context
+
+## Overview
+ASP.NET Core hosted cluster grains example.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Messages](Messages/context.md) – See the nested context for details.
+* [Node1](Node1/context.md) – See the nested context for details.
+* [Node2](Node2/context.md) – See the nested context for details.
+

--- a/examples/cluster.dashboard-host/Properties/context.md
+++ b/examples/cluster.dashboard-host/Properties/context.md
@@ -1,0 +1,16 @@
+# Properties Context
+
+## Overview
+Project metadata for the dashboard host sample.
+
+_Parent context: [Cluster Dashboard Host](../context.md)_
+
+## Key Files
+* `launchSettings.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.dashboard-host/context.md
+++ b/examples/cluster.dashboard-host/context.md
@@ -1,0 +1,21 @@
+# Cluster Dashboard Host Context
+
+## Overview
+Hosting application for the Proto.Cluster dashboard UI.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `Program.cs` – C# source defining Program behavior.
+* `Proto.Cluster.Dashboard.Host.csproj` – Project file configuring compilation targets and dependencies.
+* `README.md` – Markdown documentation.
+* `appsettings.Development.json` – Configuration or metadata in JSON format.
+* `appsettings.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Properties](Properties/context.md) – See the nested context for details.
+* [Wwwroot](wwwroot/context.md) – See the nested context for details.
+

--- a/examples/cluster.dashboard-host/wwwroot/context.md
+++ b/examples/cluster.dashboard-host/wwwroot/context.md
@@ -1,0 +1,16 @@
+# Wwwroot Context
+
+## Overview
+Static assets for the dashboard host example.
+
+_Parent context: [Cluster Dashboard Host](../context.md)_
+
+## Key Files
+* `favicon.ico` – Repository asset.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Css](css/context.md) – See the nested context for details.
+

--- a/examples/cluster.dashboard-host/wwwroot/css/bootstrap/context.md
+++ b/examples/cluster.dashboard-host/wwwroot/css/bootstrap/context.md
@@ -1,0 +1,17 @@
+# Bootstrap Context
+
+## Overview
+Bootstrap CSS assets for the dashboard host.
+
+_Parent context: [Css](../context.md)_
+
+## Key Files
+* `bootstrap.min.css` – Repository asset.
+* `bootstrap.min.css.map` – Repository asset.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.dashboard-host/wwwroot/css/context.md
+++ b/examples/cluster.dashboard-host/wwwroot/css/context.md
@@ -1,0 +1,17 @@
+# Css Context
+
+## Overview
+Dashboard host CSS assets.
+
+_Parent context: [Wwwroot](../context.md)_
+
+## Key Files
+* `site.css` – Repository asset.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Bootstrap](bootstrap/context.md) – See the nested context for details.
+* [Open Iconic](open-iconic/context.md) – See the nested context for details.
+

--- a/examples/cluster.dashboard-host/wwwroot/css/open-iconic/context.md
+++ b/examples/cluster.dashboard-host/wwwroot/css/open-iconic/context.md
@@ -1,0 +1,18 @@
+# Open Iconic Context
+
+## Overview
+Open Iconic font assets for the dashboard host.
+
+_Parent context: [Css](../context.md)_
+
+## Key Files
+* `FONT-LICENSE` – Repository asset.
+* `ICON-LICENSE` – Repository asset.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Font](font/context.md) – See the nested context for details.
+

--- a/examples/cluster.dashboard-host/wwwroot/css/open-iconic/font/context.md
+++ b/examples/cluster.dashboard-host/wwwroot/css/open-iconic/font/context.md
@@ -1,0 +1,17 @@
+# Font Context
+
+## Overview
+Font files for Open Iconic icons.
+
+_Parent context: [Open Iconic](../context.md)_
+
+## Key Files
+* No direct files; primary content is nested in subdirectories.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Css](css/context.md) – See the nested context for details.
+* [Fonts](fonts/context.md) – See the nested context for details.
+

--- a/examples/cluster.dashboard-host/wwwroot/css/open-iconic/font/css/context.md
+++ b/examples/cluster.dashboard-host/wwwroot/css/open-iconic/font/css/context.md
@@ -1,0 +1,16 @@
+# Css Context
+
+## Overview
+CSS for Open Iconic icons.
+
+_Parent context: [Font](../context.md)_
+
+## Key Files
+* `open-iconic-bootstrap.min.css` – Repository asset.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.dashboard-host/wwwroot/css/open-iconic/font/fonts/context.md
+++ b/examples/cluster.dashboard-host/wwwroot/css/open-iconic/font/fonts/context.md
@@ -1,0 +1,20 @@
+# Fonts Context
+
+## Overview
+Font binaries for Open Iconic icons.
+
+_Parent context: [Font](../context.md)_
+
+## Key Files
+* `open-iconic.eot` – Repository asset.
+* `open-iconic.otf` – Repository asset.
+* `open-iconic.svg` – Image asset.
+* `open-iconic.ttf` – Repository asset.
+* `open-iconic.woff` – Repository asset.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.event-stream-topics/context.md
+++ b/examples/cluster.event-stream-topics/context.md
@@ -1,0 +1,22 @@
+# Cluster Event Stream Topics Context
+
+## Overview
+Cluster-wide event stream topics sample.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `EventStreamTopicsCluster.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+* `messages.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* `Class MyMessage` defined in `Program.cs`
+* `Interface ITopicMessage` defined in `Program.cs`
+* `Class Program` defined in `Program.cs`
+* `Class Extensions` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.gossip/context.md
+++ b/examples/cluster.gossip/context.md
@@ -1,0 +1,19 @@
+# Cluster Gossip Context
+
+## Overview
+Example demonstrating cluster gossip inspection.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `ClusterGossip.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+* `Class EmptyActor` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.hello-world-grain/Messages/context.md
+++ b/examples/cluster.hello-world-grain/Messages/context.md
@@ -1,0 +1,17 @@
+# Messages Context
+
+## Overview
+Messages directory within the Proto.Actor repository.
+
+_Parent context: [Cluster Hello World Grain](../context.md)_
+
+## Key Files
+* `Messages.csproj` – Project file configuring compilation targets and dependencies.
+* `Protos.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.hello-world-grain/Node1/context.md
+++ b/examples/cluster.hello-world-grain/Node1/context.md
@@ -1,0 +1,17 @@
+# Node1 Context
+
+## Overview
+Node1 directory within the Proto.Actor repository.
+
+_Parent context: [Cluster Hello World Grain](../context.md)_
+
+## Key Files
+* `Node1.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.hello-world-grain/Node2/context.md
+++ b/examples/cluster.hello-world-grain/Node2/context.md
@@ -1,0 +1,17 @@
+# Node2 Context
+
+## Overview
+Node2 directory within the Proto.Actor repository.
+
+_Parent context: [Cluster Hello World Grain](../context.md)_
+
+## Key Files
+* `Node2.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* `Class HelloGrain` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.hello-world-grain/context.md
+++ b/examples/cluster.hello-world-grain/context.md
@@ -1,0 +1,21 @@
+# Cluster Hello World Grain Context
+
+## Overview
+Minimal cluster grain example.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `ClusterGrains.sln` – Solution file grouping related projects.
+* `README.md` – Markdown documentation.
+* `docker-compose.yml` – YAML configuration.
+* `run.sh` – Script file.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Messages](Messages/context.md) – See the nested context for details.
+* [Node1](Node1/context.md) – See the nested context for details.
+* [Node2](Node2/context.md) – See the nested context for details.
+

--- a/examples/cluster.kafka-virtual-actor-ingress/context.md
+++ b/examples/cluster.kafka-virtual-actor-ingress/context.md
@@ -1,0 +1,22 @@
+# Cluster Kafka Virtual Actor Ingress Context
+
+## Overview
+Kafka ingress feeding cluster grains.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `DeviceActor.cs` – C# source defining Device Actor behavior.
+* `KafkaVirtualActorIngress.csproj` – Project file configuring compilation targets and dependencies.
+* `MyMessages.proto` – Protocol Buffers schema.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+* `docker-compose.yml` – YAML configuration.
+
+## Primary Types and Contracts
+* `Class DeviceActor` defined in `DeviceActor.cs`
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.kubernetes-grains/Messages/context.md
+++ b/examples/cluster.kubernetes-grains/Messages/context.md
@@ -1,0 +1,17 @@
+# Messages Context
+
+## Overview
+Messages directory within the Proto.Actor repository.
+
+_Parent context: [Cluster Kubernetes Grains](../context.md)_
+
+## Key Files
+* `Messages.csproj` – Project file configuring compilation targets and dependencies.
+* `Protos.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.kubernetes-grains/Node1/context.md
+++ b/examples/cluster.kubernetes-grains/Node1/context.md
@@ -1,0 +1,18 @@
+# Node1 Context
+
+## Overview
+Node1 directory within the Proto.Actor repository.
+
+_Parent context: [Cluster Kubernetes Grains](../context.md)_
+
+## Key Files
+* `Dockerfile` – Repository asset.
+* `Node1.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.kubernetes-grains/Node2/context.md
+++ b/examples/cluster.kubernetes-grains/Node2/context.md
@@ -1,0 +1,18 @@
+# Node2 Context
+
+## Overview
+Node2 directory within the Proto.Actor repository.
+
+_Parent context: [Cluster Kubernetes Grains](../context.md)_
+
+## Key Files
+* `Dockerfile` – Repository asset.
+* `Node2.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* `Class HelloGrain` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.kubernetes-grains/chart/context.md
+++ b/examples/cluster.kubernetes-grains/chart/context.md
@@ -1,0 +1,18 @@
+# Chart Context
+
+## Overview
+Helm chart for the Kubernetes grains example.
+
+_Parent context: [Cluster Kubernetes Grains](../context.md)_
+
+## Key Files
+* `.helmignore` – Repository asset.
+* `Chart.yaml` – YAML configuration.
+* `values.yaml` – YAML configuration.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Templates](templates/context.md) – See the nested context for details.
+

--- a/examples/cluster.kubernetes-grains/chart/templates/context.md
+++ b/examples/cluster.kubernetes-grains/chart/templates/context.md
@@ -1,0 +1,22 @@
+# Templates Context
+
+## Overview
+Helm chart templates for Kubernetes grains example.
+
+_Parent context: [Chart](../context.md)_
+
+## Key Files
+* `namespace.yaml` – YAML configuration.
+* `node1-deployment.yaml` – YAML configuration.
+* `node2-deployment.yaml` – YAML configuration.
+* `protoactor-k8s-cluster-port-service.yaml` – YAML configuration.
+* `protoactor-k8s-grains-role.yaml` – YAML configuration.
+* `protoactor-k8s-grains-rolebinding.yaml` – YAML configuration.
+* `protoactor-k8s-grains-serviceaccount.yaml` – YAML configuration.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.kubernetes-grains/context.md
+++ b/examples/cluster.kubernetes-grains/context.md
@@ -1,0 +1,20 @@
+# Cluster Kubernetes Grains Context
+
+## Overview
+Kubernetes deployment example for grains.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `Clusterk8sGrains.sln` – Solution file grouping related projects.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Messages](Messages/context.md) – See the nested context for details.
+* [Node1](Node1/context.md) – See the nested context for details.
+* [Node2](Node2/context.md) – See the nested context for details.
+* [Chart](chart/context.md) – See the nested context for details.
+

--- a/examples/cluster.kubernetes-hello-world/context.md
+++ b/examples/cluster.kubernetes-hello-world/context.md
@@ -1,0 +1,21 @@
+# Cluster Kubernetes Hello World Context
+
+## Overview
+Hello world cluster deployment on Kubernetes.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `README.md` – Markdown documentation.
+* `build.sh` – Script file.
+* `cleanup.sh` – Script file.
+* `deploy.sh` – Script file.
+* `expose_consul.sh` – Script file.
+* `sed` – Repository asset.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Manifests](manifests/context.md) – See the nested context for details.
+

--- a/examples/cluster.kubernetes-hello-world/manifests/app/context.md
+++ b/examples/cluster.kubernetes-hello-world/manifests/app/context.md
@@ -1,0 +1,18 @@
+# App Context
+
+## Overview
+Application manifests for Kubernetes hello world.
+
+_Parent context: [Manifests](../context.md)_
+
+## Key Files
+* `node1.yaml` – YAML configuration.
+* `node2.yaml` – YAML configuration.
+* `node_template.yaml` – YAML configuration.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.kubernetes-hello-world/manifests/consul/context.md
+++ b/examples/cluster.kubernetes-hello-world/manifests/consul/context.md
@@ -1,0 +1,17 @@
+# Consul Context
+
+## Overview
+Consul deployment manifests for Kubernetes hello world example.
+
+_Parent context: [Manifests](../context.md)_
+
+## Key Files
+* `service.yaml` – YAML configuration.
+* `statefulsets.yaml` – YAML configuration.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.kubernetes-hello-world/manifests/context.md
+++ b/examples/cluster.kubernetes-hello-world/manifests/context.md
@@ -1,0 +1,17 @@
+# Manifests Context
+
+## Overview
+Kubernetes manifests used by the hello world cluster example.
+
+_Parent context: [Cluster Kubernetes Hello World](../context.md)_
+
+## Key Files
+* No direct files; primary content is nested in subdirectories.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [App](app/context.md) – See the nested context for details.
+* [Consul](consul/context.md) – See the nested context for details.
+

--- a/examples/cluster.pubsub-batching-producer/context.md
+++ b/examples/cluster.pubsub-batching-producer/context.md
@@ -1,0 +1,19 @@
+# Cluster Pubsub Batching Producer Context
+
+## Overview
+Batching producer example for cluster pub-sub.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `ClusterPubSubBatchingProducer.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+* `protos.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.pubsub/context.md
+++ b/examples/cluster.pubsub/context.md
@@ -1,0 +1,21 @@
+# Cluster Pubsub Context
+
+## Overview
+Cluster pub-sub example.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `ClusterPubSub.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+* `protos.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+* `Class User` defined in `Program.cs`
+* `Record Tick` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/cluster.statistics/context.md
+++ b/examples/cluster.statistics/context.md
@@ -1,0 +1,18 @@
+# Cluster Statistics Context
+
+## Overview
+Cluster statistics and diagnostics sample.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `ClusterStatistics.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/context.md
+++ b/examples/context.md
@@ -1,0 +1,53 @@
+# Examples Context
+
+## Overview
+Runnable samples that demonstrate Proto.Actor concepts, integrations, and troubleshooting scenarios.
+
+Each sample maps to runtime features from [`src/context.md`](../src/context.md) and can be exercised alongside the automated coverage in [`tests/context.md`](../tests/context.md) when validating changes.
+
+_Parent context: [Repository Root](../context.md)_
+
+## Key Files
+* `Directory.Build.props` – MSBuild configuration.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Actor Context Decorators](actor.context-decorators/context.md) – See the nested context for details.
+* [Actor Deadletter Throttling](actor.deadletter-throttling/context.md) – See the nested context for details.
+* [Actor Dependency Injection](actor.dependency-injection/context.md) – See the nested context for details.
+* [Actor Event Stream](actor.event-stream/context.md) – See the nested context for details.
+* [Actor Event Stream Topics](actor.event-stream-topics/context.md) – See the nested context for details.
+* [Actor Futures](actor.futures/context.md) – See the nested context for details.
+* [Actor Hello World](actor.hello-world/context.md) – See the nested context for details.
+* [Actor Hello World Fsharp](actor.hello-world-fsharp/context.md) – See the nested context for details.
+* [Actor Lifecycle Events](actor.lifecycle-events/context.md) – See the nested context for details.
+* [Actor Message Headers](actor.message-headers/context.md) – See the nested context for details.
+* [Actor Metrics](actor.metrics/context.md) – See the nested context for details.
+* [Actor Middleware](actor.middleware/context.md) – See the nested context for details.
+* [Actor Open Telemetry](actor.open-telemetry/context.md) – See the nested context for details.
+* [Actor Receive Timeout](actor.receive-timeout/context.md) – See the nested context for details.
+* [Actor Router](actor.router/context.md) – See the nested context for details.
+* [Actor Saga](actor.saga/context.md) – See the nested context for details.
+* [Actor Scheduled Messages](actor.scheduled-messages/context.md) – See the nested context for details.
+* [Actor Supervision](actor.supervision/context.md) – See the nested context for details.
+* [Actor Supervision Escalate](actor.supervision-escalate/context.md) – See the nested context for details.
+* [Cluster Aspnet Grains](cluster.aspnet-grains/context.md) – See the nested context for details.
+* [Cluster Dashboard Host](cluster.dashboard-host/context.md) – See the nested context for details.
+* [Cluster Event Stream Topics](cluster.event-stream-topics/context.md) – See the nested context for details.
+* [Cluster Gossip](cluster.gossip/context.md) – See the nested context for details.
+* [Cluster Hello World Grain](cluster.hello-world-grain/context.md) – See the nested context for details.
+* [Cluster Kafka Virtual Actor Ingress](cluster.kafka-virtual-actor-ingress/context.md) – See the nested context for details.
+* [Cluster Kubernetes Grains](cluster.kubernetes-grains/context.md) – See the nested context for details.
+* [Cluster Kubernetes Hello World](cluster.kubernetes-hello-world/context.md) – See the nested context for details.
+* [Cluster Pubsub](cluster.pubsub/context.md) – See the nested context for details.
+* [Cluster Pubsub Batching Producer](cluster.pubsub-batching-producer/context.md) – See the nested context for details.
+* [Cluster Statistics](cluster.statistics/context.md) – See the nested context for details.
+* [Persistence Basic](persistence.basic/context.md) – See the nested context for details.
+* [Remote Activate](remote.activate/context.md) – See the nested context for details.
+* [Remote Channels](remote.channels/context.md) – See the nested context for details.
+* [Remote Chat Example](remote.chat-example/context.md) – See the nested context for details.
+* [Remote Open Telemetry Tracing](remote.open-telemetry-tracing/context.md) – See the nested context for details.
+* [Remote Tls](remote.tls/context.md) – See the nested context for details.
+

--- a/examples/persistence.basic/Messages/context.md
+++ b/examples/persistence.basic/Messages/context.md
@@ -1,0 +1,17 @@
+# Messages Context
+
+## Overview
+Messages directory within the Proto.Actor repository.
+
+_Parent context: [Persistence Basic](../context.md)_
+
+## Key Files
+* `Messages.csproj` – Project file configuring compilation targets and dependencies.
+* `Protos.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/persistence.basic/Persistence/context.md
+++ b/examples/persistence.basic/Persistence/context.md
@@ -1,0 +1,21 @@
+# Persistence Context
+
+## Overview
+Persistence directory within the Proto.Actor repository.
+
+_Parent context: [Persistence Basic](../context.md)_
+
+## Key Files
+* `Persistence.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+* `Class MyPersistenceActor` defined in `Program.cs`
+* `Class StartLoopActor` defined in `Program.cs`
+* `Class LoopActor` defined in `Program.cs`
+* `Class LoopParentMessage` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/persistence.basic/context.md
+++ b/examples/persistence.basic/context.md
@@ -1,0 +1,17 @@
+# Persistence Basic Context
+
+## Overview
+Persistence Basic directory within the Proto.Actor repository.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Messages](Messages/context.md) – See the nested context for details.
+* [Persistence](Persistence/context.md) – See the nested context for details.
+

--- a/examples/remote.activate/Messages/context.md
+++ b/examples/remote.activate/Messages/context.md
@@ -1,0 +1,20 @@
+# Messages Context
+
+## Overview
+Messages directory within the Proto.Actor repository.
+
+_Parent context: [Remote Activate](../context.md)_
+
+## Key Files
+* `Messages.csproj` – Project file configuring compilation targets and dependencies.
+* `Protos.g.cs` – C# source defining Protos G behavior.
+* `Protos.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* `Class ProtosReflection` defined in `Protos.g.cs`
+* `Class HelloRequest` defined in `Protos.g.cs`
+* `Class HelloResponse` defined in `Protos.g.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/remote.activate/Node1/context.md
+++ b/examples/remote.activate/Node1/context.md
@@ -1,0 +1,18 @@
+# Node1 Context
+
+## Overview
+First node hosting remote actors.
+
+_Parent context: [Remote Activate](../context.md)_
+
+## Key Files
+* `Node1.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `runtimeconfig.template.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/remote.activate/Node2/context.md
+++ b/examples/remote.activate/Node2/context.md
@@ -1,0 +1,18 @@
+# Node2 Context
+
+## Overview
+Second node interacting with remote actors.
+
+_Parent context: [Remote Activate](../context.md)_
+
+## Key Files
+* `Node2.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `runtimeconfig.template.json` – Configuration or metadata in JSON format.
+
+## Primary Types and Contracts
+* `Class Program` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/remote.activate/context.md
+++ b/examples/remote.activate/context.md
@@ -1,0 +1,18 @@
+# Remote Activate Context
+
+## Overview
+Remote actor activation sample with two nodes.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Messages](Messages/context.md) – See the nested context for details.
+* [Node1](Node1/context.md) – See the nested context for details.
+* [Node2](Node2/context.md) – See the nested context for details.
+

--- a/examples/remote.channels/Client/context.md
+++ b/examples/remote.channels/Client/context.md
@@ -1,0 +1,17 @@
+# Client Context
+
+## Overview
+Client node for remote channels example.
+
+_Parent context: [Remote Channels](../context.md)_
+
+## Key Files
+* `Client.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/remote.channels/Common/context.md
+++ b/examples/remote.channels/Common/context.md
@@ -1,0 +1,24 @@
+# Common Context
+
+## Overview
+Shared contracts for remote channels example.
+
+_Parent context: [Remote Channels](../context.md)_
+
+## Key Files
+* `ChannelPublisherActor.cs` – C# source defining Channel Publisher Actor behavior.
+* `ChannelSubscriberActor.cs` – C# source defining Channel Subscriber Actor behavior.
+* `Common.csproj` – Project file configuring compilation targets and dependencies.
+* `Messages.cs` – C# source defining Messages behavior.
+
+## Primary Types and Contracts
+* `Class ChannelPublisher` defined in `ChannelPublisherActor.cs`
+* `Class ChannelPublisherActor` defined in `ChannelPublisherActor.cs`
+* `Class ChannelSubscriber` defined in `ChannelSubscriberActor.cs`
+* `Class ChannelSubscriberActor` defined in `ChannelSubscriberActor.cs`
+* `Record Subscribed` defined in `ChannelSubscriberActor.cs`
+* `Record MyMessage` defined in `Messages.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/remote.channels/Server/context.md
+++ b/examples/remote.channels/Server/context.md
@@ -1,0 +1,17 @@
+# Server Context
+
+## Overview
+Server node for remote channels example.
+
+_Parent context: [Remote Channels](../context.md)_
+
+## Key Files
+* `Program.cs` – C# source defining Program behavior.
+* `Server.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/remote.channels/context.md
+++ b/examples/remote.channels/context.md
@@ -1,0 +1,18 @@
+# Remote Channels Context
+
+## Overview
+Channel-based remote streaming example.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Client](Client/context.md) – See the nested context for details.
+* [Common](Common/context.md) – See the nested context for details.
+* [Server](Server/context.md) – See the nested context for details.
+

--- a/examples/remote.chat-example/Client/context.md
+++ b/examples/remote.chat-example/Client/context.md
@@ -1,0 +1,17 @@
+# Client Context
+
+## Overview
+Client node for chat example.
+
+_Parent context: [Remote Chat Example](../context.md)_
+
+## Key Files
+* `Client.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/remote.chat-example/Messages/context.md
+++ b/examples/remote.chat-example/Messages/context.md
@@ -1,0 +1,17 @@
+# Messages Context
+
+## Overview
+Contracts shared by chat example nodes.
+
+_Parent context: [Remote Chat Example](../context.md)_
+
+## Key Files
+* `Chat.Messages.csproj` – Project file configuring compilation targets and dependencies.
+* `Chat.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/remote.chat-example/Server/context.md
+++ b/examples/remote.chat-example/Server/context.md
@@ -1,0 +1,17 @@
+# Server Context
+
+## Overview
+Server node for chat example.
+
+_Parent context: [Remote Chat Example](../context.md)_
+
+## Key Files
+* `Program.cs` – C# source defining Program behavior.
+* `Server.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/remote.chat-example/context.md
+++ b/examples/remote.chat-example/context.md
@@ -1,0 +1,18 @@
+# Remote Chat Example Context
+
+## Overview
+Chat application demonstrating remote actors across nodes.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Client](Client/context.md) – See the nested context for details.
+* [Messages](Messages/context.md) – See the nested context for details.
+* [Server](Server/context.md) – See the nested context for details.
+

--- a/examples/remote.open-telemetry-tracing/context.md
+++ b/examples/remote.open-telemetry-tracing/context.md
@@ -1,0 +1,18 @@
+# Remote Open Telemetry Tracing Context
+
+## Overview
+Remote actors with OpenTelemetry tracing example.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `OpenTelemetryTracing.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/remote.tls/Client/context.md
+++ b/examples/remote.tls/Client/context.md
@@ -1,0 +1,17 @@
+# Client Context
+
+## Overview
+Client configured for TLS remoting.
+
+_Parent context: [Remote Tls](../context.md)_
+
+## Key Files
+* `Client.csproj` – Project file configuring compilation targets and dependencies.
+* `Program.cs` – C# source defining Program behavior.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/remote.tls/Common/context.md
+++ b/examples/remote.tls/Common/context.md
@@ -1,0 +1,18 @@
+# Common Context
+
+## Overview
+Shared TLS configuration assets.
+
+_Parent context: [Remote Tls](../context.md)_
+
+## Key Files
+* `Common.csproj` – Project file configuring compilation targets and dependencies.
+* `Messages.cs` – C# source defining Messages behavior.
+
+## Primary Types and Contracts
+* `Record HelloRequest` defined in `Messages.cs`
+* `Record HelloResponse` defined in `Messages.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/remote.tls/Server/context.md
+++ b/examples/remote.tls/Server/context.md
@@ -1,0 +1,17 @@
+# Server Context
+
+## Overview
+Server configured for TLS remoting.
+
+_Parent context: [Remote Tls](../context.md)_
+
+## Key Files
+* `Program.cs` – C# source defining Program behavior.
+* `Server.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* `Class GreeterActor` defined in `Program.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/examples/remote.tls/context.md
+++ b/examples/remote.tls/context.md
@@ -1,0 +1,18 @@
+# Remote Tls Context
+
+## Overview
+Remote actors communicating over TLS.
+
+_Parent context: [Examples](../context.md)_
+
+## Key Files
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Client](Client/context.md) – See the nested context for details.
+* [Common](Common/context.md) – See the nested context for details.
+* [Server](Server/context.md) – See the nested context for details.
+

--- a/logs/context.md
+++ b/logs/context.md
@@ -1,0 +1,100 @@
+# Logs Context
+
+## Overview
+Operational notes generated during repository maintenance tasks.
+
+_Parent context: [Repository Root](../context.md)_
+
+## Key Files
+* `exceptions.md` – Markdown documentation.
+* `log1755870784.md` – Markdown documentation.
+* `log1755871205.md` – Markdown documentation.
+* `log1755871331.md` – Markdown documentation.
+* `log1755872234.md` – Markdown documentation.
+* `log1755873369.md` – Markdown documentation.
+* `log1755875598.md` – Markdown documentation.
+* `log1755877694.md` – Markdown documentation.
+* `log1755879377.md` – Markdown documentation.
+* `log1755879960.md` – Markdown documentation.
+* `log1755881596.md` – Markdown documentation.
+* `log1755883079.md` – Markdown documentation.
+* `log1755884377.md` – Markdown documentation.
+* `log1755885706.md` – Markdown documentation.
+* `log1755887131.md` – Markdown documentation.
+* `log1755887133.md` – Markdown documentation.
+* `log1755887170.md` – Markdown documentation.
+* `log1755887442.md` – Markdown documentation.
+* `log1755890580.md` – Markdown documentation.
+* `log1755890748.md` – Markdown documentation.
+* `log1755892615.md` – Markdown documentation.
+* `log1755892790.md` – Markdown documentation.
+* `log1755893016.md` – Markdown documentation.
+* `log1755894226.md` – Markdown documentation.
+* `log1755928636.md` – Markdown documentation.
+* `log1755929684.md` – Markdown documentation.
+* `log1755930042.md` – Markdown documentation.
+* `log1755937495.md` – Markdown documentation.
+* `log1755937774.md` – Markdown documentation.
+* `log1755938425.md` – Markdown documentation.
+* `log1755940222.md` – Markdown documentation.
+* `log1755940517.md` – Markdown documentation.
+* `log1755940658.md` – Markdown documentation.
+* `log1755941043.md` – Markdown documentation.
+* `log1755942454.md` – Markdown documentation.
+* `log1755942573.md` – Markdown documentation.
+* `log1755949362.md` – Markdown documentation.
+* `log1755953264.md` – Markdown documentation.
+* `log1755969060.md` – Markdown documentation.
+* `log1755972031.md` – Markdown documentation.
+* `log1755972987.md` – Markdown documentation.
+* `log1755973076.md` – Markdown documentation.
+* `log1755973590.md` – Markdown documentation.
+* `log1755974004.md` – Markdown documentation.
+* `log1755975410.md` – Markdown documentation.
+* `log1755975701.md` – Markdown documentation.
+* `log1755976135.md` – Markdown documentation.
+* `log1755977078.md` – Markdown documentation.
+* `log1755977337.md` – Markdown documentation.
+* `log1755978126.md` – Markdown documentation.
+* `log1755980804.md` – Markdown documentation.
+* `log1756009491.md` – Markdown documentation.
+* `log1756009684.md` – Markdown documentation.
+* `log1756010588.md` – Markdown documentation.
+* `log1756012262.md` – Markdown documentation.
+* `log1756013526.md` – Markdown documentation.
+* `log1756014903.md` – Markdown documentation.
+* `log1756017958.md` – Markdown documentation.
+* `log1756018838.md` – Markdown documentation.
+* `log1756021716.md` – Markdown documentation.
+* `log1756024459.md` – Markdown documentation.
+* `log1756064359.md` – Markdown documentation.
+* `log1756067564.md` – Markdown documentation.
+* `log1756071034.md` – Markdown documentation.
+* `log1756071104.md` – Markdown documentation.
+* `log1756071220.md` – Markdown documentation.
+* `log1756098266.md` – Markdown documentation.
+* `log1756108907.md` – Markdown documentation.
+* `log1756110054.md` – Markdown documentation.
+* `log1756114527.md` – Markdown documentation.
+* `log1756115099.md` – Markdown documentation.
+* `log1756116841.md` – Markdown documentation.
+* `log1756121959.md` – Markdown documentation.
+* `log1756122285.md` – Markdown documentation.
+* `log1756123592.md` – Markdown documentation.
+* `log1756124640.md` – Markdown documentation.
+* `log1756126119.md` – Markdown documentation.
+* `log1756126139.md` – Markdown documentation.
+* `log1756132378.md` – Markdown documentation.
+* `log1756135976.md` – Markdown documentation.
+* `log1756138092.md` – Markdown documentation.
+* `log1756141591.md` – Markdown documentation.
+* `log1756143118.md` – Markdown documentation.
+* `log1756149439.md` – Markdown documentation.
+* `log1759123815.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/logs/log1759123815.md
+++ b/logs/log1759123815.md
@@ -1,0 +1,9 @@
+# Task Log
+
+## Summary of Actions
+- Generated `context.md` knowledge cards for every directory in the repository to create an AI-friendly navigation index.
+- Enhanced context generation script to capture key files, primary types, and hierarchical links across subsystems.
+- Updated `AGENTS.md` to codify usage and maintenance expectations for the new context index.
+
+## Motivation
+Providing structured directory-level summaries accelerates comprehension for AI agents and humans alike, making it faster to identify relevant subsystems and types before editing code. Formalizing this requirement in `AGENTS.md` ensures the knowledge base stays accurate as the code evolves.

--- a/src/Proto.Actor/Context/context.md
+++ b/src/Proto.Actor/Context/context.md
@@ -1,0 +1,82 @@
+# Context Context
+
+## Overview
+ActorContext and IContext implementations orchestrating message flow, lifecycle, and middleware.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `ActorContext.cs` – C# source defining Actor Context behavior.
+* `ActorContextDecorator.cs` – C# source defining Actor Context Decorator behavior.
+* `ActorContextExtras.cs` – C# source defining Actor Context Extras behavior.
+* `ActorContextLogMessages.cs` – C# source defining Actor Context Log Messages behavior.
+* `ActorLoggingContext.cs` – C# source defining Actor Logging Context behavior.
+* `ActorLoggingContextExtensions.cs` – C# source defining Actor Logging Context Extensions behavior.
+* `BatchContext.cs` – C# source defining Batch Context behavior.
+* `BatchContextLogMessages.cs` – C# source defining Batch Context Log Messages behavior.
+* `CapturedContext.cs` – C# source defining Captured Context behavior.
+* `ContextState.cs` – C# source defining Context State behavior.
+* `DeadlineContextDecorator.cs` – C# source defining Deadline Context Decorator behavior.
+* `DeadlineContextDecoratorLogMessages.cs` – C# source defining Deadline Context Decorator Log Messages behavior.
+* `IContext.cs` – C# source defining I Context behavior.
+* `IContextStore.cs` – C# source defining I Context Store behavior.
+* `IInfoContext.cs` – C# source defining I Info Context behavior.
+* `IReceiverContext.cs` – C# source defining I Receiver Context behavior.
+* `ISenderContext.cs` – C# source defining I Sender Context behavior.
+* `ISpawnerContext.cs` – C# source defining I Spawner Context behavior.
+* `IStopperContext.cs` – C# source defining I Stopper Context behavior.
+* `ISystemContext.cs` – C# source defining I System Context behavior.
+* `PassivationContextDecorator.cs` – C# source defining Passivation Context Decorator behavior.
+* `ReenterAfterExtensions.cs` – C# source defining Reenter After Extensions behavior.
+* `RootContext.cs` – C# source defining Root Context behavior.
+* `RootContextDecorator.cs` – C# source defining Root Context Decorator behavior.
+* `RootContextLogMessages.cs` – C# source defining Root Context Log Messages behavior.
+* `RootLoggingContext.cs` – C# source defining Root Logging Context behavior.
+* `SenderContextLogMessages.cs` – C# source defining Sender Context Log Messages behavior.
+* `StartupDeadlineContextDecorator.cs` – C# source defining Startup Deadline Context Decorator behavior.
+* `StartupDeadlineContextDecoratorLogMessages.cs` – C# source defining Startup Deadline Context Decorator Log Messages behavior.
+* `SystemContext.cs` – C# source defining System Context behavior.
+* `SystemContextLogMessages.cs` – C# source defining System Context Log Messages behavior.
+
+## Primary Types and Contracts
+* `Class ActorContext` defined in `ActorContext.cs`
+* `Class ActorContextDecorator` defined in `ActorContextDecorator.cs`
+* `Class ActorContextExtras` defined in `ActorContextExtras.cs`
+* `Class ActorContextLogMessages` defined in `ActorContextLogMessages.cs`
+* `Class ActorLoggingContext` defined in `ActorLoggingContext.cs`
+* `Class ActorLoggingContextExtensions` defined in `ActorLoggingContextExtensions.cs`
+* `Class BatchContext` defined in `BatchContext.cs`
+* `Class BatchContextLogMessages` defined in `BatchContextLogMessages.cs`
+* `Record CapturedContext` defined in `CapturedContext.cs`
+* `Enum ContextState` defined in `ContextState.cs`
+* `Class DeadlineContextExtensions` defined in `DeadlineContextDecorator.cs`
+* `Class DeadlineContextDecorator` defined in `DeadlineContextDecorator.cs`
+* `Class DeadlineContextDecoratorLogMessages` defined in `DeadlineContextDecoratorLogMessages.cs`
+* `Interface IContext` defined in `IContext.cs`
+* `Interface IContextStore` defined in `IContextStore.cs`
+* `Interface IInfoContext` defined in `IInfoContext.cs`
+* `Interface IReceiverContext` defined in `IReceiverContext.cs`
+* `Interface ISenderContext` defined in `ISenderContext.cs`
+* `Class SenderContextExtensions` defined in `ISenderContext.cs`
+* `Interface ISpawnerContext` defined in `ISpawnerContext.cs`
+* `Class SpawnerContextExtensions` defined in `ISpawnerContext.cs`
+* `Interface IStopperContext` defined in `IStopperContext.cs`
+* `Interface ISystemContext` defined in `ISystemContext.cs`
+* `Class PassivationContextExtensions` defined in `PassivationContextDecorator.cs`
+* `Class PassivationContextDecorator` defined in `PassivationContextDecorator.cs`
+* `Class ReenterAfterExtensions` defined in `ReenterAfterExtensions.cs`
+* `Interface IRootContext` defined in `RootContext.cs`
+* `Record RootContext` defined in `RootContext.cs`
+* `Class RootContextDecorator` defined in `RootContextDecorator.cs`
+* `Class RootContextLogMessages` defined in `RootContextLogMessages.cs`
+* `Class RootLoggingContext` defined in `RootLoggingContext.cs`
+* `Class SenderContextLogMessages` defined in `SenderContextLogMessages.cs`
+* `Class StartupDeadlineContextExtensions` defined in `StartupDeadlineContextDecorator.cs`
+* `Class StartupDeadlineContextDecorator` defined in `StartupDeadlineContextDecorator.cs`
+* `Class StartupDeadlineContextDecoratorLogMessages` defined in `StartupDeadlineContextDecoratorLogMessages.cs`
+* `Class SystemContext` defined in `SystemContext.cs`
+* `Class SystemContextLogMessages` defined in `SystemContextLogMessages.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Deduplication/context.md
+++ b/src/Proto.Actor/Deduplication/context.md
@@ -1,0 +1,19 @@
+# Deduplication Context
+
+## Overview
+Utilities for deduplicating actor messages in transit.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `DeDuplicatorLogMessages.cs` – C# source defining De Duplicator Log Messages behavior.
+* `DeduplicationContext.cs` – C# source defining Deduplication Context behavior.
+
+## Primary Types and Contracts
+* `Class DeDuplicatorLogMessages` defined in `DeDuplicatorLogMessages.cs`
+* `Class DeduplicationContext` defined in `DeduplicationContext.cs`
+* `Class DeDuplicator` defined in `DeduplicationContext.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/DependencyInjection/context.md
+++ b/src/Proto.Actor/DependencyInjection/context.md
@@ -1,0 +1,23 @@
+# Dependency Injection Context
+
+## Overview
+Integration with dependency injection containers for actor construction.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `DIExtension.cs` – C# source defining DI Extension behavior.
+* `DependencyResolver.cs` – C# source defining Dependency Resolver behavior.
+* `DependencyResolverLogMessages.cs` – C# source defining Dependency Resolver Log Messages behavior.
+* `IDependencyResolver.cs` – C# source defining I Dependency Resolver behavior.
+
+## Primary Types and Contracts
+* `Class DIExtension` defined in `DIExtension.cs`
+* `Class Extensions` defined in `DIExtension.cs`
+* `Class DependencyResolver` defined in `DependencyResolver.cs`
+* `Class DependencyResolverLogMessages` defined in `DependencyResolverLogMessages.cs`
+* `Interface IDependencyResolver` defined in `IDependencyResolver.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Diagnostics/context.md
+++ b/src/Proto.Actor/Diagnostics/context.md
@@ -1,0 +1,28 @@
+# Diagnostics Context
+
+## Overview
+Diagnostics hooks and tracing helpers for the actor runtime.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `DiagnosticTools.cs` – C# source defining Diagnostic Tools behavior.
+* `DiagnosticsEntry.cs` – C# source defining Diagnostics Entry behavior.
+* `DiagnosticsSerializer.cs` – C# source defining Diagnostics Serializer behavior.
+* `DiagnosticsStore.cs` – C# source defining Diagnostics Store behavior.
+* `IActorDiagnostics.cs` – C# source defining I Actor Diagnostics behavior.
+* `IDiagnosticsProvider.cs` – C# source defining I Diagnostics Provider behavior.
+* `IDiagnosticsTypeName.cs` – C# source defining I Diagnostics Type Name behavior.
+
+## Primary Types and Contracts
+* `Class DiagnosticTools` defined in `DiagnosticTools.cs`
+* `Record DiagnosticsEntry` defined in `DiagnosticsEntry.cs`
+* `Class DiagnosticsSerializer` defined in `DiagnosticsSerializer.cs`
+* `Class DiagnosticsStore` defined in `DiagnosticsStore.cs`
+* `Interface IActorDiagnostics` defined in `IActorDiagnostics.cs`
+* `Interface IDiagnosticsProvider` defined in `IDiagnosticsProvider.cs`
+* `Interface IDiagnosticsTypeName` defined in `IDiagnosticsTypeName.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/EventStream/context.md
+++ b/src/Proto.Actor/EventStream/context.md
@@ -1,0 +1,33 @@
+# Event Stream Context
+
+## Overview
+Event stream pub-sub infrastructure used internally by the runtime.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `DeadLetter.cs` – C# source defining Dead Letter behavior.
+* `EventExpectation.cs` – C# source defining Event Expectation behavior.
+* `EventProbe.cs` – C# source defining Event Probe behavior.
+* `EventProbeLogMessages.cs` – C# source defining Event Probe Log Messages behavior.
+* `EventStream.cs` – C# source defining Event Stream behavior.
+* `EventStreamLogMessages.cs` – C# source defining Event Stream Log Messages behavior.
+* `EventStreamProcess.cs` – C# source defining Event Stream Process behavior.
+
+## Primary Types and Contracts
+* `Class DeadLetterEvent` defined in `DeadLetter.cs`
+* `Class DeadLetterProcess` defined in `DeadLetter.cs`
+* `Class DeadLetterException` defined in `DeadLetter.cs`
+* `Class EventExpectation` defined in `EventExpectation.cs`
+* `Class EventStreamExtensions` defined in `EventProbe.cs`
+* `Class EventProbe` defined in `EventProbe.cs`
+* `Class EventProbeLogMessages` defined in `EventProbeLogMessages.cs`
+* `Class EventStream` defined in `EventStream.cs`
+* `Class EventStream` defined in `EventStream.cs`
+* `Class EventStreamSubscription` defined in `EventStream.cs`
+* `Class EventStreamLogMessages` defined in `EventStreamLogMessages.cs`
+* `Class EventStreamProcess` defined in `EventStreamProcess.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Extensions/context.md
+++ b/src/Proto.Actor/Extensions/context.md
@@ -1,0 +1,21 @@
+# Extensions Context
+
+## Overview
+Extension points hooking into Proto.Actor runtime behavior.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `ActorSystemExtensions.cs` – C# source defining Actor System Extensions behavior.
+* `IActorSystemExtension.cs` – C# source defining I Actor System Extension behavior.
+* `TypeExtensions.cs` – C# source defining Type Extensions behavior.
+
+## Primary Types and Contracts
+* `Class ActorSystemExtensions` defined in `ActorSystemExtensions.cs`
+* `Interface IActorSystemExtension` defined in `IActorSystemExtension.cs`
+* `Interface IActorSystemExtension` defined in `IActorSystemExtension.cs`
+* `Class TypeExtensions` defined in `TypeExtensions.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Future/context.md
+++ b/src/Proto.Actor/Future/context.md
@@ -1,0 +1,25 @@
+# Future Context
+
+## Overview
+Future/TCS helpers for awaiting actor responses.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `FutureBatch.cs` – C# source defining Future Batch behavior.
+* `Futures.cs` – C# source defining Futures behavior.
+* `SharedFuture.cs` – C# source defining Shared Future behavior.
+
+## Primary Types and Contracts
+* `Class FutureBatchProcess` defined in `FutureBatch.cs`
+* `Class SimpleFutureHandle` defined in `FutureBatch.cs`
+* `Interface IFuture` defined in `Futures.cs`
+* `Class FutureFactory` defined in `Futures.cs`
+* `Class FutureProcess` defined in `Futures.cs`
+* `Class SharedFutureProcess` defined in `SharedFuture.cs`
+* `Class SharedFutureHandle` defined in `SharedFuture.cs`
+* `Class FutureHandle` defined in `SharedFuture.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Logging/context.md
+++ b/src/Proto.Actor/Logging/context.md
@@ -1,0 +1,28 @@
+# Logging Context
+
+## Overview
+Typed logging extensions and abstractions for actors.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `Extensions.cs` – C# source defining Extensions behavior.
+* `InstanceLogger.cs` – C# source defining Instance Logger behavior.
+* `Log.cs` – C# source defining Log behavior.
+* `LogStore.cs` – C# source defining Log Store behavior.
+* `LogStoreEntry.cs` – C# source defining Log Store Entry behavior.
+* `LogValueFormatter.cs` – C# source defining Log Value Formatter behavior.
+* `NullLoggerFactory.cs` – C# source defining Null Logger Factory behavior.
+
+## Primary Types and Contracts
+* `Class Extensions` defined in `Extensions.cs`
+* `Class InstanceLogger` defined in `InstanceLogger.cs`
+* `Class Log` defined in `Log.cs`
+* `Class LogStore` defined in `LogStore.cs`
+* `Record LogStoreEntry` defined in `LogStoreEntry.cs`
+* `Class LogValuesFormatter` defined in `LogValueFormatter.cs`
+* `Class NullLoggerFactory` defined in `NullLoggerFactory.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Mailbox/context.md
+++ b/src/Proto.Actor/Mailbox/context.md
@@ -1,0 +1,52 @@
+# Mailbox Context
+
+## Overview
+Mailboxes and dispatchers responsible for scheduling actor message processing.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `BatchingMailbox.cs` – C# source defining Batching Mailbox behavior.
+* `BoundedMailbox.cs` – C# source defining Bounded Mailbox behavior.
+* `BoundedMailboxQueue.cs` – C# source defining Bounded Mailbox Queue behavior.
+* `DefaultMailbox.cs` – C# source defining Default Mailbox behavior.
+* `Dispatcher.cs` – C# source defining Dispatcher behavior.
+* `IMailbox.cs` – C# source defining I Mailbox behavior.
+* `LockingUnboundedMailboxQueue.cs` – C# source defining Locking Unbounded Mailbox Queue behavior.
+* `MPMCQueue.cs` – C# source defining MPMC Queue behavior.
+* `Messages.cs` – C# source defining Messages behavior.
+* `NonBlockingBoundedMailbox.cs` – C# source defining Non Blocking Bounded Mailbox behavior.
+* `Queue.cs` – C# source defining Queue behavior.
+* `UnboundedMailbox.cs` – C# source defining Unbounded Mailbox behavior.
+* `UnboundedMailboxQueue.cs` – C# source defining Unbounded Mailbox Queue behavior.
+
+## Primary Types and Contracts
+* `Record MessageBatch` defined in `BatchingMailbox.cs`
+* `Class BatchingMailbox` defined in `BatchingMailbox.cs`
+* `Class BoundedMailbox` defined in `BoundedMailbox.cs`
+* `Class BoundedMailboxQueue` defined in `BoundedMailboxQueue.cs`
+* `Class DefaultMailbox` defined in `DefaultMailbox.cs`
+* `Interface IMailboxStatistics` defined in `DefaultMailbox.cs`
+* `Interface IMessageInvoker` defined in `Dispatcher.cs`
+* `Interface IDispatcher` defined in `Dispatcher.cs`
+* `Class Dispatchers` defined in `Dispatcher.cs`
+* `Class SynchronousDispatcher` defined in `Dispatcher.cs`
+* `Class ThreadPoolDispatcher` defined in `Dispatcher.cs`
+* `Class CurrentSynchronizationContextDispatcher` defined in `Dispatcher.cs`
+* `Class NoopDispatcher` defined in `Dispatcher.cs`
+* `Class NoopInvoker` defined in `Dispatcher.cs`
+* `Interface IMailbox` defined in `IMailbox.cs`
+* `Class LockingUnboundedMailboxQueue` defined in `LockingUnboundedMailboxQueue.cs`
+* `Class MPMCQueue` defined in `MPMCQueue.cs`
+* `Struct Cell` defined in `MPMCQueue.cs`
+* `Interface SystemMessage` defined in `Messages.cs`
+* `Class SuspendMailbox` defined in `Messages.cs`
+* `Class ResumeMailbox` defined in `Messages.cs`
+* `Class NonBlockingBoundedMailbox` defined in `NonBlockingBoundedMailbox.cs`
+* `Interface IMailboxQueue` defined in `Queue.cs`
+* `Class UnboundedMailbox` defined in `UnboundedMailbox.cs`
+* `Class UnboundedMailboxQueue` defined in `UnboundedMailboxQueue.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Messages/context.md
+++ b/src/Proto.Actor/Messages/context.md
@@ -1,0 +1,44 @@
+# Messages Context
+
+## Overview
+Messages directory within the Proto.Actor repository.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `IAutoRespond.cs` – C# source defining I Auto Respond behavior.
+* `IMessageBatch.cs` – C# source defining I Message Batch behavior.
+* `MessageEnvelope.cs` – C# source defining Message Envelope behavior.
+* `MessageExtensions.cs` – C# source defining Message Extensions behavior.
+* `MessageHeader.cs` – C# source defining Message Header behavior.
+* `Messages.cs` – C# source defining Messages behavior.
+
+## Primary Types and Contracts
+* `Interface IAutoRespond` defined in `IAutoRespond.cs`
+* `Interface IMessageBatch` defined in `IMessageBatch.cs`
+* `Record MessageEnvelope` defined in `MessageEnvelope.cs`
+* `Class Terminated` defined in `MessageExtensions.cs`
+* `Record MessageHeader` defined in `MessageHeader.cs`
+* `Interface InfrastructureMessage` defined in `Messages.cs`
+* `Interface IIgnoreDeadLetterLogging` defined in `Messages.cs`
+* `Class Terminated` defined in `Messages.cs`
+* `Class Restarting` defined in `Messages.cs`
+* `Class Touch` defined in `Messages.cs`
+* `Class PoisonPill` defined in `Messages.cs`
+* `Class Failure` defined in `Messages.cs`
+* `Class Watch` defined in `Messages.cs`
+* `Class Unwatch` defined in `Messages.cs`
+* `Class Restart` defined in `Messages.cs`
+* `Class Stop` defined in `Messages.cs`
+* `Class Stopping` defined in `Messages.cs`
+* `Class Started` defined in `Messages.cs`
+* `Class Stopped` defined in `Messages.cs`
+* `Class ReceiveTimeout` defined in `Messages.cs`
+* `Interface INotInfluenceReceiveTimeout` defined in `Messages.cs`
+* `Class Continuation` defined in `Messages.cs`
+* `Record ProcessDiagnosticsRequest` defined in `Messages.cs`
+* `Class Nothing` defined in `Messages.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Metrics/context.md
+++ b/src/Proto.Actor/Metrics/context.md
@@ -1,0 +1,22 @@
+# Metrics Context
+
+## Overview
+Metrics hooks for actor-level instrumentation.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `ActorMetrics.cs` – C# source defining Actor Metrics behavior.
+* `Metrics.cs` – C# source defining Metrics behavior.
+* `MetricsExtensions.cs` – C# source defining Metrics Extensions behavior.
+* `ObservableGaugeWrapper.cs` – C# source defining Observable Gauge Wrapper behavior.
+
+## Primary Types and Contracts
+* `Class ActorMetrics` defined in `ActorMetrics.cs`
+* `Class ProtoMetrics` defined in `Metrics.cs`
+* `Class MetricsExtensions` defined in `MetricsExtensions.cs`
+* `Class ObservableGaugeWrapper` defined in `ObservableGaugeWrapper.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Process/context.md
+++ b/src/Proto.Actor/Process/context.md
@@ -1,0 +1,20 @@
+# Process Context
+
+## Overview
+Process registry and PID management for addressing actors.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `ActorProcess.cs` – C# source defining Actor Process behavior.
+* `Process.cs` – C# source defining Process behavior.
+* `ProcessRegistry.cs` – C# source defining Process Registry behavior.
+
+## Primary Types and Contracts
+* `Class ActorProcess` defined in `ActorProcess.cs`
+* `Class Process` defined in `Process.cs`
+* `Class ProcessRegistry` defined in `ProcessRegistry.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Properties/context.md
+++ b/src/Proto.Actor/Properties/context.md
@@ -1,0 +1,16 @@
+# Properties Context
+
+## Overview
+Assembly metadata and configuration files for the Proto.Actor package.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `AssemblyInfo.cs` – C# source defining Assembly Info behavior.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Props/context.md
+++ b/src/Proto.Actor/Props/context.md
@@ -1,0 +1,16 @@
+# Props Context
+
+## Overview
+Actor Props configuration, decorators, and spawning logic.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `Props.cs` – C# source defining Props behavior.
+
+## Primary Types and Contracts
+* `Record Props` defined in `Props.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Router/Messages/context.md
+++ b/src/Proto.Actor/Router/Messages/context.md
@@ -1,0 +1,21 @@
+# Messages Context
+
+## Overview
+Routing messages and configuration commands for router actors.
+
+_Parent context: [Router](../context.md)_
+
+## Key Files
+* `RouterMessages.cs` – C# source defining Router Messages behavior.
+
+## Primary Types and Contracts
+* `Record Routees` defined in `RouterMessages.cs`
+* `Record RouterManagementMessage` defined in `RouterMessages.cs`
+* `Record RouterAddRoutee` defined in `RouterMessages.cs`
+* `Record RouterBroadcastMessage` defined in `RouterMessages.cs`
+* `Record RouterRemoveRoutee` defined in `RouterMessages.cs`
+* `Record RouterGetRoutees` defined in `RouterMessages.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Router/Routers/context.md
+++ b/src/Proto.Actor/Router/Routers/context.md
@@ -1,0 +1,48 @@
+# Routers Context
+
+## Overview
+Concrete router logic implementing the different routing strategies.
+
+_Parent context: [Router](../context.md)_
+
+## Key Files
+* `BroadcastGroupRouterConfig.cs` – C# source defining Broadcast Group Router Config behavior.
+* `BroadcastPoolRouterConfig.cs` – C# source defining Broadcast Pool Router Config behavior.
+* `BroadcastRouterState.cs` – C# source defining Broadcast Router State behavior.
+* `ConsistentHashGroupRouterConfig.cs` – C# source defining Consistent Hash Group Router Config behavior.
+* `ConsistentHashPoolRouterConfig.cs` – C# source defining Consistent Hash Pool Router Config behavior.
+* `ConsistentHashRouterState.cs` – C# source defining Consistent Hash Router State behavior.
+* `GroupRouterConfig.cs` – C# source defining Group Router Config behavior.
+* `PoolRouterConfig.cs` – C# source defining Pool Router Config behavior.
+* `RandomGroupRouterConfig.cs` – C# source defining Random Group Router Config behavior.
+* `RandomPoolRouterConfig.cs` – C# source defining Random Pool Router Config behavior.
+* `RandomRouterState.cs` – C# source defining Random Router State behavior.
+* `RoundRobinGroupRouterConfig.cs` – C# source defining Round Robin Group Router Config behavior.
+* `RoundRobinPoolRouterConfig.cs` – C# source defining Round Robin Pool Router Config behavior.
+* `RoundRobinRouterState.cs` – C# source defining Round Robin Router State behavior.
+* `RouterConfig.cs` – C# source defining Router Config behavior.
+* `RouterState.cs` – C# source defining Router State behavior.
+
+## Primary Types and Contracts
+* `Record BroadcastGroupRouterConfig` defined in `BroadcastGroupRouterConfig.cs`
+* `Record BroadcastPoolRouterConfig` defined in `BroadcastPoolRouterConfig.cs`
+* `Class BroadcastRouterState` defined in `BroadcastRouterState.cs`
+* `Record ConsistentHashGroupRouterConfig` defined in `ConsistentHashGroupRouterConfig.cs`
+* `Record ConsistentHashPoolRouterConfig` defined in `ConsistentHashPoolRouterConfig.cs`
+* `Class ConsistentHashRouterState` defined in `ConsistentHashRouterState.cs`
+* `Record GroupRouterConfig` defined in `GroupRouterConfig.cs`
+* `Record PoolRouterConfig` defined in `PoolRouterConfig.cs`
+* `Record RandomGroupRouterConfig` defined in `RandomGroupRouterConfig.cs`
+* `Record RandomPoolRouterConfig` defined in `RandomPoolRouterConfig.cs`
+* `Class RandomRouterState` defined in `RandomRouterState.cs`
+* `Record RoundRobinGroupRouterConfig` defined in `RoundRobinGroupRouterConfig.cs`
+* `Record RoundRobinPoolRouterConfig` defined in `RoundRobinPoolRouterConfig.cs`
+* `Class RoundRobinRouterState` defined in `RoundRobinRouterState.cs`
+* `Record RouterConfig` defined in `RouterConfig.cs`
+* `Class RouterStartNotification` defined in `RouterConfig.cs`
+* `Class RouterStartFailedException` defined in `RouterConfig.cs`
+* `Class RouterState` defined in `RouterState.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Router/context.md
+++ b/src/Proto.Actor/Router/context.md
@@ -1,0 +1,25 @@
+# Router Context
+
+## Overview
+Routing actors and their message contracts, supporting broadcast, round-robin, consistent hashing, and other routers.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `HashRing.cs` – C# source defining Hash Ring behavior.
+* `IHashable.cs` – C# source defining I Hashable behavior.
+* `RouterActor.cs` – C# source defining Router Actor behavior.
+* `RouterExtensions.cs` – C# source defining Router Extensions behavior.
+* `RouterProcess.cs` – C# source defining Router Process behavior.
+
+## Primary Types and Contracts
+* `Class HashRing` defined in `HashRing.cs`
+* `Interface IHashable` defined in `IHashable.cs`
+* `Class RouterActor` defined in `RouterActor.cs`
+* `Class RouterExtensions` defined in `RouterExtensions.cs`
+* `Class RouterProcess` defined in `RouterProcess.cs`
+
+## Related Subcontexts
+* [Messages](Messages/context.md) – See the nested context for details.
+* [Routers](Routers/context.md) – See the nested context for details.
+

--- a/src/Proto.Actor/Supervision/context.md
+++ b/src/Proto.Actor/Supervision/context.md
@@ -1,0 +1,39 @@
+# Supervision Context
+
+## Overview
+Supervision strategies, restart logic, and escalation behavior.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `AllForOneStrategy.cs` – C# source defining All For One Strategy behavior.
+* `AllForOneStrategyLogMessages.cs` – C# source defining All For One Strategy Log Messages behavior.
+* `AlwaysRestartStrategy.cs` – C# source defining Always Restart Strategy behavior.
+* `ExponentialBackoffStrategy.cs` – C# source defining Exponential Backoff Strategy behavior.
+* `Guardians.cs` – C# source defining Guardians behavior.
+* `ISupervisor.cs` – C# source defining I Supervisor behavior.
+* `ISupervisorStrategy.cs` – C# source defining I Supervisor Strategy behavior.
+* `OneForOneStrategy.cs` – C# source defining One For One Strategy behavior.
+* `OneForOneStrategyLogMessages.cs` – C# source defining One For One Strategy Log Messages behavior.
+* `RestartStatistics.cs` – C# source defining Restart Statistics behavior.
+* `Supervision.cs` – C# source defining Supervision behavior.
+* `SupervisorDirective.cs` – C# source defining Supervisor Directive behavior.
+
+## Primary Types and Contracts
+* `Class AllForOneStrategy` defined in `AllForOneStrategy.cs`
+* `Class AllForOneStrategyLogMessages` defined in `AllForOneStrategyLogMessages.cs`
+* `Class AlwaysRestartStrategy` defined in `AlwaysRestartStrategy.cs`
+* `Class ExponentialBackoffStrategy` defined in `ExponentialBackoffStrategy.cs`
+* `Class Guardians` defined in `Guardians.cs`
+* `Class GuardianProcess` defined in `Guardians.cs`
+* `Interface ISupervisor` defined in `ISupervisor.cs`
+* `Interface ISupervisorStrategy` defined in `ISupervisorStrategy.cs`
+* `Class OneForOneStrategy` defined in `OneForOneStrategy.cs`
+* `Class OneForOneStrategyLogMessages` defined in `OneForOneStrategyLogMessages.cs`
+* `Class RestartStatistics` defined in `RestartStatistics.cs`
+* `Class Supervision` defined in `Supervision.cs`
+* `Enum SupervisorDirective` defined in `SupervisorDirective.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Timers/context.md
+++ b/src/Proto.Actor/Timers/context.md
@@ -1,0 +1,20 @@
+# Timers Context
+
+## Overview
+Timer and scheduling primitives for actors.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `ISchedulerHook.cs` – C# source defining I Scheduler Hook behavior.
+* `Scheduler.cs` – C# source defining Scheduler behavior.
+* `TimerExtensions.cs` – C# source defining Timer Extensions behavior.
+
+## Primary Types and Contracts
+* `Interface ISchedulerHook` defined in `ISchedulerHook.cs`
+* `Class Scheduler` defined in `Scheduler.cs`
+* `Class TimerExtensions` defined in `TimerExtensions.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/Utils/context.md
+++ b/src/Proto.Actor/Utils/context.md
@@ -1,0 +1,46 @@
+# Utils Context
+
+## Overview
+Shared runtime utilities and helpers used by the actor system.
+
+_Parent context: [Proto Actor](../context.md)_
+
+## Key Files
+* `AsyncSemaphore.cs` – C# source defining Async Semaphore behavior.
+* `ConcurrentKeyValueStore.cs` – C# source defining Concurrent Key Value Store behavior.
+* `ConcurrentSet.cs` – C# source defining Concurrent Set behavior.
+* `EmptyKeyValueStore.cs` – C# source defining Empty Key Value Store behavior.
+* `IKeyValueStore.cs` – C# source defining I Key Value Store behavior.
+* `MurMurHash2.cs` – C# source defining Mur Mur Hash2 behavior.
+* `Retry.cs` – C# source defining Retry behavior.
+* `TaskClock.cs` – C# source defining Task Clock behavior.
+* `TaskExtensions.cs` – C# source defining Task Extensions behavior.
+* `TaskFactory.cs` – C# source defining Task Factory behavior.
+* `TaskFactoryLogMessages.cs` – C# source defining Task Factory Log Messages behavior.
+* `ThreadPoolStats.cs` – C# source defining Thread Pool Stats behavior.
+* `Throttle.cs` – C# source defining Throttle behavior.
+* `TypedDictionary.cs` – C# source defining Typed Dictionary behavior.
+
+## Primary Types and Contracts
+* `Class AsyncSemaphore` defined in `AsyncSemaphore.cs`
+* `Class ConcurrentKeyValueStore` defined in `ConcurrentKeyValueStore.cs`
+* `Class ConcurrentSet` defined in `ConcurrentSet.cs`
+* `Class EmptyKeyValueStore` defined in `EmptyKeyValueStore.cs`
+* `Interface IKeyValueStore` defined in `IKeyValueStore.cs`
+* `Class MurmurHash2` defined in `MurMurHash2.cs`
+* `Class Retry` defined in `Retry.cs`
+* `Class RetriesExhaustedException` defined in `Retry.cs`
+* `Class TaskClock` defined in `TaskClock.cs`
+* `Class TaskExtensions` defined in `TaskExtensions.cs`
+* `Class SafeTask` defined in `TaskFactory.cs`
+* `Class TaskFactoryLogMessages` defined in `TaskFactoryLogMessages.cs`
+* `Class ThreadPoolStats` defined in `ThreadPoolStats.cs`
+* `Class Throttle` defined in `Throttle.cs`
+* `Enum Valve` defined in `Throttle.cs`
+* `Record ThrottleOptions` defined in `Throttle.cs`
+* `Class TypeDictionary` defined in `TypedDictionary.cs`
+* `Class TypeKey` defined in `TypedDictionary.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Actor/context.md
+++ b/src/Proto.Actor/context.md
@@ -1,0 +1,62 @@
+# Proto Actor Context
+
+## Overview
+Core actor runtime implementation: actors, contexts, mailboxes, supervision, logging, scheduling, and supporting utilities.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `ActorSystem.cs` – C# source defining Actor System behavior.
+* `ActorSystemConfig.cs` – C# source defining Actor System Config behavior.
+* `ActorSystemLogMessages.cs` – C# source defining Actor System Log Messages behavior.
+* `Behavior.cs` – C# source defining Behavior behavior.
+* `CancellationTokens.cs` – C# source defining Cancellation Tokens behavior.
+* `Delegates.cs` – C# source defining Delegates behavior.
+* `Exceptions.cs` – C# source defining Exceptions behavior.
+* `Extensions.cs` – C# source defining Extensions behavior.
+* `FunctionActor.cs` – C# source defining Function Actor behavior.
+* `IActor.cs` – C# source defining I Actor behavior.
+* `InternalsVisibleTo.cs` – C# source defining Internals Visible To behavior.
+* `Middleware.cs` – C# source defining Middleware behavior.
+* `PID.cs` – C# source defining PID behavior.
+* `Proto.Actor.csproj` – Project file configuring compilation targets and dependencies.
+* `ProtoTags.cs` – C# source defining Proto Tags behavior.
+* `Protos.proto` – Protocol Buffers schema.
+* `Stopper.cs` – C# source defining Stopper behavior.
+
+## Primary Types and Contracts
+* `Class ActorSystem` defined in `ActorSystem.cs`
+* `Record ActorSystemConfig` defined in `ActorSystemConfig.cs`
+* `Class ActorSystemLogMessages` defined in `ActorSystemLogMessages.cs`
+* `Class Behavior` defined in `Behavior.cs`
+* `Class CancellationTokens` defined in `CancellationTokens.cs`
+* `Record TokenEntry` defined in `CancellationTokens.cs`
+* `Class ProcessNameExistException` defined in `Exceptions.cs`
+* `Class UtilExtensions` defined in `Extensions.cs`
+* `Class FunctionActor` defined in `FunctionActor.cs`
+* `Interface IActor` defined in `IActor.cs`
+* `Class Middleware` defined in `Middleware.cs`
+* `Class PID` defined in `PID.cs`
+* `Class ProtoTags` defined in `ProtoTags.cs`
+* `Class Stopper` defined in `Stopper.cs`
+
+## Related Subcontexts
+* [Context](Context/context.md) – See the nested context for details.
+* [Deduplication](Deduplication/context.md) – See the nested context for details.
+* [Dependency Injection](DependencyInjection/context.md) – See the nested context for details.
+* [Diagnostics](Diagnostics/context.md) – See the nested context for details.
+* [Event Stream](EventStream/context.md) – See the nested context for details.
+* [Extensions](Extensions/context.md) – See the nested context for details.
+* [Future](Future/context.md) – See the nested context for details.
+* [Logging](Logging/context.md) – See the nested context for details.
+* [Mailbox](Mailbox/context.md) – See the nested context for details.
+* [Messages](Messages/context.md) – See the nested context for details.
+* [Metrics](Metrics/context.md) – See the nested context for details.
+* [Process](Process/context.md) – See the nested context for details.
+* [Properties](Properties/context.md) – See the nested context for details.
+* [Props](Props/context.md) – See the nested context for details.
+* [Router](Router/context.md) – See the nested context for details.
+* [Supervision](Supervision/context.md) – See the nested context for details.
+* [Timers](Timers/context.md) – See the nested context for details.
+* [Utils](Utils/context.md) – See the nested context for details.
+

--- a/src/Proto.Analyzers/Diagnostics/context.md
+++ b/src/Proto.Analyzers/Diagnostics/context.md
@@ -1,0 +1,18 @@
+# Diagnostics Context
+
+## Overview
+Diagnostics directory within the Proto.Actor repository.
+
+_Parent context: [Proto Analyzers](../context.md)_
+
+## Key Files
+* `PoisonSelfAnalyzer.cs` – C# source defining Poison Self Analyzer behavior.
+* `TaskMessageAnalyzer.cs` – C# source defining Task Message Analyzer behavior.
+
+## Primary Types and Contracts
+* `Class PoisonSelfAnalyzer` defined in `PoisonSelfAnalyzer.cs`
+* `Class TaskMessageAnalyzer` defined in `TaskMessageAnalyzer.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Analyzers/context.md
+++ b/src/Proto.Analyzers/context.md
@@ -1,0 +1,26 @@
+# Proto Analyzers Context
+
+## Overview
+Proto Analyzers directory within the Proto.Actor repository.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `DiagnosticCategories.cs` – C# source defining Diagnostic Categories behavior.
+* `DiagnosticDescriptors.cs` – C# source defining Diagnostic Descriptors behavior.
+* `DiagnosticIds.cs` – C# source defining Diagnostic Ids behavior.
+* `Proto.Analyzers.csproj` – Project file configuring compilation targets and dependencies.
+* `SymbolExtensions.cs` – C# source defining Symbol Extensions behavior.
+* `SyntaxExtensions.cs` – C# source defining Syntax Extensions behavior.
+
+## Primary Types and Contracts
+* `Class DiagnosticCategories` defined in `DiagnosticCategories.cs`
+* `Class DiagnosticDescriptors` defined in `DiagnosticDescriptors.cs`
+* `Class DiagnosticIds` defined in `DiagnosticIds.cs`
+* `Class SymbolExtensions` defined in `SymbolExtensions.cs`
+* `Class SyntaxExtensions` defined in `SyntaxExtensions.cs`
+
+## Related Subcontexts
+* [Diagnostics](Diagnostics/context.md) – See the nested context for details.
+* [Tools](tools/context.md) – See the nested context for details.
+

--- a/src/Proto.Cluster.AmazonECS/context.md
+++ b/src/Proto.Cluster.AmazonECS/context.md
@@ -1,0 +1,31 @@
+# Proto Cluster Amazon ECS Context
+
+## Overview
+Amazon ECS cluster provider integration.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `AmazonEcsProvider.cs` – C# source defining Amazon Ecs Provider behavior.
+* `AmazonEcsProviderConfig.cs` – C# source defining Amazon Ecs Provider Config behavior.
+* `AwsHttpClient.cs` – C# source defining Aws Http Client behavior.
+* `EcsUtils.cs` – C# source defining Ecs Utils behavior.
+* `Proto.Cluster.AmazonECS.csproj` – Project file configuring compilation targets and dependencies.
+* `ProtoLabels.cs` – C# source defining Proto Labels behavior.
+
+## Primary Types and Contracts
+* `Class AmazonEcsProvider` defined in `AmazonEcsProvider.cs`
+* `Record AmazonEcsProviderConfig` defined in `AmazonEcsProviderConfig.cs`
+* `Class AwsEcsContainerMetadataHttpClient` defined in `AwsHttpClient.cs`
+* `Class Limits` defined in `AwsHttpClient.cs`
+* `Class Network` defined in `AwsHttpClient.cs`
+* `Class LogOptions` defined in `AwsHttpClient.cs`
+* `Class ContainerMetadata` defined in `AwsHttpClient.cs`
+* `Class Container` defined in `AwsHttpClient.cs`
+* `Class TaskMetadata` defined in `AwsHttpClient.cs`
+* `Class EcsUtils` defined in `EcsUtils.cs`
+* `Class ProtoLabels` defined in `ProtoLabels.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.AzureContainerApps/Actors/context.md
+++ b/src/Proto.Cluster.AzureContainerApps/Actors/context.md
@@ -1,0 +1,16 @@
+# Actors Context
+
+## Overview
+Actor implementations orchestrating ACA lifecycle tasks.
+
+_Parent context: [Proto Cluster Azure Container Apps](../context.md)_
+
+## Key Files
+* `AzureContainerAppsClusterMonitor.cs` – C# source defining Azure Container Apps Cluster Monitor behavior.
+
+## Primary Types and Contracts
+* `Class AzureContainerAppsClusterMonitor` defined in `AzureContainerAppsClusterMonitor.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.AzureContainerApps/ArmClientProviders/context.md
+++ b/src/Proto.Cluster.AzureContainerApps/ArmClientProviders/context.md
@@ -1,0 +1,16 @@
+# Arm Client Providers Context
+
+## Overview
+Factory logic for Azure ARM clients used by the ACA integration.
+
+_Parent context: [Proto Cluster Azure Container Apps](../context.md)_
+
+## Key Files
+* `DefaultAzureCredentialArmClientProvider.cs` – C# source defining Default Azure Credential Arm Client Provider behavior.
+
+## Primary Types and Contracts
+* `Class DefaultAzureCredentialArmClientProvider` defined in `DefaultAzureCredentialArmClientProvider.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.AzureContainerApps/ClusterProviders/context.md
+++ b/src/Proto.Cluster.AzureContainerApps/ClusterProviders/context.md
@@ -1,0 +1,16 @@
+# Cluster Providers Context
+
+## Overview
+Cluster provider implementations targeting Azure Container Apps.
+
+_Parent context: [Proto Cluster Azure Container Apps](../context.md)_
+
+## Key Files
+* `AzureContainerAppsProvider.cs` – C# source defining Azure Container Apps Provider behavior.
+
+## Primary Types and Contracts
+* `Class AzureContainerAppsProvider` defined in `AzureContainerAppsProvider.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.AzureContainerApps/Contracts/context.md
+++ b/src/Proto.Cluster.AzureContainerApps/Contracts/context.md
@@ -1,0 +1,22 @@
+# Contracts Context
+
+## Overview
+Message and DTO contracts used by the ACA integration.
+
+_Parent context: [Proto Cluster Azure Container Apps](../context.md)_
+
+## Key Files
+* `IArmClientProvider.cs` – C# source defining I Arm Client Provider behavior.
+* `IClusterMemberStore.cs` – C# source defining I Cluster Member Store behavior.
+* `IContainerAppMetadataAccessor.cs` – C# source defining I Container App Metadata Accessor behavior.
+* `ISystemClock.cs` – C# source defining I System Clock behavior.
+
+## Primary Types and Contracts
+* `Interface IArmClientProvider` defined in `IArmClientProvider.cs`
+* `Interface IClusterMemberStore` defined in `IClusterMemberStore.cs`
+* `Interface IContainerAppMetadataAccessor` defined in `IContainerAppMetadataAccessor.cs`
+* `Interface ISystemClock` defined in `ISystemClock.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.AzureContainerApps/Extensions/context.md
+++ b/src/Proto.Cluster.AzureContainerApps/Extensions/context.md
@@ -1,0 +1,16 @@
+# Extensions Context
+
+## Overview
+Extension methods that wire ACA integration into Proto.Cluster options.
+
+_Parent context: [Proto Cluster Azure Container Apps](../context.md)_
+
+## Key Files
+* `ServiceCollectionExtensions.cs` – C# source defining Service Collection Extensions behavior.
+
+## Primary Types and Contracts
+* `Class ServiceCollectionExtensions` defined in `ServiceCollectionExtensions.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.AzureContainerApps/Messages/context.md
+++ b/src/Proto.Cluster.AzureContainerApps/Messages/context.md
@@ -1,0 +1,20 @@
+# Messages Context
+
+## Overview
+Internal ACA-specific Proto contracts.
+
+_Parent context: [Proto Cluster Azure Container Apps](../context.md)_
+
+## Key Files
+* `RegisterMember.cs` – C# source defining Register Member behavior.
+* `UnregisterMember.cs` – C# source defining Unregister Member behavior.
+* `UpdateMembers.cs` – C# source defining Update Members behavior.
+
+## Primary Types and Contracts
+* `Record RegisterMember` defined in `RegisterMember.cs`
+* `Record UnregisterMember` defined in `UnregisterMember.cs`
+* `Record UpdateMembers` defined in `UpdateMembers.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.AzureContainerApps/Models/context.md
+++ b/src/Proto.Cluster.AzureContainerApps/Models/context.md
@@ -1,0 +1,18 @@
+# Models Context
+
+## Overview
+Model classes mirroring Azure Container Apps API payloads.
+
+_Parent context: [Proto Cluster Azure Container Apps](../context.md)_
+
+## Key Files
+* `ContainerAppMetadata.cs` – C# source defining Container App Metadata behavior.
+* `StoredMember.cs` – C# source defining Stored Member behavior.
+
+## Primary Types and Contracts
+* `Record ContainerAppMetadata` defined in `ContainerAppMetadata.cs`
+* `Record StoredMember` defined in `StoredMember.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.AzureContainerApps/Options/context.md
+++ b/src/Proto.Cluster.AzureContainerApps/Options/context.md
@@ -1,0 +1,18 @@
+# Options Context
+
+## Overview
+Options classes for configuring the ACA integration.
+
+_Parent context: [Proto Cluster Azure Container Apps](../context.md)_
+
+## Key Files
+* `AzureContainerAppsProviderOptions.cs` – C# source defining Azure Container Apps Provider Options behavior.
+* `AzureContainerAppsProviderOptionsValidator.cs` – C# source defining Azure Container Apps Provider Options Validator behavior.
+
+## Primary Types and Contracts
+* `Class AzureContainerAppsProviderOptions` defined in `AzureContainerAppsProviderOptions.cs`
+* `Class AzureContainerAppsProviderOptionsValidator` defined in `AzureContainerAppsProviderOptionsValidator.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.AzureContainerApps/Services/context.md
+++ b/src/Proto.Cluster.AzureContainerApps/Services/context.md
@@ -1,0 +1,18 @@
+# Services Context
+
+## Overview
+Services coordinating ACA resources and cluster membership.
+
+_Parent context: [Proto Cluster Azure Container Apps](../context.md)_
+
+## Key Files
+* `DefaultSystemClock.cs` – C# source defining Default System Clock behavior.
+* `EnvironmentContainerAppMetadataAccessor.cs` – C# source defining Environment Container App Metadata Accessor behavior.
+
+## Primary Types and Contracts
+* `Class DefaultSystemClock` defined in `DefaultSystemClock.cs`
+* `Class EnvironmentContainerAppMetadataAccessor` defined in `EnvironmentContainerAppMetadataAccessor.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.AzureContainerApps/Stores/Redis/context.md
+++ b/src/Proto.Cluster.AzureContainerApps/Stores/Redis/context.md
@@ -1,0 +1,22 @@
+# Redis Context
+
+## Overview
+Redis-backed state store for the ACA integration.
+
+_Parent context: [Stores](../context.md)_
+
+## Key Files
+* `IRedisConnectionMultiplexerProvider.cs` – C# source defining I Redis Connection Multiplexer Provider behavior.
+* `RedisClusterMemberStore.cs` – C# source defining Redis Cluster Member Store behavior.
+* `RedisConnectionMultiplexerProvider.cs` – C# source defining Redis Connection Multiplexer Provider behavior.
+* `ServiceCollectionExtensions.cs` – C# source defining Service Collection Extensions behavior.
+
+## Primary Types and Contracts
+* `Interface IRedisConnectionMultiplexerProvider` defined in `IRedisConnectionMultiplexerProvider.cs`
+* `Class RedisClusterMemberStore` defined in `RedisClusterMemberStore.cs`
+* `Class RedisConnectionMultiplexerProvider` defined in `RedisConnectionMultiplexerProvider.cs`
+* `Class ServiceCollectionExtensions` defined in `ServiceCollectionExtensions.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.AzureContainerApps/Stores/ResourceTags/context.md
+++ b/src/Proto.Cluster.AzureContainerApps/Stores/ResourceTags/context.md
@@ -1,0 +1,28 @@
+# Resource Tags Context
+
+## Overview
+Helpers for manipulating Azure resource tags.
+
+_Parent context: [Stores](../context.md)_
+
+## Key Files
+* `ArmClientUtils.cs` – C# source defining Arm Client Utils behavior.
+* `ResourceTagNames.cs` – C# source defining Resource Tag Names behavior.
+* `ResourceTagsClusterMemberStore.cs` – C# source defining Resource Tags Cluster Member Store behavior.
+* `ResourceTagsMemberStoreOptions.cs` – C# source defining Resource Tags Member Store Options behavior.
+* `ResourceTagsMemberStoreOptionsValidator.cs` – C# source defining Resource Tags Member Store Options Validator behavior.
+* `ServiceCollectionExtensions.cs` – C# source defining Service Collection Extensions behavior.
+* `TaggedMember.cs` – C# source defining Tagged Member behavior.
+
+## Primary Types and Contracts
+* `Class ArmClientUtils` defined in `ArmClientUtils.cs`
+* `Class ResourceTagNames` defined in `ResourceTagNames.cs`
+* `Class ResourceTagsClusterMemberStore` defined in `ResourceTagsClusterMemberStore.cs`
+* `Class ResourceTagsMemberStoreOptions` defined in `ResourceTagsMemberStoreOptions.cs`
+* `Class ResourceTagsMemberStoreOptionsValidator` defined in `ResourceTagsMemberStoreOptionsValidator.cs`
+* `Class ServiceCollectionExtensions` defined in `ServiceCollectionExtensions.cs`
+* `Record TaggedMember` defined in `TaggedMember.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.AzureContainerApps/Stores/context.md
+++ b/src/Proto.Cluster.AzureContainerApps/Stores/context.md
@@ -1,0 +1,17 @@
+# Stores Context
+
+## Overview
+State stores backing ACA cluster providers.
+
+_Parent context: [Proto Cluster Azure Container Apps](../context.md)_
+
+## Key Files
+* No direct files; primary content is nested in subdirectories.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Redis](Redis/context.md) – See the nested context for details.
+* [Resource Tags](ResourceTags/context.md) – See the nested context for details.
+

--- a/src/Proto.Cluster.AzureContainerApps/Utils/context.md
+++ b/src/Proto.Cluster.AzureContainerApps/Utils/context.md
@@ -1,0 +1,18 @@
+# Utils Context
+
+## Overview
+Utility types supporting the ACA integration.
+
+_Parent context: [Proto Cluster Azure Container Apps](../context.md)_
+
+## Key Files
+* `ArmClientProviders.cs` – C# source defining Arm Client Providers behavior.
+* `IPUtils.cs` – C# source defining IP Utils behavior.
+
+## Primary Types and Contracts
+* `Class ArmClientProviders` defined in `ArmClientProviders.cs`
+* `Class IPUtils` defined in `IPUtils.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.AzureContainerApps/context.md
+++ b/src/Proto.Cluster.AzureContainerApps/context.md
@@ -1,0 +1,27 @@
+# Proto Cluster Azure Container Apps Context
+
+## Overview
+Azure Container Apps integration: providers, actors, options, and support services for running Proto.Cluster on ACA.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `Proto.Cluster.AzureContainerApps.csproj` – Project file configuring compilation targets and dependencies.
+* `Readme.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Actors](Actors/context.md) – See the nested context for details.
+* [Arm Client Providers](ArmClientProviders/context.md) – See the nested context for details.
+* [Cluster Providers](ClusterProviders/context.md) – See the nested context for details.
+* [Contracts](Contracts/context.md) – See the nested context for details.
+* [Extensions](Extensions/context.md) – See the nested context for details.
+* [Messages](Messages/context.md) – See the nested context for details.
+* [Models](Models/context.md) – See the nested context for details.
+* [Options](Options/context.md) – See the nested context for details.
+* [Services](Services/context.md) – See the nested context for details.
+* [Stores](Stores/context.md) – See the nested context for details.
+* [Utils](Utils/context.md) – See the nested context for details.
+

--- a/src/Proto.Cluster.CodeGen/Properties/context.md
+++ b/src/Proto.Cluster.CodeGen/Properties/context.md
@@ -1,0 +1,16 @@
+# Properties Context
+
+## Overview
+Assembly metadata for the code generator.
+
+_Parent context: [Proto Cluster Code Gen](../context.md)_
+
+## Key Files
+* `AssemblyInfo.cs` – C# source defining Assembly Info behavior.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.CodeGen/build/context.md
+++ b/src/Proto.Cluster.CodeGen/build/context.md
@@ -1,0 +1,17 @@
+# Build Context
+
+## Overview
+MSBuild integration scripts for the code generator.
+
+_Parent context: [Proto Cluster Code Gen](../context.md)_
+
+## Key Files
+* `Proto.Cluster.CodeGen.props` – MSBuild configuration.
+* `ProtoGrainGenerator.props` – MSBuild configuration.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.CodeGen/buildMultiTargeting/context.md
+++ b/src/Proto.Cluster.CodeGen/buildMultiTargeting/context.md
@@ -1,0 +1,17 @@
+# Build Multi Targeting Context
+
+## Overview
+Multi-targeting build assets for the code generator.
+
+_Parent context: [Proto Cluster Code Gen](../context.md)_
+
+## Key Files
+* `Proto.Cluster.CodeGen.props` – MSBuild configuration.
+* `ProtoGrainGenerator.props` – MSBuild configuration.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.CodeGen/context.md
+++ b/src/Proto.Cluster.CodeGen/context.md
@@ -1,0 +1,35 @@
+# Proto Cluster Code Gen Context
+
+## Overview
+Source generator and command-line tooling for Proto.Cluster grains.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `CodeGenerator.cs` – C# source defining Code Generator behavior.
+* `Generator.cs` – C# source defining Generator behavior.
+* `OutputFileName.cs` – C# source defining Output File Name behavior.
+* `PathPolyfill.cs` – C# source defining Path Polyfill behavior.
+* `Proto.Cluster.CodeGen.csproj` – Project file configuring compilation targets and dependencies.
+* `ProtoGenTask.cs` – C# source defining Proto Gen Task behavior.
+* `README.md` – Markdown documentation.
+* `Template.cs` – C# source defining Template behavior.
+* `build.sh` – Script file.
+* `logo.png` – Image asset.
+
+## Primary Types and Contracts
+* `Class CodeGenerator` defined in `CodeGenerator.cs`
+* `Class Generator` defined in `Generator.cs`
+* `Class OutputFileName` defined in `OutputFileName.cs`
+* `Class PathPolyfill` defined in `PathPolyfill.cs`
+* `Class ProtoGenTask` defined in `ProtoGenTask.cs`
+* `Class Template` defined in `Template.cs`
+* `Class GrainExtensions` defined in `Template.cs`
+
+## Related Subcontexts
+* [Properties](Properties/context.md) – See the nested context for details.
+* [Build](build/context.md) – See the nested context for details.
+* [Build Multi Targeting](buildMultiTargeting/context.md) – See the nested context for details.
+* [Deps](deps/context.md) – See the nested context for details.
+* [Model](model/context.md) – See the nested context for details.
+

--- a/src/Proto.Cluster.CodeGen/deps/context.md
+++ b/src/Proto.Cluster.CodeGen/deps/context.md
@@ -1,0 +1,19 @@
+# Deps Context
+
+## Overview
+Template dependencies embedded with the code generator.
+
+_Parent context: [Proto Cluster Code Gen](../context.md)_
+
+## Key Files
+* `Handlebars.dll` – Repository asset.
+* `protobuf-net.Core.dll` – Repository asset.
+* `protobuf-net.Reflection.dll` – Repository asset.
+* `protobuf-net.dll` – Repository asset.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.CodeGen/model/context.md
+++ b/src/Proto.Cluster.CodeGen/model/context.md
@@ -1,0 +1,26 @@
+# Model Context
+
+## Overview
+Internal models describing grain services for generation.
+
+_Parent context: [Proto Cluster Code Gen](../context.md)_
+
+## Key Files
+* `ProtoField.cs` – C# source defining Proto Field behavior.
+* `ProtoFile.cs` – C# source defining Proto File behavior.
+* `ProtoHack.cs` – C# source defining Proto Hack behavior.
+* `ProtoMessage.cs` – C# source defining Proto Message behavior.
+* `ProtoMethod.cs` – C# source defining Proto Method behavior.
+* `ProtoService.cs` – C# source defining Proto Service behavior.
+
+## Primary Types and Contracts
+* `Class ProtoField` defined in `ProtoField.cs`
+* `Class ProtoFile` defined in `ProtoFile.cs`
+* `Class ProtoHack` defined in `ProtoHack.cs`
+* `Class ProtoMessage` defined in `ProtoMessage.cs`
+* `Class ProtoMethod` defined in `ProtoMethod.cs`
+* `Class ProtoService` defined in `ProtoService.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.Consul/context.md
+++ b/src/Proto.Cluster.Consul/context.md
@@ -1,0 +1,19 @@
+# Proto Cluster Consul Context
+
+## Overview
+Consul-based cluster membership provider.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `ConsulProvider.cs` – C# source defining Consul Provider behavior.
+* `ConsulProviderConfig.cs` – C# source defining Consul Provider Config behavior.
+* `Proto.Cluster.Consul.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* `Class ConsulProvider` defined in `ConsulProvider.cs`
+* `Record ConsulProviderConfig` defined in `ConsulProviderConfig.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.Dashboard/Pages/context.md
+++ b/src/Proto.Cluster.Dashboard/Pages/context.md
@@ -1,0 +1,24 @@
+# Pages Context
+
+## Overview
+Razor pages for the cluster dashboard UI.
+
+_Parent context: [Proto Cluster Dashboard](../context.md)_
+
+## Key Files
+* `ActorDiagram.razor` – Repository asset.
+* `ClusterDiagnostics.razor` – Repository asset.
+* `ClusterOverview.razor` – Repository asset.
+* `ClusterState.razor` – Repository asset.
+* `Error.cshtml` – Repository asset.
+* `Error.cshtml.cs` – C# source defining Error Cshtml behavior.
+* `Index.razor` – Repository asset.
+* `_Host.cshtml` – Repository asset.
+* `_Layout.cshtml` – Repository asset.
+
+## Primary Types and Contracts
+* `Class ErrorModel` defined in `Error.cshtml.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.Dashboard/Shared/context.md
+++ b/src/Proto.Cluster.Dashboard/Shared/context.md
@@ -1,0 +1,31 @@
+# Shared Context
+
+## Overview
+Shared Razor components for the dashboard.
+
+_Parent context: [Proto Cluster Dashboard](../context.md)_
+
+## Key Files
+* `ActorDiagnosticsWidget.razor` – Repository asset.
+* `AggregatedActors.razor` – Repository asset.
+* `AnyStateWidget.razor` – Repository asset.
+* `ClusterTopologyWidget.razor` – Repository asset.
+* `ExpanderButton.razor` – Repository asset.
+* `InfoBlock.razor` – Repository asset.
+* `MainLayout.razor` – Repository asset.
+* `MainLayout.razor.css` – Repository asset.
+* `MemberCard.razor` – Repository asset.
+* `MemberHeartbeatWidget.razor` – Repository asset.
+* `MemberSearch.razor` – Repository asset.
+* `MemberStateWidget.razor` – Repository asset.
+* `NavMenu.razor` – Repository asset.
+* `ProtoNavLink.razor` – Repository asset.
+* `ReadyForRebalanceWidget.razor` – Repository asset.
+* `RebalanceCompletedWidget.razor` – Repository asset.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.Dashboard/context.md
+++ b/src/Proto.Cluster.Dashboard/context.md
@@ -1,0 +1,26 @@
+# Proto Cluster Dashboard Context
+
+## Overview
+Blazor dashboard for visualizing Proto.Cluster topology and metrics.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `App.razor` – Repository asset.
+* `DashboardSettings.cs` – C# source defining Dashboard Settings behavior.
+* `Extensions.cs` – C# source defining Extensions behavior.
+* `Proto.Cluster.Dashboard.csproj` – Project file configuring compilation targets and dependencies.
+* `TreeNode.cs` – C# source defining Tree Node behavior.
+* `_Imports.razor` – Repository asset.
+
+## Primary Types and Contracts
+* `Class DashboardSettings` defined in `DashboardSettings.cs`
+* `Class Extensions` defined in `Extensions.cs`
+* `Class TreeNodeComparer` defined in `TreeNode.cs`
+* `Record TreeNode` defined in `TreeNode.cs`
+
+## Related Subcontexts
+* [Pages](Pages/context.md) – See the nested context for details.
+* [Shared](Shared/context.md) – See the nested context for details.
+* [Wwwroot](wwwroot/context.md) – See the nested context for details.
+

--- a/src/Proto.Cluster.Dashboard/wwwroot/context.md
+++ b/src/Proto.Cluster.Dashboard/wwwroot/context.md
@@ -1,0 +1,16 @@
+# Wwwroot Context
+
+## Overview
+Static assets for the dashboard UI.
+
+_Parent context: [Proto Cluster Dashboard](../context.md)_
+
+## Key Files
+* `protosymbol.png` – Image asset.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.Etcd/context.md
+++ b/src/Proto.Cluster.Etcd/context.md
@@ -1,0 +1,19 @@
+# Proto Cluster Etcd Context
+
+## Overview
+Etcd-based cluster membership provider.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `EtcdProvider.cs` – C# source defining Etcd Provider behavior.
+* `EtcdProviderConfig.cs` – C# source defining Etcd Provider Config behavior.
+* `Proto.Cluster.Etcd.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* `Class EtcdProvider` defined in `EtcdProvider.cs`
+* `Record EtcdProviderConfig` defined in `EtcdProviderConfig.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.Identity.MongoDb/context.md
+++ b/src/Proto.Cluster.Identity.MongoDb/context.md
@@ -1,0 +1,19 @@
+# Proto Cluster Identity Mongo Db Context
+
+## Overview
+MongoDB identity lookup implementation.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `MongoIdentityStorage.cs` – C# source defining Mongo Identity Storage behavior.
+* `PidLookupEntity.cs` – C# source defining Pid Lookup Entity behavior.
+* `Proto.Cluster.Identity.MongoDb.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* `Class MongoIdentityStorage` defined in `MongoIdentityStorage.cs`
+* `Class PidLookupEntity` defined in `PidLookupEntity.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.Identity.Redis/context.md
+++ b/src/Proto.Cluster.Identity.Redis/context.md
@@ -1,0 +1,18 @@
+# Proto Cluster Identity Redis Context
+
+## Overview
+Redis-based cluster identity store.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `Proto.Cluster.Identity.Redis.csproj` – Project file configuring compilation targets and dependencies.
+* `RedisIdentityStorage.cs` – C# source defining Redis Identity Storage behavior.
+
+## Primary Types and Contracts
+* `Class RedisIdentityStorage` defined in `RedisIdentityStorage.cs`
+* `Class ActivationStatus` defined in `RedisIdentityStorage.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.Kubernetes/context.md
+++ b/src/Proto.Cluster.Kubernetes/context.md
@@ -1,0 +1,33 @@
+# Proto Cluster Kubernetes Context
+
+## Overview
+Kubernetes-based cluster provider and tooling.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `KubernetesClusterMonitor.cs` – C# source defining Kubernetes Cluster Monitor behavior.
+* `KubernetesExtensions.cs` – C# source defining Kubernetes Extensions behavior.
+* `KubernetesHelper.cs` – C# source defining Kubernetes Helper behavior.
+* `KubernetesProvider.cs` – C# source defining Kubernetes Provider behavior.
+* `KubernetesProviderConfig.cs` – C# source defining Kubernetes Provider Config behavior.
+* `Messages.cs` – C# source defining Messages behavior.
+* `Proto.Cluster.Kubernetes.csproj` – Project file configuring compilation targets and dependencies.
+* `ProtoLabels.cs` – C# source defining Proto Labels behavior.
+
+## Primary Types and Contracts
+* `Class KubernetesClusterMonitor` defined in `KubernetesClusterMonitor.cs`
+* `Class KubernetesExtensions` defined in `KubernetesExtensions.cs`
+* `Record MemberStatus` defined in `KubernetesExtensions.cs`
+* `Class KubernetesHelper` defined in `KubernetesHelper.cs`
+* `Class KubernetesProvider` defined in `KubernetesProvider.cs`
+* `Record KubernetesProviderConfig` defined in `KubernetesProviderConfig.cs`
+* `Class Messages` defined in `Messages.cs`
+* `Class RegisterMember` defined in `Messages.cs`
+* `Class DeregisterMember` defined in `Messages.cs`
+* `Class StartWatchingCluster` defined in `Messages.cs`
+* `Class ProtoLabels` defined in `ProtoLabels.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.SeedNode.MongoDb/context.md
+++ b/src/Proto.Cluster.SeedNode.MongoDb/context.md
@@ -1,0 +1,19 @@
+# Proto Cluster Seed Node Mongo Db Context
+
+## Overview
+MongoDB-backed cluster seed node implementation.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `MongoDbSeedNodeDiscovery.cs` – C# source defining Mongo Db Seed Node Discovery behavior.
+* `Proto.Cluster.SeedNode.MongoDb.csproj` – Project file configuring compilation targets and dependencies.
+* `ProtoActorMember.cs` – C# source defining Proto Actor Member behavior.
+
+## Primary Types and Contracts
+* `Class MongoDbSeedNodeDiscovery` defined in `MongoDbSeedNodeDiscovery.cs`
+* `Class ProtoActorMember` defined in `ProtoActorMember.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.SeedNode.Redis/context.md
+++ b/src/Proto.Cluster.SeedNode.Redis/context.md
@@ -1,0 +1,17 @@
+# Proto Cluster Seed Node Redis Context
+
+## Overview
+Redis-backed cluster seed node implementation.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `Proto.Cluster.SeedNode.Redis.csproj` – Project file configuring compilation targets and dependencies.
+* `RedisSeedNodeDiscovery.cs` – C# source defining Redis Seed Node Discovery behavior.
+
+## Primary Types and Contracts
+* `Class RedisSeedNodeDiscovery` defined in `RedisSeedNodeDiscovery.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster.TestProvider/context.md
+++ b/src/Proto.Cluster.TestProvider/context.md
@@ -1,0 +1,27 @@
+# Proto Cluster Test Provider Context
+
+## Overview
+Test/dummy cluster provider implementations for integration testing.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `AgentServiceRegistration.cs` – C# source defining Agent Service Registration behavior.
+* `InMemAgent.cs` – C# source defining In Mem Agent behavior.
+* `Messages.cs` – C# source defining Messages behavior.
+* `Proto.Cluster.TestProvider.csproj` – Project file configuring compilation targets and dependencies.
+* `QueryOptions.cs` – C# source defining Query Options behavior.
+* `TestProvider.cs` – C# source defining Test Provider behavior.
+* `TestProviderOptions.cs` – C# source defining Test Provider Options behavior.
+
+## Primary Types and Contracts
+* `Class AgentServiceRegistration` defined in `AgentServiceRegistration.cs`
+* `Class AgentServiceStatus` defined in `InMemAgent.cs`
+* `Class InMemAgent` defined in `InMemAgent.cs`
+* `Class QueryOptions` defined in `QueryOptions.cs`
+* `Class TestProvider` defined in `TestProvider.cs`
+* `Class TestProviderOptions` defined in `TestProviderOptions.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/Cache/context.md
+++ b/src/Proto.Cluster/Cache/context.md
@@ -1,0 +1,18 @@
+# Cache Context
+
+## Overview
+Cache directory within the Proto.Actor repository.
+
+_Parent context: [Proto Cluster](../context.md)_
+
+## Key Files
+* `CacheInvalidationExtensions.cs` – C# source defining Cache Invalidation Extensions behavior.
+* `ClusterCacheInvalidation.cs` – C# source defining Cluster Cache Invalidation behavior.
+
+## Primary Types and Contracts
+* `Class CacheInvalidationExtensions` defined in `CacheInvalidationExtensions.cs`
+* `Class ClusterCacheInvalidation` defined in `ClusterCacheInvalidation.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/Gossip/context.md
+++ b/src/Proto.Cluster/Gossip/context.md
@@ -1,0 +1,90 @@
+# Gossip Context
+
+## Overview
+Gossip protocol implementation for disseminating cluster topology and health information.
+
+_Parent context: [Proto Cluster](../context.md)_
+
+## Key Files
+* `Consensus.cs` – C# source defining Consensus behavior.
+* `ConsensusCheckBuilder.cs` – C# source defining Consensus Check Builder behavior.
+* `ConsensusChecks.cs` – C# source defining Consensus Checks behavior.
+* `ConsensusEvaluator.cs` – C# source defining Consensus Evaluator behavior.
+* `Extensions.cs` – C# source defining Extensions behavior.
+* `Gossip.cs` – C# source defining Gossip behavior.
+* `GossipActor.cs` – C# source defining Gossip Actor behavior.
+* `GossipDefaults.cs` – C# source defining Gossip Defaults behavior.
+* `GossipKeyValue.cs` – C# source defining Gossip Key Value behavior.
+* `GossipKeys.cs` – C# source defining Gossip Keys behavior.
+* `GossipSender.cs` – C# source defining Gossip Sender behavior.
+* `GossipStateManagement.cs` – C# source defining Gossip State Management behavior.
+* `Gossiper.Consensus.cs` – C# source defining Gossiper Consensus behavior.
+* `Gossiper.Dissemination.cs` – C# source defining Gossiper Dissemination behavior.
+* `Gossiper.StateQueries.cs` – C# source defining Gossiper State Queries behavior.
+* `Gossiper.cs` – C# source defining Gossiper behavior.
+* `GossiperFactory.cs` – C# source defining Gossiper Factory behavior.
+* `GossiperLogMessages.cs` – C# source defining Gossiper Log Messages behavior.
+* `IConsensusCheckDefinition.cs` – C# source defining I Consensus Check Definition behavior.
+* `IDeltaValue.cs` – C# source defining I Delta Value behavior.
+* `IGossip.cs` – C# source defining I Gossip behavior.
+* `IGossipTransport.cs` – C# source defining I Gossip Transport behavior.
+* `IRandomProvider.cs` – C# source defining I Random Provider behavior.
+* `MemberStateDelta.cs` – C# source defining Member State Delta behavior.
+* `MemberStateDeltaBuilder.cs` – C# source defining Member State Delta Builder behavior.
+* `Messages.cs` – C# source defining Messages behavior.
+* `RandomOrderExtensions.cs` – C# source defining Random Order Extensions behavior.
+* `SystemRandomProvider.cs` – C# source defining System Random Provider behavior.
+
+## Primary Types and Contracts
+* `Interface IConsensusHandle` defined in `Consensus.cs`
+* `Class GossipConsensusHandle` defined in `Consensus.cs`
+* `Class ConsensusCheckBuilder` defined in `ConsensusCheckBuilder.cs`
+* `Record ConsensusCheck` defined in `ConsensusChecks.cs`
+* `Class ConsensusChecks` defined in `ConsensusChecks.cs`
+* `Class ConsensusEvaluator` defined in `ConsensusEvaluator.cs`
+* `Class Extensions` defined in `Extensions.cs`
+* `Class Gossip` defined in `Gossip.cs`
+* `Class GossipActor` defined in `GossipActor.cs`
+* `Class GossipDefaults` defined in `GossipDefaults.cs`
+* `Class GossipKeyValue` defined in `GossipKeyValue.cs`
+* `Class GossipKeys` defined in `GossipKeys.cs`
+* `Class GossipSender` defined in `GossipSender.cs`
+* `Class GossipStateManagement` defined in `GossipStateManagement.cs`
+* `Class Gossiper` defined in `Gossiper.Consensus.cs`
+* `Class Gossiper` defined in `Gossiper.Dissemination.cs`
+* `Class Gossiper` defined in `Gossiper.StateQueries.cs`
+* `Record GossiperOptions` defined in `Gossiper.cs`
+* `Class Gossiper` defined in `Gossiper.cs`
+* `Class Gossiper` defined in `GossiperFactory.cs`
+* `Class GossiperLogMessages` defined in `GossiperLogMessages.cs`
+* `Interface IConsensusCheckDefinition` defined in `IConsensusCheckDefinition.cs`
+* `Interface IDeltaValue` defined in `IDeltaValue.cs`
+* `Interface IGossip` defined in `IGossip.cs`
+* `Interface IGossipCore` defined in `IGossip.cs`
+* `Interface IGossipConsensusChecker` defined in `IGossip.cs`
+* `Interface IGossipStateStore` defined in `IGossip.cs`
+* `Interface IGossipTransport` defined in `IGossipTransport.cs`
+* `Class GossipTransport` defined in `IGossipTransport.cs`
+* `Interface IRandomProvider` defined in `IRandomProvider.cs`
+* `Record MemberStateDelta` defined in `MemberStateDelta.cs`
+* `Class MemberStateDeltaBuilder` defined in `MemberStateDeltaBuilder.cs`
+* `Record MemberStateDeltaBuildResult` defined in `MemberStateDeltaBuilder.cs`
+* `Class GossipRequest` defined in `Messages.cs`
+* `Class GossipResponse` defined in `Messages.cs`
+* `Record GossipUpdate` defined in `Messages.cs`
+* `Record GetGossipStateRequest` defined in `Messages.cs`
+* `Record GetGossipStateResponse` defined in `Messages.cs`
+* `Record GetGossipStateEntryRequest` defined in `Messages.cs`
+* `Record GetGossipStateEntryResponse` defined in `Messages.cs`
+* `Record SetGossipStateKey` defined in `Messages.cs`
+* `Record SetGossipStateResponse` defined in `Messages.cs`
+* `Record SendGossipStateRequest` defined in `Messages.cs`
+* `Record SendGossipStateResponse` defined in `Messages.cs`
+* `Record AddConsensusCheck` defined in `Messages.cs`
+* `Record GetGossipStateSnapshot` defined in `Messages.cs`
+* `Class RandomOrderExtensions` defined in `RandomOrderExtensions.cs`
+* `Class SystemRandomProvider` defined in `SystemRandomProvider.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/Grain/context.md
+++ b/src/Proto.Cluster/Grain/context.md
@@ -1,0 +1,26 @@
+# Grain Context
+
+## Overview
+Grain (virtual actor) abstractions, code generation hooks, and grain lifecycle helpers.
+
+_Parent context: [Proto Cluster](../context.md)_
+
+## Key Files
+* `ContextExtensions.cs` – C# source defining Context Extensions behavior.
+* `GrainException.cs` – C# source defining Grain Exception behavior.
+* `GrainRequest.cs` – C# source defining Grain Request behavior.
+* `GrainRequestMessage.cs` – C# source defining Grain Request Message behavior.
+* `GrainResponse.cs` – C# source defining Grain Response behavior.
+* `GrainResponseMessage.cs` – C# source defining Grain Response Message behavior.
+
+## Primary Types and Contracts
+* `Class ContextExtensions` defined in `ContextExtensions.cs`
+* `Class GrainException` defined in `GrainException.cs`
+* `Class GrainRequest` defined in `GrainRequest.cs`
+* `Record GrainRequestMessage` defined in `GrainRequestMessage.cs`
+* `Class GrainResponse` defined in `GrainResponse.cs`
+* `Record GrainResponseMessage` defined in `GrainResponseMessage.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/Healthchecks/context.md
+++ b/src/Proto.Cluster/Healthchecks/context.md
@@ -1,0 +1,16 @@
+# Healthchecks Context
+
+## Overview
+Healthchecks directory within the Proto.Actor repository.
+
+_Parent context: [Proto Cluster](../context.md)_
+
+## Key Files
+* `Healthcheck.cs` – C# source defining Healthcheck behavior.
+
+## Primary Types and Contracts
+* `Class ClusterHealthCheck` defined in `Healthcheck.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/Identity/context.md
+++ b/src/Proto.Cluster/Identity/context.md
@@ -1,0 +1,37 @@
+# Identity Context
+
+## Overview
+Identity directory within the Proto.Actor repository.
+
+_Parent context: [Proto Cluster](../context.md)_
+
+## Key Files
+* `GetPid.cs` – C# source defining Get Pid behavior.
+* `IIdentityLookup.cs` – C# source defining I Identity Lookup behavior.
+* `IIdentityStorage.cs` – C# source defining I Identity Storage behavior.
+* `IdentityActivatorProxy.cs` – C# source defining Identity Activator Proxy behavior.
+* `IdentityIsBlockedException.cs` – C# source defining Identity Is Blocked Exception behavior.
+* `IdentityMetrics.cs` – C# source defining Identity Metrics behavior.
+* `IdentityStorageLookup.cs` – C# source defining Identity Storage Lookup behavior.
+* `IdentityStoragePlacementActor.cs` – C# source defining Identity Storage Placement Actor behavior.
+* `IdentityStorageWorker.cs` – C# source defining Identity Storage Worker behavior.
+
+## Primary Types and Contracts
+* `Class GetPid` defined in `GetPid.cs`
+* `Class PidResult` defined in `GetPid.cs`
+* `Interface IIdentityLookup` defined in `IIdentityLookup.cs`
+* `Interface IIdentityStorage` defined in `IIdentityStorage.cs`
+* `Class SpawnLock` defined in `IIdentityStorage.cs`
+* `Class StoredActivation` defined in `IIdentityStorage.cs`
+* `Class StorageFailureException` defined in `IIdentityStorage.cs`
+* `Class LockNotFoundException` defined in `IIdentityStorage.cs`
+* `Class IdentityActivatorProxy` defined in `IdentityActivatorProxy.cs`
+* `Class IdentityIsBlockedException` defined in `IdentityIsBlockedException.cs`
+* `Class IdentityMetrics` defined in `IdentityMetrics.cs`
+* `Class IdentityStorageLookup` defined in `IdentityStorageLookup.cs`
+* `Class IdentityStoragePlacementActor` defined in `IdentityStoragePlacementActor.cs`
+* `Class IdentityStorageWorker` defined in `IdentityStorageWorker.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/Membership/context.md
+++ b/src/Proto.Cluster/Membership/context.md
@@ -1,0 +1,48 @@
+# Membership Context
+
+## Overview
+Cluster membership model, events, providers, and observers.
+
+_Parent context: [Proto Cluster](../context.md)_
+
+## Key Files
+* `ClusterTopologyBuilder.cs` – C# source defining Cluster Topology Builder behavior.
+* `ConsensusManager.cs` – C# source defining Consensus Manager behavior.
+* `GossipMemberStrategy.cs` – C# source defining Gossip Member Strategy behavior.
+* `IMemberList.cs` – C# source defining I Member List behavior.
+* `ImmutableMemberSet.cs` – C# source defining Immutable Member Set behavior.
+* `LeaderElection.cs` – C# source defining Leader Election behavior.
+* `LocalAffinityExtensions.cs` – C# source defining Local Affinity Extensions behavior.
+* `LocalAffinityOptions.cs` – C# source defining Local Affinity Options behavior.
+* `LocalAffinityStrategy.cs` – C# source defining Local Affinity Strategy behavior.
+* `MemberList.cs` – C# source defining Member List behavior.
+* `MemberListLogMessages.cs` – C# source defining Member List Log Messages behavior.
+* `MemberStrategy.cs` – C# source defining Member Strategy behavior.
+* `MemberStrategyManager.cs` – C# source defining Member Strategy Manager behavior.
+* `MetaMember.cs` – C# source defining Meta Member behavior.
+* `RoundRobinMemberSelector.cs` – C# source defining Round Robin Member Selector behavior.
+
+## Primary Types and Contracts
+* `Record TopologyChanges` defined in `ClusterTopologyBuilder.cs`
+* `Class ClusterTopologyBuilder` defined in `ClusterTopologyBuilder.cs`
+* `Class ConsensusManager` defined in `ConsensusManager.cs`
+* `Class GossipMemberStrategy` defined in `GossipMemberStrategy.cs`
+* `Interface IMemberList` defined in `IMemberList.cs`
+* `Class ImmutableMemberSet` defined in `ImmutableMemberSet.cs`
+* `Class LeaderElection` defined in `LeaderElection.cs`
+* `Record LeaderElected` defined in `LeaderElection.cs`
+* `Class LocalAffinityExtensions` defined in `LocalAffinityExtensions.cs`
+* `Class Tombstone` defined in `LocalAffinityExtensions.cs`
+* `Record LocalAffinityOptions` defined in `LocalAffinityOptions.cs`
+* `Class LocalAffinityStrategy` defined in `LocalAffinityStrategy.cs`
+* `Record MemberList` defined in `MemberList.cs`
+* `Class MemberListLogMessages` defined in `MemberListLogMessages.cs`
+* `Interface IMemberStrategy` defined in `MemberStrategy.cs`
+* `Class SimpleMemberStrategy` defined in `MemberStrategy.cs`
+* `Class MemberStrategyManager` defined in `MemberStrategyManager.cs`
+* `Record MetaMember` defined in `MetaMember.cs`
+* `Class RoundRobinMemberSelector` defined in `RoundRobinMemberSelector.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/Messages/context.md
+++ b/src/Proto.Cluster/Messages/context.md
@@ -1,0 +1,25 @@
+# Messages Context
+
+## Overview
+Generated message contracts shared across cluster components.
+
+_Parent context: [Proto Cluster](../context.md)_
+
+## Key Files
+* `Messages.cs` – C# source defining Messages behavior.
+
+## Primary Types and Contracts
+* `Class ClusterIdentity` defined in `Messages.cs`
+* `Class ActivationRequest` defined in `Messages.cs`
+* `Class ActivationTerminated` defined in `Messages.cs`
+* `Class Activation` defined in `Messages.cs`
+* `Class IdentityHandover` defined in `Messages.cs`
+* `Class RemoteIdentityHandover` defined in `Messages.cs`
+* `Class PackedActivations` defined in `Messages.cs`
+* `Class ClusterTopology` defined in `Messages.cs`
+* `Class Member` defined in `Messages.cs`
+* `Class MemberHeartbeat` defined in `Messages.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/Metrics/context.md
+++ b/src/Proto.Cluster/Metrics/context.md
@@ -1,0 +1,16 @@
+# Metrics Context
+
+## Overview
+Metrics primitives and exporters for monitoring cluster activity.
+
+_Parent context: [Proto Cluster](../context.md)_
+
+## Key Files
+* `ClusterMetrics.cs` – C# source defining Cluster Metrics behavior.
+
+## Primary Types and Contracts
+* `Class ClusterMetrics` defined in `ClusterMetrics.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/Partition/context.md
+++ b/src/Proto.Cluster/Partition/context.md
@@ -1,0 +1,58 @@
+# Partition Context
+
+## Overview
+Partitioning strategies and activators that distribute grain ownership across cluster members.
+
+_Parent context: [Proto Cluster](../context.md)_
+
+## Key Files
+* `Extensions.cs` – C# source defining Extensions behavior.
+* `HandoverSink.cs` – C# source defining Handover Sink behavior.
+* `HandoverSource.cs` – C# source defining Handover Source behavior.
+* `IndexSet.cs` – C# source defining Index Set behavior.
+* `MemberHashRing.cs` – C# source defining Member Hash Ring behavior.
+* `PartitionActivationLifecycle.cs` – C# source defining Partition Activation Lifecycle behavior.
+* `PartitionConfig.cs` – C# source defining Partition Config behavior.
+* `PartitionIdentityActor.cs` – C# source defining Partition Identity Actor behavior.
+* `PartitionIdentityLookup.cs` – C# source defining Partition Identity Lookup behavior.
+* `PartitionIdentityRebalanceWorker.cs` – C# source defining Partition Identity Rebalance Worker behavior.
+* `PartitionManager.cs` – C# source defining Partition Manager behavior.
+* `PartitionMemberSelector.cs` – C# source defining Partition Member Selector behavior.
+* `PartitionPlacementActor.cs` – C# source defining Partition Placement Actor behavior.
+* `PartitionPlacementRebalance.cs` – C# source defining Partition Placement Rebalance behavior.
+* `Rendezvous.cs` – C# source defining Rendezvous behavior.
+
+## Primary Types and Contracts
+* `Class Extensions` defined in `Extensions.cs`
+* `Class HandoverSink` defined in `HandoverSink.cs`
+* `Record MemberHandoverStats` defined in `HandoverSink.cs`
+* `Class MemberHandoverSink` defined in `HandoverSink.cs`
+* `Class HandoverSource` defined in `HandoverSource.cs`
+* `Class MemberHandover` defined in `HandoverSource.cs`
+* `Class IndexSet` defined in `IndexSet.cs`
+* `Class MemberHashRing` defined in `MemberHashRing.cs`
+* `Class PartitionActivationLifecycle` defined in `PartitionActivationLifecycle.cs`
+* `Record PartitionConfig` defined in `PartitionConfig.cs`
+* `Class PartitionIdentityActor` defined in `PartitionIdentityActor.cs`
+* `Class MemberStatistics` defined in `PartitionIdentityActor.cs`
+* `Class MemberDetails` defined in `PartitionIdentityActor.cs`
+* `Enum OperatingState` defined in `PartitionIdentityActor.cs`
+* `Record PartitionCompleted` defined in `PartitionIdentityActor.cs`
+* `Record PartitionFailed` defined in `PartitionIdentityActor.cs`
+* `Class PartitionIdentityLookup` defined in `PartitionIdentityLookup.cs`
+* `Enum Mode` defined in `PartitionIdentityLookup.cs`
+* `Enum Send` defined in `PartitionIdentityLookup.cs`
+* `Class PartitionIdentityRebalanceWorker` defined in `PartitionIdentityRebalanceWorker.cs`
+* `Class PartitionWorker` defined in `PartitionIdentityRebalanceWorker.cs`
+* `Class PartitionManager` defined in `PartitionManager.cs`
+* `Class PartitionMemberSelector` defined in `PartitionMemberSelector.cs`
+* `Record State` defined in `PartitionMemberSelector.cs`
+* `Class PartitionPlacementActor` defined in `PartitionPlacementActor.cs`
+* `Class PartitionPlacementRebalance` defined in `PartitionPlacementRebalance.cs`
+* `Class MemberHandover` defined in `PartitionPlacementRebalance.cs`
+* `Class Rendezvous` defined in `Rendezvous.cs`
+* `Struct MemberData` defined in `Rendezvous.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/PartitionActivator/context.md
+++ b/src/Proto.Cluster/PartitionActivator/context.md
@@ -1,0 +1,25 @@
+# Partition Activator Context
+
+## Overview
+Partition Activator directory within the Proto.Actor repository.
+
+_Parent context: [Proto Cluster](../context.md)_
+
+## Key Files
+* `PartitionActivatorActor.cs` – C# source defining Partition Activator Actor behavior.
+* `PartitionActivatorLookup.cs` – C# source defining Partition Activator Lookup behavior.
+* `PartitionActivatorManager.cs` – C# source defining Partition Activator Manager behavior.
+* `PartitionActivatorSelector.cs` – C# source defining Partition Activator Selector behavior.
+* `RendezvousFast.cs` – C# source defining Rendezvous Fast behavior.
+
+## Primary Types and Contracts
+* `Class PartitionActivatorActor` defined in `PartitionActivatorActor.cs`
+* `Class PartitionActivatorLookup` defined in `PartitionActivatorLookup.cs`
+* `Class PartitionActivatorManager` defined in `PartitionActivatorManager.cs`
+* `Class PartitionActivatorSelector` defined in `PartitionActivatorSelector.cs`
+* `Class RendezvousFast` defined in `RendezvousFast.cs`
+* `Struct MemberData` defined in `RendezvousFast.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/Properties/context.md
+++ b/src/Proto.Cluster/Properties/context.md
@@ -1,0 +1,16 @@
+# Properties Context
+
+## Overview
+Properties directory within the Proto.Actor repository.
+
+_Parent context: [Proto Cluster](../context.md)_
+
+## Key Files
+* `AssemblyInfo.cs` – C# source defining Assembly Info behavior.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/PubSub/context.md
+++ b/src/Proto.Cluster/PubSub/context.md
@@ -1,0 +1,51 @@
+# Pub Sub Context
+
+## Overview
+Distributed publish/subscribe infrastructure for Proto.Cluster.
+
+_Parent context: [Proto Cluster](../context.md)_
+
+## Key Files
+* `BatchingProducer.cs` – C# source defining Batching Producer behavior.
+* `BatchingProducerConfig.cs` – C# source defining Batching Producer Config behavior.
+* `DeliverBatchRequest.cs` – C# source defining Deliver Batch Request behavior.
+* `IPublisher.cs` – C# source defining I Publisher behavior.
+* `PubSubAutoRespondBatch.cs` – C# source defining Pub Sub Auto Respond Batch behavior.
+* `PubSubBatch.cs` – C# source defining Pub Sub Batch behavior.
+* `PubSubConfig.cs` – C# source defining Pub Sub Config behavior.
+* `PubSubDeliveryException.cs` – C# source defining Pub Sub Delivery Exception behavior.
+* `PubSubExtension.cs` – C# source defining Pub Sub Extension behavior.
+* `PubSubExtensions.cs` – C# source defining Pub Sub Extensions behavior.
+* `PubSubMemberDeliveryActor.cs` – C# source defining Pub Sub Member Delivery Actor behavior.
+* `Publisher.cs` – C# source defining Publisher behavior.
+* `PublisherConfig.cs` – C# source defining Publisher Config behavior.
+* `PublishingErrorDecision.cs` – C# source defining Publishing Error Decision behavior.
+* `TopicActor.cs` – C# source defining Topic Actor behavior.
+
+## Primary Types and Contracts
+* `Class BatchingProducer` defined in `BatchingProducer.cs`
+* `Record ProduceMessage` defined in `BatchingProducer.cs`
+* `Class PubSubBatchWithReceipts` defined in `BatchingProducer.cs`
+* `Class ProducerQueueFullException` defined in `BatchingProducer.cs`
+* `Record BatchingProducerConfig` defined in `BatchingProducerConfig.cs`
+* `Record DeliverBatchRequest` defined in `DeliverBatchRequest.cs`
+* `Class DeliverBatchRequestTransport` defined in `DeliverBatchRequest.cs`
+* `Interface IPublisher` defined in `IPublisher.cs`
+* `Record PubSubAutoRespondBatch` defined in `PubSubAutoRespondBatch.cs`
+* `Class PubSubAutoRespondBatchTransport` defined in `PubSubAutoRespondBatch.cs`
+* `Class PubSubBatch` defined in `PubSubBatch.cs`
+* `Class PubSubBatchTransport` defined in `PubSubBatch.cs`
+* `Record PubSubConfig` defined in `PubSubConfig.cs`
+* `Class PubSubDeliveryException` defined in `PubSubDeliveryException.cs`
+* `Class PubSubExtension` defined in `PubSubExtension.cs`
+* `Class PubSubExtensions` defined in `PubSubExtensions.cs`
+* `Class PubSubMemberDeliveryActor` defined in `PubSubMemberDeliveryActor.cs`
+* `Class Publisher` defined in `Publisher.cs`
+* `Class PublisherExtensions` defined in `Publisher.cs`
+* `Record PublisherConfig` defined in `PublisherConfig.cs`
+* `Class PublishingErrorDecision` defined in `PublishingErrorDecision.cs`
+* `Class TopicActor` defined in `TopicActor.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/Seed/context.md
+++ b/src/Proto.Cluster/Seed/context.md
@@ -1,0 +1,31 @@
+# Seed Context
+
+## Overview
+Seed directory within the Proto.Actor repository.
+
+_Parent context: [Proto Cluster](../context.md)_
+
+## Key Files
+* `FixedServerSeedNodeDiscovery.cs` – C# source defining Fixed Server Seed Node Discovery behavior.
+* `ISeedNodeDiscovery.cs` – C# source defining I Seed Node Discovery behavior.
+* `Messages.cs` – C# source defining Messages behavior.
+* `SeedClientNodeActor.cs` – C# source defining Seed Client Node Actor behavior.
+* `SeedNodeActor.cs` – C# source defining Seed Node Actor behavior.
+* `SeedNodeClusterProvider.cs` – C# source defining Seed Node Cluster Provider behavior.
+* `SeedNodeClusterProviderOptions.cs` – C# source defining Seed Node Cluster Provider Options behavior.
+
+## Primary Types and Contracts
+* `Class FixedServerSeedNode` defined in `FixedServerSeedNodeDiscovery.cs`
+* `Class FixedServerSeedNodeDiscovery` defined in `FixedServerSeedNodeDiscovery.cs`
+* `Interface ISeedNodeDiscovery` defined in `ISeedNodeDiscovery.cs`
+* `Record Connect` defined in `Messages.cs`
+* `Record Connected` defined in `Messages.cs`
+* `Record FailedToConnect` defined in `Messages.cs`
+* `Class SeedClientNodeActor` defined in `SeedClientNodeActor.cs`
+* `Class SeedNodeActor` defined in `SeedNodeActor.cs`
+* `Class SeedNodeClusterProvider` defined in `SeedNodeClusterProvider.cs`
+* `Record SeedNodeClusterProviderOptions` defined in `SeedNodeClusterProviderOptions.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/SingleNode/context.md
+++ b/src/Proto.Cluster/SingleNode/context.md
@@ -1,0 +1,20 @@
+# Single Node Context
+
+## Overview
+Single Node directory within the Proto.Actor repository.
+
+_Parent context: [Proto Cluster](../context.md)_
+
+## Key Files
+* `SingleNodeActivatorActor.cs` – C# source defining Single Node Activator Actor behavior.
+* `SingleNodeLookup.cs` – C# source defining Single Node Lookup behavior.
+* `SingleNodeProvider.cs` – C# source defining Single Node Provider behavior.
+
+## Primary Types and Contracts
+* `Class SingleNodeActivatorActor` defined in `SingleNodeActivatorActor.cs`
+* `Class SingleNodeLookup` defined in `SingleNodeLookup.cs`
+* `Class SingleNodeProvider` defined in `SingleNodeProvider.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Cluster/context.md
+++ b/src/Proto.Cluster/context.md
@@ -1,0 +1,74 @@
+# Proto Cluster Context
+
+## Overview
+Cluster runtime: membership, identity lookup, partitioning, pub-sub, gossip, metrics, and grain activation.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `ActivatedClusterKind.cs` – C# source defining Activated Cluster Kind behavior.
+* `Cluster.cs` – C# source defining Cluster behavior.
+* `ClusterConfig.cs` – C# source defining Cluster Config behavior.
+* `ClusterContext.cs` – C# source defining Cluster Context behavior.
+* `ClusterContextConfig.cs` – C# source defining Cluster Context Config behavior.
+* `ClusterContracts.proto` – Protocol Buffers schema.
+* `ClusterDiagnostics.cs` – C# source defining Cluster Diagnostics behavior.
+* `ClusterExtension.cs` – C# source defining Cluster Extension behavior.
+* `ClusterExtensions.cs` – C# source defining Cluster Extensions behavior.
+* `ClusterInitialization.cs` – C# source defining Cluster Initialization behavior.
+* `ClusterKind.cs` – C# source defining Cluster Kind behavior.
+* `ClusterMetricsCollector.cs` – C# source defining Cluster Metrics Collector behavior.
+* `DefaultClusterContext.cs` – C# source defining Default Cluster Context behavior.
+* `DiagnosticsContracts.cs` – C# source defining Diagnostics Contracts behavior.
+* `GossipContracts.proto` – Protocol Buffers schema.
+* `GrainContracts.proto` – Protocol Buffers schema.
+* `IClusterProvider.cs` – C# source defining I Cluster Provider behavior.
+* `InternalsVisibleTo.cs` – C# source defining Internals Visible To behavior.
+* `Member.cs` – C# source defining Member behavior.
+* `PidCache.cs` – C# source defining Pid Cache behavior.
+* `Proto.Cluster.csproj` – Project file configuring compilation targets and dependencies.
+* `ProtoActorLifecycleHost.cs` – C# source defining Proto Actor Lifecycle Host behavior.
+* `PubSubContracts.proto` – Protocol Buffers schema.
+* `SeedContracts.proto` – Protocol Buffers schema.
+* `ServiceCollectionExtensions.cs` – C# source defining Service Collection Extensions behavior.
+
+## Primary Types and Contracts
+* `Record ActivatedClusterKind` defined in `ActivatedClusterKind.cs`
+* `Class Cluster` defined in `Cluster.cs`
+* `Record ClusterConfig` defined in `ClusterConfig.cs`
+* `Interface IClusterContext` defined in `ClusterContext.cs`
+* `Record ClusterContextConfig` defined in `ClusterContextConfig.cs`
+* `Class ClusterConfigExtensions` defined in `ClusterContextConfig.cs`
+* `Class ClusterDiagnostics` defined in `ClusterDiagnostics.cs`
+* `Class Extensions` defined in `ClusterExtension.cs`
+* `Struct PidRef` defined in `ClusterExtension.cs`
+* `Class ClusterExtensions` defined in `ClusterExtensions.cs`
+* `Class ClusterInitialization` defined in `ClusterInitialization.cs`
+* `Record ClusterKind` defined in `ClusterKind.cs`
+* `Class ClusterMetricsCollector` defined in `ClusterMetricsCollector.cs`
+* `Class DefaultClusterContext` defined in `DefaultClusterContext.cs`
+* `Enum PidSource` defined in `DefaultClusterContext.cs`
+* `Record DiagnosticsMemberHeartbeat` defined in `DiagnosticsContracts.cs`
+* `Interface IClusterProvider` defined in `IClusterProvider.cs`
+* `Class Member` defined in `Member.cs`
+* `Class PidCache` defined in `PidCache.cs`
+* `Class ProtoActorLifecycleHost` defined in `ProtoActorLifecycleHost.cs`
+* `Class HostedClusterConfig` defined in `ServiceCollectionExtensions.cs`
+* `Class ServiceCollectionExtensions` defined in `ServiceCollectionExtensions.cs`
+
+## Related Subcontexts
+* [Cache](Cache/context.md) – See the nested context for details.
+* [Gossip](Gossip/context.md) – See the nested context for details.
+* [Grain](Grain/context.md) – See the nested context for details.
+* [Healthchecks](Healthchecks/context.md) – See the nested context for details.
+* [Identity](Identity/context.md) – See the nested context for details.
+* [Membership](Membership/context.md) – See the nested context for details.
+* [Messages](Messages/context.md) – See the nested context for details.
+* [Metrics](Metrics/context.md) – See the nested context for details.
+* [Partition](Partition/context.md) – See the nested context for details.
+* [Partition Activator](PartitionActivator/context.md) – See the nested context for details.
+* [Properties](Properties/context.md) – See the nested context for details.
+* [Pub Sub](PubSub/context.md) – See the nested context for details.
+* [Seed](Seed/context.md) – See the nested context for details.
+* [Single Node](SingleNode/context.md) – See the nested context for details.
+

--- a/src/Proto.OpenTelemetry/context.md
+++ b/src/Proto.OpenTelemetry/context.md
@@ -1,0 +1,27 @@
+# Proto Open Telemetry Context
+
+## Overview
+OpenTelemetry instrumentation hooks for Proto.Actor, Proto.Cluster, and Proto.Remote.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `OpenTelemetryActorContextDecorator.cs` – C# source defining Open Telemetry Actor Context Decorator behavior.
+* `OpenTelemetryHelpers.cs` – C# source defining Open Telemetry Helpers behavior.
+* `OpenTelemetryMethodsDecorators.cs` – C# source defining Open Telemetry Methods Decorators behavior.
+* `OpenTelemetryMetricsExtensions.cs` – C# source defining Open Telemetry Metrics Extensions behavior.
+* `OpenTelemetryRootContextDecorator.cs` – C# source defining Open Telemetry Root Context Decorator behavior.
+* `OpenTelemetryTracingExtensions.cs` – C# source defining Open Telemetry Tracing Extensions behavior.
+* `Proto.OpenTelemetry.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* `Class OpenTelemetryActorContextDecorator` defined in `OpenTelemetryActorContextDecorator.cs`
+* `Class OpenTelemetryHelpers` defined in `OpenTelemetryHelpers.cs`
+* `Class OpenTelemetryMethodsDecorators` defined in `OpenTelemetryMethodsDecorators.cs`
+* `Class OpenTelemetryMetricsExtensions` defined in `OpenTelemetryMetricsExtensions.cs`
+* `Class OpenTelemetryRootContextDecorator` defined in `OpenTelemetryRootContextDecorator.cs`
+* `Class OpenTelemetryTracingExtensions` defined in `OpenTelemetryTracingExtensions.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Persistence.Couchbase/context.md
+++ b/src/Proto.Persistence.Couchbase/context.md
@@ -1,0 +1,21 @@
+# Proto Persistence Couchbase Context
+
+## Overview
+Couchbase persistence provider.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `CouchbaseProvider.cs` – C# source defining Couchbase Provider behavior.
+* `Event.cs` – C# source defining Event behavior.
+* `Proto.Persistence.Couchbase.csproj` – Project file configuring compilation targets and dependencies.
+* `Snapshot.cs` – C# source defining Snapshot behavior.
+
+## Primary Types and Contracts
+* `Class CouchbaseProvider` defined in `CouchbaseProvider.cs`
+* `Class Event` defined in `Event.cs`
+* `Class Snapshot` defined in `Snapshot.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Persistence.DynamoDB/context.md
+++ b/src/Proto.Persistence.DynamoDB/context.md
@@ -1,0 +1,25 @@
+# Proto Persistence Dynamo DB Context
+
+## Overview
+DynamoDB persistence provider.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `DynamoDBExtensions.cs` – C# source defining Dynamo DB Extensions behavior.
+* `DynamoDBHelper.cs` – C# source defining Dynamo DB Helper behavior.
+* `DynamoDBProvider.cs` – C# source defining Dynamo DB Provider behavior.
+* `DynamoDBProviderOptions.cs` – C# source defining Dynamo DB Provider Options behavior.
+* `Extensions.cs` – C# source defining Extensions behavior.
+* `Proto.Persistence.DynamoDB.csproj` – Project file configuring compilation targets and dependencies.
+* `README.md` – Markdown documentation.
+
+## Primary Types and Contracts
+* `Class DynamoDBExtensions` defined in `DynamoDBExtensions.cs`
+* `Class DynamoDBProvider` defined in `DynamoDBProvider.cs`
+* `Class DynamoDBProviderOptions` defined in `DynamoDBProviderOptions.cs`
+* `Class Extensions` defined in `Extensions.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Persistence.Marten/context.md
+++ b/src/Proto.Persistence.Marten/context.md
@@ -1,0 +1,21 @@
+# Proto Persistence Marten Context
+
+## Overview
+Marten (PostgreSQL) persistence provider.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `Event.cs` – C# source defining Event behavior.
+* `MartenProvider.cs` – C# source defining Marten Provider behavior.
+* `Proto.Persistence.Marten.csproj` – Project file configuring compilation targets and dependencies.
+* `Snapshot.cs` – C# source defining Snapshot behavior.
+
+## Primary Types and Contracts
+* `Class Event` defined in `Event.cs`
+* `Class MartenProvider` defined in `MartenProvider.cs`
+* `Class Snapshot` defined in `Snapshot.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Persistence.MongoDB/context.md
+++ b/src/Proto.Persistence.MongoDB/context.md
@@ -1,0 +1,21 @@
+# Proto Persistence Mongo DB Context
+
+## Overview
+MongoDB-backed persistence provider implementation.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `Event.cs` – C# source defining Event behavior.
+* `MongoDBProvider.cs` – C# source defining Mongo DB Provider behavior.
+* `Proto.Persistence.MongoDB.csproj` – Project file configuring compilation targets and dependencies.
+* `Snapshot.cs` – C# source defining Snapshot behavior.
+
+## Primary Types and Contracts
+* `Class Event` defined in `Event.cs`
+* `Class MongoDBProvider` defined in `MongoDBProvider.cs`
+* `Class Snapshot` defined in `Snapshot.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Persistence.RavenDB/context.md
+++ b/src/Proto.Persistence.RavenDB/context.md
@@ -1,0 +1,25 @@
+# Proto Persistence Raven DB Context
+
+## Overview
+RavenDB persistence provider.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `DeleteEventIndex.cs` – C# source defining Delete Event Index behavior.
+* `DeleteSnapshotIndex.cs` – C# source defining Delete Snapshot Index behavior.
+* `Event.cs` – C# source defining Event behavior.
+* `Proto.Persistence.RavenDB.csproj` – Project file configuring compilation targets and dependencies.
+* `RavenDBProvider.cs` – C# source defining Raven DB Provider behavior.
+* `Snapshot.cs` – C# source defining Snapshot behavior.
+
+## Primary Types and Contracts
+* `Class DeleteEventIndex` defined in `DeleteEventIndex.cs`
+* `Class DeleteSnapshotIndex` defined in `DeleteSnapshotIndex.cs`
+* `Class Event` defined in `Event.cs`
+* `Class RavenDBProvider` defined in `RavenDBProvider.cs`
+* `Class Snapshot` defined in `Snapshot.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Persistence.SqlServer/context.md
+++ b/src/Proto.Persistence.SqlServer/context.md
@@ -1,0 +1,21 @@
+# Proto Persistence Sql Server Context
+
+## Overview
+SQL Server persistence provider.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `Event.cs` – C# source defining Event behavior.
+* `Proto.Persistence.SqlServer.csproj` – Project file configuring compilation targets and dependencies.
+* `Snapshot.cs` – C# source defining Snapshot behavior.
+* `SqlServerProvider.cs` – C# source defining Sql Server Provider behavior.
+
+## Primary Types and Contracts
+* `Class Event` defined in `Event.cs`
+* `Class Snapshot` defined in `Snapshot.cs`
+* `Class SqlServerProvider` defined in `SqlServerProvider.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Persistence.Sqlite/context.md
+++ b/src/Proto.Persistence.Sqlite/context.md
@@ -1,0 +1,21 @@
+# Proto Persistence Sqlite Context
+
+## Overview
+SQLite persistence provider.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `Event.cs` – C# source defining Event behavior.
+* `Proto.Persistence.Sqlite.csproj` – Project file configuring compilation targets and dependencies.
+* `Snapshot.cs` – C# source defining Snapshot behavior.
+* `SqliteProvider.cs` – C# source defining Sqlite Provider behavior.
+
+## Primary Types and Contracts
+* `Class Event` defined in `Event.cs`
+* `Class Snapshot` defined in `Snapshot.cs`
+* `Class SqliteProvider` defined in `SqliteProvider.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Persistence/SnapshotStrategies/context.md
+++ b/src/Proto.Persistence/SnapshotStrategies/context.md
@@ -1,0 +1,20 @@
+# Snapshot Strategies Context
+
+## Overview
+Built-in snapshotting strategies for persistence providers.
+
+_Parent context: [Proto Persistence](../context.md)_
+
+## Key Files
+* `EventTypeStrategy.cs` – C# source defining Event Type Strategy behavior.
+* `IntervalStrategy.cs` – C# source defining Interval Strategy behavior.
+* `TimeStrategy.cs` – C# source defining Time Strategy behavior.
+
+## Primary Types and Contracts
+* `Class EventTypeStrategy` defined in `EventTypeStrategy.cs`
+* `Class IntervalStrategy` defined in `IntervalStrategy.cs`
+* `Class TimeStrategy` defined in `TimeStrategy.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Persistence/context.md
+++ b/src/Proto.Persistence/context.md
@@ -1,0 +1,34 @@
+# Proto Persistence Context
+
+## Overview
+Persistence abstractions and tooling shared across providers (journals, snapshots, strategies).
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `IProvider.cs` – C# source defining I Provider behavior.
+* `ISnapshotStrategy.cs` – C# source defining I Snapshot Strategy behavior.
+* `Messages.cs` – C# source defining Messages behavior.
+* `Persistence.cs` – C# source defining Persistence behavior.
+* `Proto.Persistence.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* `Interface ISnapshotStore` defined in `IProvider.cs`
+* `Interface IEventStore` defined in `IProvider.cs`
+* `Interface IProvider` defined in `IProvider.cs`
+* `Interface ISnapshotStrategy` defined in `ISnapshotStrategy.cs`
+* `Class Event` defined in `Messages.cs`
+* `Class PersistedSnapshot` defined in `Messages.cs`
+* `Class RecoverSnapshot` defined in `Messages.cs`
+* `Class Snapshot` defined in `Messages.cs`
+* `Class RecoverEvent` defined in `Messages.cs`
+* `Class ReplayEvent` defined in `Messages.cs`
+* `Class PersistedEvent` defined in `Messages.cs`
+* `Class Persistence` defined in `Persistence.cs`
+* `Class ManualSnapshots` defined in `Persistence.cs`
+* `Class NoEventStore` defined in `Persistence.cs`
+* `Class NoSnapshotStore` defined in `Persistence.cs`
+
+## Related Subcontexts
+* [Snapshot Strategies](SnapshotStrategies/context.md) – See the nested context for details.
+

--- a/src/Proto.Remote/Endpoints/Runner/context.md
+++ b/src/Proto.Remote/Endpoints/Runner/context.md
@@ -1,0 +1,22 @@
+# Runner Context
+
+## Overview
+Runner directory within the Proto.Actor repository.
+
+_Parent context: [Endpoints](../context.md)_
+
+## Key Files
+* `ConnectionReader.cs` – C# source defining Connection Reader behavior.
+* `ConnectionRunner.cs` – C# source defining Connection Runner behavior.
+* `ConnectionWriter.cs` – C# source defining Connection Writer behavior.
+* `RemoteStreamProcessor.cs` – C# source defining Remote Stream Processor behavior.
+
+## Primary Types and Contracts
+* `Class ConnectionReader` defined in `ConnectionReader.cs`
+* `Class ConnectionRunner` defined in `ConnectionRunner.cs`
+* `Class ConnectionWriter` defined in `ConnectionWriter.cs`
+* `Class RemoteStreamProcessor` defined in `RemoteStreamProcessor.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Remote/Endpoints/context.md
+++ b/src/Proto.Remote/Endpoints/context.md
@@ -1,0 +1,52 @@
+# Endpoints Context
+
+## Overview
+Endpoint management, including readers, writers, batching, and pipeline orchestration for remote messaging.
+
+_Parent context: [Proto Remote](../context.md)_
+
+## Key Files
+* `BlockedEndpoint.cs` – C# source defining Blocked Endpoint behavior.
+* `ClientConnectionMode.cs` – C# source defining Client Connection Mode behavior.
+* `ClientRemoteEndpoint.cs` – C# source defining Client Remote Endpoint behavior.
+* `ConnectionRunnerLogMessages.cs` – C# source defining Connection Runner Log Messages behavior.
+* `EndpointManager.cs` – C# source defining Endpoint Manager behavior.
+* `EndpointManagerLogMessages.cs` – C# source defining Endpoint Manager Log Messages behavior.
+* `EndpointWriterOptions.cs` – C# source defining Endpoint Writer Options behavior.
+* `IConnectionMode.cs` – C# source defining I Connection Mode behavior.
+* `IRemoteEndpoint.cs` – C# source defining I Remote Endpoint behavior.
+* `MessageBatchFactory.cs` – C# source defining Message Batch Factory behavior.
+* `MessageBatchFactoryLogMessages.cs` – C# source defining Message Batch Factory Log Messages behavior.
+* `README.md` – Markdown documentation.
+* `RemoteEndpointBase.cs` – C# source defining Remote Endpoint Base behavior.
+* `RemoteMessageHandler.cs` – C# source defining Remote Message Handler behavior.
+* `RemotingGrpcService.cs` – C# source defining Remoting Grpc Service behavior.
+* `ServerConnectionMode.cs` – C# source defining Server Connection Mode behavior.
+* `ServerConnector.cs` – C# source defining Server Connector behavior.
+* `ServerRemoteEndpoint.cs` – C# source defining Server Remote Endpoint behavior.
+
+## Primary Types and Contracts
+* `Class BlockedEndpoint` defined in `BlockedEndpoint.cs`
+* `Class ClientConnectionMode` defined in `ClientConnectionMode.cs`
+* `Class ClientRemoteEndpoint` defined in `ClientRemoteEndpoint.cs`
+* `Class ConnectionRunnerLogMessages` defined in `ConnectionRunnerLogMessages.cs`
+* `Class EndpointManager` defined in `EndpointManager.cs`
+* `Class EndpointManagerLogMessages` defined in `EndpointManagerLogMessages.cs`
+* `Class EndpointWriterOptions` defined in `EndpointWriterOptions.cs`
+* `Interface IConnectionMode` defined in `IConnectionMode.cs`
+* `Interface IRemoteEndpoint` defined in `IRemoteEndpoint.cs`
+* `Class MessageBatchFactory` defined in `MessageBatchFactory.cs`
+* `Class MessageBatchFactoryLogMessages` defined in `MessageBatchFactoryLogMessages.cs`
+* `Class RemoteEndpointBase` defined in `RemoteEndpointBase.cs`
+* `Class MultiTaskReuseWaiter` defined in `RemoteEndpointBase.cs`
+* `Class RemoteMessageHandler` defined in `RemoteMessageHandler.cs`
+* `Class RemotingGrpcService` defined in `RemotingGrpcService.cs`
+* `Record struct` defined in `RemotingGrpcService.cs`
+* `Class ServerConnectionMode` defined in `ServerConnectionMode.cs`
+* `Class ServerConnector` defined in `ServerConnector.cs`
+* `Enum Type` defined in `ServerConnector.cs`
+* `Class ServerRemoteEndpoint` defined in `ServerRemoteEndpoint.cs`
+
+## Related Subcontexts
+* [Runner](Runner/context.md) – See the nested context for details.
+

--- a/src/Proto.Remote/GrpcNet/context.md
+++ b/src/Proto.Remote/GrpcNet/context.md
@@ -1,0 +1,24 @@
+# Grpc Net Context
+
+## Overview
+gRPC transport implementation supporting Proto.Remote communication.
+
+_Parent context: [Proto Remote](../context.md)_
+
+## Key Files
+* `GrpcNetClientRemote.cs` – C# source defining Grpc Net Client Remote behavior.
+* `GrpcNetExtensions.cs` – C# source defining Grpc Net Extensions behavior.
+* `GrpcNetRemote.cs` – C# source defining Grpc Net Remote behavior.
+* `HostedGrpcNetRemote.cs` – C# source defining Hosted Grpc Net Remote behavior.
+* `RemoteHostedService.cs` – C# source defining Remote Hosted Service behavior.
+
+## Primary Types and Contracts
+* `Class GrpcNetClientRemote` defined in `GrpcNetClientRemote.cs`
+* `Class Extensions` defined in `GrpcNetExtensions.cs`
+* `Class GrpcNetRemote` defined in `GrpcNetRemote.cs`
+* `Class HostedGrpcNetRemote` defined in `HostedGrpcNetRemote.cs`
+* `Class RemoteHostedService` defined in `RemoteHostedService.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Remote/Healthchecks/context.md
+++ b/src/Proto.Remote/Healthchecks/context.md
@@ -1,0 +1,16 @@
+# Healthchecks Context
+
+## Overview
+Health check services for remote endpoints.
+
+_Parent context: [Proto Remote](../context.md)_
+
+## Key Files
+* `Healthcheck.cs` – C# source defining Healthcheck behavior.
+
+## Primary Types and Contracts
+* `Class ActorSystemHealthCheck` defined in `Healthcheck.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Remote/Metrics/context.md
+++ b/src/Proto.Remote/Metrics/context.md
@@ -1,0 +1,16 @@
+# Metrics Context
+
+## Overview
+Metrics adapters specifically for remoting endpoints and mailboxes.
+
+_Parent context: [Proto Remote](../context.md)_
+
+## Key Files
+* `RemoteMetrics.cs` – C# source defining Remote Metrics behavior.
+
+## Primary Types and Contracts
+* `Class RemoteMetrics` defined in `RemoteMetrics.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Remote/Properties/context.md
+++ b/src/Proto.Remote/Properties/context.md
@@ -1,0 +1,16 @@
+# Properties Context
+
+## Overview
+Package metadata for Proto.Remote.
+
+_Parent context: [Proto Remote](../context.md)_
+
+## Key Files
+* `AssemblyInfo.cs` – C# source defining Assembly Info behavior.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Remote/Serialization/context.md
+++ b/src/Proto.Remote/Serialization/context.md
@@ -1,0 +1,31 @@
+# Serialization Context
+
+## Overview
+Message serialization abstractions, message descriptors, and serializers for remote messaging.
+
+_Parent context: [Proto Remote](../context.md)_
+
+## Key Files
+* `ForcedSerializationSenderMiddleware.cs` – C# source defining Forced Serialization Sender Middleware behavior.
+* `ICachedSerialization.cs` – C# source defining I Cached Serialization behavior.
+* `IMessageSurrogate.cs` – C# source defining I Message Surrogate behavior.
+* `ISerializer.cs` – C# source defining I Serializer behavior.
+* `JsonSerializer.cs` – C# source defining Json Serializer behavior.
+* `ProtobufSerializer.cs` – C# source defining Protobuf Serializer behavior.
+* `Serialization.cs` – C# source defining Serialization behavior.
+
+## Primary Types and Contracts
+* `Class ForcedSerializationSenderMiddleware` defined in `ForcedSerializationSenderMiddleware.cs`
+* `Interface ICachedSerialization` defined in `ICachedSerialization.cs`
+* `Interface IRootSerializable` defined in `IMessageSurrogate.cs`
+* `Interface IRootSerialized` defined in `IMessageSurrogate.cs`
+* `Interface ISerializer` defined in `ISerializer.cs`
+* `Class JsonSerializer` defined in `JsonSerializer.cs`
+* `Class ProtobufSerializer` defined in `ProtobufSerializer.cs`
+* `Class Serialization` defined in `Serialization.cs`
+* `Struct SerializerItem` defined in `Serialization.cs`
+* `Struct TypeSerializerItem` defined in `Serialization.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/Proto.Remote/context.md
+++ b/src/Proto.Remote/context.md
@@ -1,0 +1,50 @@
+# Proto Remote Context
+
+## Overview
+Remote messaging transport built on gRPC. Manages endpoints, serialization, and cluster communication plumbing.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `Activator.cs` – C# source defining Activator behavior.
+* `BlockList.cs` – C# source defining Block List behavior.
+* `Extensions.cs` – C# source defining Extensions behavior.
+* `IBlockList.cs` – C# source defining I Block List behavior.
+* `IRemote.cs` – C# source defining I Remote behavior.
+* `IRemoteExtensions.cs` – C# source defining I Remote Extensions behavior.
+* `IRemotePriorityMessage.cs` – C# source defining I Remote Priority Message behavior.
+* `InternalsVisibleTo.cs` – C# source defining Internals Visible To behavior.
+* `Messages.cs` – C# source defining Messages behavior.
+* `PidExtensions.cs` – C# source defining Pid Extensions behavior.
+* `Proto.Remote.csproj` – Project file configuring compilation targets and dependencies.
+* `Protos.proto` – Protocol Buffers schema.
+* `RemoteConfig.cs` – C# source defining Remote Config behavior.
+* `RemoteConfigExtensions.cs` – C# source defining Remote Config Extensions behavior.
+* `RemoteProcess.cs` – C# source defining Remote Process behavior.
+* `ResponseStatusCode.cs` – C# source defining Response Status Code behavior.
+
+## Primary Types and Contracts
+* `Class Activator` defined in `Activator.cs`
+* `Record MemberBlocked` defined in `BlockList.cs`
+* `Class BlockList` defined in `BlockList.cs`
+* `Class ActorSystemExtensions` defined in `Extensions.cs`
+* `Interface IBlockList` defined in `IBlockList.cs`
+* `Interface IRemote` defined in `IRemote.cs`
+* `Class IRemoteExtensions` defined in `IRemoteExtensions.cs`
+* `Interface IRemotePriorityMessage` defined in `IRemotePriorityMessage.cs`
+* `Record EndpointTerminatedEvent` defined in `Messages.cs`
+* `Record RemoteDeliver` defined in `Messages.cs`
+* `Class PidExtensions` defined in `PidExtensions.cs`
+* `Record RemoteConfig` defined in `RemoteConfig.cs`
+* `Class RemoteConfigExtensions` defined in `RemoteConfigExtensions.cs`
+* `Class RemoteProcess` defined in `RemoteProcess.cs`
+* `Enum ResponseStatusCode` defined in `ResponseStatusCode.cs`
+
+## Related Subcontexts
+* [Endpoints](Endpoints/context.md) – See the nested context for details.
+* [Grpc Net](GrpcNet/context.md) – See the nested context for details.
+* [Healthchecks](Healthchecks/context.md) – See the nested context for details.
+* [Metrics](Metrics/context.md) – See the nested context for details.
+* [Properties](Properties/context.md) – See the nested context for details.
+* [Serialization](Serialization/context.md) – See the nested context for details.
+

--- a/src/Proto.TestKit/context.md
+++ b/src/Proto.TestKit/context.md
@@ -1,0 +1,40 @@
+# Proto Test Kit Context
+
+## Overview
+Test utilities for Proto.Actor/Proto.Cluster, including probes, harnesses, and extensions.
+
+_Parent context: [Src](../context.md)_
+
+## Key Files
+* `ActorSystemTestProbeExtensions.cs` – C# source defining Actor System Test Probe Extensions behavior.
+* `ClusterTestKitExtensions.cs` – C# source defining Cluster Test Kit Extensions behavior.
+* `GossipNetworkPartition.cs` – C# source defining Gossip Network Partition behavior.
+* `ITestProbe.cs` – C# source defining I Test Probe behavior.
+* `MessageAndSender.cs` – C# source defining Message And Sender behavior.
+* `ProbeMailboxStatistics.cs` – C# source defining Probe Mailbox Statistics behavior.
+* `PropsTestMailboxStatsExtensions.cs` – C# source defining Props Test Mailbox Stats Extensions behavior.
+* `PropsTestProbeExtensions.cs` – C# source defining Props Test Probe Extensions behavior.
+* `Proto.TestKit.csproj` – Project file configuring compilation targets and dependencies.
+* `README.md` – Markdown documentation.
+* `TestKit.cs` – C# source defining Test Kit behavior.
+* `TestKitException.cs` – C# source defining Test Kit Exception behavior.
+* `TestMailboxStats.cs` – C# source defining Test Mailbox Stats behavior.
+* `TestProbe.cs` – C# source defining Test Probe behavior.
+
+## Primary Types and Contracts
+* `Class ActorSystemTestProbeExtensions` defined in `ActorSystemTestProbeExtensions.cs`
+* `Class ClusterTestKitExtensions` defined in `ClusterTestKitExtensions.cs`
+* `Class GossipNetworkPartition` defined in `GossipNetworkPartition.cs`
+* `Interface ITestProbe` defined in `ITestProbe.cs`
+* `Class MessageAndSender` defined in `MessageAndSender.cs`
+* `Class ProbeMailboxStatistics` defined in `ProbeMailboxStatistics.cs`
+* `Class PropsTestMailboxStatsExtensions` defined in `PropsTestMailboxStatsExtensions.cs`
+* `Class PropsTestProbeExtensions` defined in `PropsTestProbeExtensions.cs`
+* `Class TestKit` defined in `TestKit.cs`
+* `Class TestKitException` defined in `TestKitException.cs`
+* `Class TestMailboxStats` defined in `TestMailboxStats.cs`
+* `Class TestProbe` defined in `TestProbe.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/src/context.md
+++ b/src/context.md
@@ -1,0 +1,43 @@
+# Src Context
+
+## Overview
+Source code for the Proto.Actor runtime and its extensions. Each subfolder is a separate package or integration point.
+
+Pair this overview with [`tests/context.md`](../tests/context.md) to find matching coverage and with [`examples/context.md`](../examples/context.md) for runnable demonstrations built on these packages.
+
+_Parent context: [Repository Root](../context.md)_
+
+## Key Files
+* `Directory.Build.props` – MSBuild configuration.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Proto Actor](Proto.Actor/context.md) – See the nested context for details.
+* [Proto Analyzers](Proto.Analyzers/context.md) – See the nested context for details.
+* [Proto Cluster](Proto.Cluster/context.md) – See the nested context for details.
+* [Proto Cluster Amazon ECS](Proto.Cluster.AmazonECS/context.md) – See the nested context for details.
+* [Proto Cluster Azure Container Apps](Proto.Cluster.AzureContainerApps/context.md) – See the nested context for details.
+* [Proto Cluster Code Gen](Proto.Cluster.CodeGen/context.md) – See the nested context for details.
+* [Proto Cluster Consul](Proto.Cluster.Consul/context.md) – See the nested context for details.
+* [Proto Cluster Dashboard](Proto.Cluster.Dashboard/context.md) – See the nested context for details.
+* [Proto Cluster Etcd](Proto.Cluster.Etcd/context.md) – See the nested context for details.
+* [Proto Cluster Identity Mongo Db](Proto.Cluster.Identity.MongoDb/context.md) – See the nested context for details.
+* [Proto Cluster Identity Redis](Proto.Cluster.Identity.Redis/context.md) – See the nested context for details.
+* [Proto Cluster Kubernetes](Proto.Cluster.Kubernetes/context.md) – See the nested context for details.
+* [Proto Cluster Seed Node Mongo Db](Proto.Cluster.SeedNode.MongoDb/context.md) – See the nested context for details.
+* [Proto Cluster Seed Node Redis](Proto.Cluster.SeedNode.Redis/context.md) – See the nested context for details.
+* [Proto Cluster Test Provider](Proto.Cluster.TestProvider/context.md) – See the nested context for details.
+* [Proto Open Telemetry](Proto.OpenTelemetry/context.md) – See the nested context for details.
+* [Proto Persistence](Proto.Persistence/context.md) – See the nested context for details.
+* [Proto Persistence Couchbase](Proto.Persistence.Couchbase/context.md) – See the nested context for details.
+* [Proto Persistence Dynamo DB](Proto.Persistence.DynamoDB/context.md) – See the nested context for details.
+* [Proto Persistence Marten](Proto.Persistence.Marten/context.md) – See the nested context for details.
+* [Proto Persistence Mongo DB](Proto.Persistence.MongoDB/context.md) – See the nested context for details.
+* [Proto Persistence Raven DB](Proto.Persistence.RavenDB/context.md) – See the nested context for details.
+* [Proto Persistence Sql Server](Proto.Persistence.SqlServer/context.md) – See the nested context for details.
+* [Proto Persistence Sqlite](Proto.Persistence.Sqlite/context.md) – See the nested context for details.
+* [Proto Remote](Proto.Remote/context.md) – See the nested context for details.
+* [Proto Test Kit](Proto.TestKit/context.md) – See the nested context for details.
+

--- a/tests/Proto.Actor.Tests/DependencyInjection/context.md
+++ b/tests/Proto.Actor.Tests/DependencyInjection/context.md
@@ -1,0 +1,19 @@
+# Dependency Injection Context
+
+## Overview
+Dependency injection integration tests for actor construction.
+
+_Parent context: [Proto Actor Tests](../context.md)_
+
+## Key Files
+* `DependencyInjectionTests.cs` – C# source defining Dependency Injection Tests behavior.
+
+## Primary Types and Contracts
+* `Class DependencyInjectionTests` defined in `DependencyInjectionTests.cs`
+* `Class FooDep` defined in `DependencyInjectionTests.cs`
+* `Class BarDep` defined in `DependencyInjectionTests.cs`
+* `Class DiActor` defined in `DependencyInjectionTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Actor.Tests/Diagnostics/context.md
+++ b/tests/Proto.Actor.Tests/Diagnostics/context.md
@@ -1,0 +1,17 @@
+# Diagnostics Context
+
+## Overview
+Diagnostics and tracing tests for the actor runtime.
+
+_Parent context: [Proto Actor Tests](../context.md)_
+
+## Key Files
+* `DiagnosticsTests.cs` – C# source defining Diagnostics Tests behavior.
+
+## Primary Types and Contracts
+* `Class MyDiagnosticsActor` defined in `DiagnosticsTests.cs`
+* `Class DiagnosticsTests` defined in `DiagnosticsTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Actor.Tests/Extensions/context.md
+++ b/tests/Proto.Actor.Tests/Extensions/context.md
@@ -1,0 +1,18 @@
+# Extensions Context
+
+## Overview
+Extension and middleware behavior tests.
+
+_Parent context: [Proto Actor Tests](../context.md)_
+
+## Key Files
+* `ExtensionTests.cs` – C# source defining Extension Tests behavior.
+
+## Primary Types and Contracts
+* `Class ExtensionA` defined in `ExtensionTests.cs`
+* `Class ExtensionB` defined in `ExtensionTests.cs`
+* `Class ExtensionTests` defined in `ExtensionTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Actor.Tests/Futures/context.md
+++ b/tests/Proto.Actor.Tests/Futures/context.md
@@ -1,0 +1,26 @@
+# Futures Context
+
+## Overview
+Future/awaitable interaction tests.
+
+_Parent context: [Proto Actor Tests](../context.md)_
+
+## Key Files
+* `BaseFutureTests.cs` – C# source defining Base Future Tests behavior.
+* `BatchFutureTests.cs` – C# source defining Batch Future Tests behavior.
+* `FutureProcessTests.cs` – C# source defining Future Process Tests behavior.
+* `FutureTests.cs` – C# source defining Future Tests behavior.
+* `SharedFutureBugTests.cs` – C# source defining Shared Future Bug Tests behavior.
+* `SharedFutureTests.cs` – C# source defining Shared Future Tests behavior.
+
+## Primary Types and Contracts
+* `Class BaseFutureTests` defined in `BaseFutureTests.cs`
+* `Class BatchFutureTests` defined in `BatchFutureTests.cs`
+* `Class FutureProcessTests` defined in `FutureProcessTests.cs`
+* `Class FutureTests` defined in `FutureTests.cs`
+* `Class SharedFutureBugTests` defined in `SharedFutureBugTests.cs`
+* `Class SharedFutureTests` defined in `SharedFutureTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Actor.Tests/Headers/context.md
+++ b/tests/Proto.Actor.Tests/Headers/context.md
@@ -1,0 +1,19 @@
+# Headers Context
+
+## Overview
+Header propagation tests for actor messages.
+
+_Parent context: [Proto Actor Tests](../context.md)_
+
+## Key Files
+* `MessageHeaderTests.cs` – C# source defining Message Header Tests behavior.
+
+## Primary Types and Contracts
+* `Class MessageHeaderTests` defined in `MessageHeaderTests.cs`
+* `Record SomeRequest` defined in `MessageHeaderTests.cs`
+* `Record SomeResponse` defined in `MessageHeaderTests.cs`
+* `Record StartMessage` defined in `MessageHeaderTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Actor.Tests/Mailbox/context.md
+++ b/tests/Proto.Actor.Tests/Mailbox/context.md
@@ -1,0 +1,28 @@
+# Mailbox Context
+
+## Overview
+Mailbox scheduling and throughput tests.
+
+_Parent context: [Proto Actor Tests](../context.md)_
+
+## Key Files
+* `EscalateFailureTests.cs` – C# source defining Escalate Failure Tests behavior.
+* `MailboxQueuesTests.cs` – C# source defining Mailbox Queues Tests behavior.
+* `MailboxSchedulingTests.cs` – C# source defining Mailbox Scheduling Tests behavior.
+* `MailboxStatisticsTests.cs` – C# source defining Mailbox Statistics Tests behavior.
+* `MessageBatchTests.cs` – C# source defining Message Batch Tests behavior.
+* `NonBlockingBoundedMailboxTests.cs` – C# source defining Non Blocking Bounded Mailbox Tests behavior.
+
+## Primary Types and Contracts
+* `Class EscalateFailureTests` defined in `EscalateFailureTests.cs`
+* `Class MailboxQueuesTests` defined in `MailboxQueuesTests.cs`
+* `Enum MailboxQueueKind` defined in `MailboxQueuesTests.cs`
+* `Class MailboxSchedulingTests` defined in `MailboxSchedulingTests.cs`
+* `Class MailboxStatisticsTests` defined in `MailboxStatisticsTests.cs`
+* `Class MessageBatchTests` defined in `MessageBatchTests.cs`
+* `Class MyMessageBatch` defined in `MessageBatchTests.cs`
+* `Class NonBlockingBoundedMailboxTests` defined in `NonBlockingBoundedMailboxTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Actor.Tests/Router/context.md
+++ b/tests/Proto.Actor.Tests/Router/context.md
@@ -1,0 +1,40 @@
+# Router Context
+
+## Overview
+Router-specific tests verifying distribution strategies.
+
+_Parent context: [Proto Actor Tests](../context.md)_
+
+## Key Files
+* `BroadcastGroupTests.cs` – C# source defining Broadcast Group Tests behavior.
+* `BroadcastPoolRouterTests.cs` – C# source defining Broadcast Pool Router Tests behavior.
+* `ConsistentHashGroupTests.cs` – C# source defining Consistent Hash Group Tests behavior.
+* `ConsistentHashPoolRouterTests.cs` – C# source defining Consistent Hash Pool Router Tests behavior.
+* `HashRingTests.cs` – C# source defining Hash Ring Tests behavior.
+* `PoolRouterTests.cs` – C# source defining Pool Router Tests behavior.
+* `RandomGroupRouterTests.cs` – C# source defining Random Group Router Tests behavior.
+* `RoundRobinGroupTests.cs` – C# source defining Round Robin Group Tests behavior.
+* `RoundRobinPoolRouterTests.cs` – C# source defining Round Robin Pool Router Tests behavior.
+
+## Primary Types and Contracts
+* `Class BroadcastGroupTests` defined in `BroadcastGroupTests.cs`
+* `Class SlowForwardActor` defined in `BroadcastGroupTests.cs`
+* `Class BroadcastPoolRouterTests` defined in `BroadcastPoolRouterTests.cs`
+* `Class ConsistentHashGroupTests` defined in `ConsistentHashGroupTests.cs`
+* `Class SuperIntelligentDeterministicHash` defined in `ConsistentHashGroupTests.cs`
+* `Class Message` defined in `ConsistentHashGroupTests.cs`
+* `Class ConsistentHashPoolRouterTests` defined in `ConsistentHashPoolRouterTests.cs`
+* `Record Ping` defined in `ConsistentHashPoolRouterTests.cs`
+* `Class RespondWithSelfActor` defined in `ConsistentHashPoolRouterTests.cs`
+* `Class HashRingTests` defined in `HashRingTests.cs`
+* `Class PoolRouterTests` defined in `PoolRouterTests.cs`
+* `Class MyTestActor` defined in `PoolRouterTests.cs`
+* `Class Message` defined in `PoolRouterTests.cs`
+* `Class RandomGroupRouterTests` defined in `RandomGroupRouterTests.cs`
+* `Class RoundRobinGroupTests` defined in `RoundRobinGroupTests.cs`
+* `Class RoundRobinPoolRouterTests` defined in `RoundRobinPoolRouterTests.cs`
+* `Class RespondWithSelfActor` defined in `RoundRobinPoolRouterTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Actor.Tests/Utils/context.md
+++ b/tests/Proto.Actor.Tests/Utils/context.md
@@ -1,0 +1,18 @@
+# Utils Context
+
+## Overview
+Utility tests for helper functions used in Proto.Actor.
+
+_Parent context: [Proto Actor Tests](../context.md)_
+
+## Key Files
+* `RetryTests.cs` – C# source defining Retry Tests behavior.
+* `ThrottleTests.cs` – C# source defining Throttle Tests behavior.
+
+## Primary Types and Contracts
+* `Class RetryTests` defined in `RetryTests.cs`
+* `Class ThrottleTests` defined in `ThrottleTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Actor.Tests/context.md
+++ b/tests/Proto.Actor.Tests/context.md
@@ -1,0 +1,136 @@
+# Proto Actor Tests Context
+
+## Overview
+Unit tests covering the Proto.Actor runtime behavior, mailboxes, supervision, futures, headers, and diagnostics.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `ActorMetricsTests.cs` – C# source defining Actor Metrics Tests behavior.
+* `ActorTestBase.cs` – C# source defining Actor Test Base behavior.
+* `ActorTests.cs` – C# source defining Actor Tests behavior.
+* `AssemblyInfo.cs` – C# source defining Assembly Info behavior.
+* `BehaviorTests.cs` – C# source defining Behavior Tests behavior.
+* `CaptureContextTests.cs` – C# source defining Capture Context Tests behavior.
+* `DeadLetterResponseTests.cs` – C# source defining Dead Letter Response Tests behavior.
+* `DeduplicationContextTests.cs` – C# source defining Deduplication Context Tests behavior.
+* `DisposableActorTests.cs` – C# source defining Disposable Actor Tests behavior.
+* `EventStreamTests.cs` – C# source defining Event Stream Tests behavior.
+* `FunctionActorTests.cs` – C# source defining Function Actor Tests behavior.
+* `GuardianProcessTests.cs` – C# source defining Guardian Process Tests behavior.
+* `LoggingExtensionTests.cs` – C# source defining Logging Extension Tests behavior.
+* `MiddlewareTests.cs` – C# source defining Middleware Tests behavior.
+* `ObservableGaugeWrapperTests.cs` – C# source defining Observable Gauge Wrapper Tests behavior.
+* `PIDTests.cs` – C# source defining PID Tests behavior.
+* `PoisonTests.cs` – C# source defining Poison Tests behavior.
+* `ProcessRegistryTests.cs` – C# source defining Process Registry Tests behavior.
+* `PropsTests.cs` – C# source defining Props Tests behavior.
+* `Proto.Actor.Tests.csproj` – Project file configuring compilation targets and dependencies.
+* `ReceiveTimeoutTests.cs` – C# source defining Receive Timeout Tests behavior.
+* `ReenterAfterExtensionsDecoratorTests.cs` – C# source defining Reenter After Extensions Decorator Tests behavior.
+* `ReenterTests.cs` – C# source defining Reenter Tests behavior.
+* `SchedulerTests.cs` – C# source defining Scheduler Tests behavior.
+* `SpawnTests.cs` – C# source defining Spawn Tests behavior.
+* `StashingTests.cs` – C# source defining Stashing Tests behavior.
+* `StoreTests.cs` – C# source defining Store Tests behavior.
+* `SupervisionTests_ActorSupervisorStrategy.cs` – C# source defining Supervision Tests Actor Supervisor Strategy behavior.
+* `SupervisionTests_AllForOne.cs` – C# source defining Supervision Tests All For One behavior.
+* `SupervisionTests_AlwaysRestart.cs` – C# source defining Supervision Tests Always Restart behavior.
+* `SupervisionTests_ExponentialBackoff.cs` – C# source defining Supervision Tests Exponential Backoff behavior.
+* `SupervisionTests_OneForOne.cs` – C# source defining Supervision Tests One For One behavior.
+* `TestProbeAsyncTests.cs` – C# source defining Test Probe Async Tests behavior.
+* `TimerExtensionsTests.cs` – C# source defining Timer Extensions Tests behavior.
+* `UnknownSystemMessageTests.cs` – C# source defining Unknown System Message Tests behavior.
+* `WatchTests.cs` – C# source defining Watch Tests behavior.
+
+## Primary Types and Contracts
+* `Class ActorMetricsTests` defined in `ActorMetricsTests.cs`
+* `Class ActorTestBase` defined in `ActorTestBase.cs`
+* `Class MyAutoRespondMessage` defined in `ActorTests.cs`
+* `Class ActorTests` defined in `ActorTests.cs`
+* `Class BehaviorTests` defined in `BehaviorTests.cs`
+* `Class LightBulb` defined in `BehaviorTests.cs`
+* `Class PressSwitch` defined in `BehaviorTests.cs`
+* `Class Touch` defined in `BehaviorTests.cs`
+* `Class HitWithHammer` defined in `BehaviorTests.cs`
+* `Record Unstash` defined in `CaptureContextTests.cs`
+* `Record UnstashResponse` defined in `CaptureContextTests.cs`
+* `Record UnstashResult` defined in `CaptureContextTests.cs`
+* `Class CaptureContextActor` defined in `CaptureContextTests.cs`
+* `Class CaptureContextTests` defined in `CaptureContextTests.cs`
+* `Class DeadLetterResponseTests` defined in `DeadLetterResponseTests.cs`
+* `Class DeadLetterResponseValidationActor` defined in `DeadLetterResponseTests.cs`
+* `Class DeduplicationContextTests` defined in `DeduplicationContextTests.cs`
+* `Class DisposableActorTests` defined in `DisposableActorTests.cs`
+* `Class SupervisingActor` defined in `DisposableActorTests.cs`
+* `Class AsyncDisposableActor` defined in `DisposableActorTests.cs`
+* `Class DisposableActor` defined in `DisposableActorTests.cs`
+* `Class ParentWithMultipleChildrenActor` defined in `DisposableActorTests.cs`
+* `Class EventStreamTests` defined in `EventStreamTests.cs`
+* `Class FunctionActorTests` defined in `FunctionActorTests.cs`
+* `Class GuardianProcessTests` defined in `GuardianProcessTests.cs`
+* `Class NoopStrategy` defined in `GuardianProcessTests.cs`
+* `Class RecordingProcess` defined in `GuardianProcessTests.cs`
+* `Class LoggingExtensionTests` defined in `LoggingExtensionTests.cs`
+* `Class TestContextDecorator` defined in `MiddlewareTests.cs`
+* `Class MiddlewareTests` defined in `MiddlewareTests.cs`
+* `Class ObservableGaugeWrapperTests` defined in `ObservableGaugeWrapperTests.cs`
+* `Class PidTests` defined in `PIDTests.cs`
+* `Class PoisonTests` defined in `PoisonTests.cs`
+* `Class ProcessRegistryTests` defined in `ProcessRegistryTests.cs`
+* `Class PropsTests` defined in `PropsTests.cs`
+* `Class DummyActor` defined in `PropsTests.cs`
+* `Class ActorWithSystem` defined in `PropsTests.cs`
+* `Class ReceiveTimeoutTests` defined in `ReceiveTimeoutTests.cs`
+* `Record IgnoreMe` defined in `ReceiveTimeoutTests.cs`
+* `Class ReenterAfterExtensionsDecoratorTests` defined in `ReenterAfterExtensionsDecoratorTests.cs`
+* `Class CountingReenterDecorator` defined in `ReenterAfterExtensionsDecoratorTests.cs`
+* `Class ReenterTests` defined in `ReenterTests.cs`
+* `Class ReenterAfterCancellationActor` defined in `ReenterTests.cs`
+* `Record Request` defined in `ReenterTests.cs`
+* `Record Response` defined in `ReenterTests.cs`
+* `Class SchedulerTests` defined in `SchedulerTests.cs`
+* `Class TestSchedulerHook` defined in `SchedulerTests.cs`
+* `Class SpawnTests` defined in `SpawnTests.cs`
+* `Class StashingActor` defined in `StashingTests.cs`
+* `Class ApplyActor` defined in `StashingTests.cs`
+* `Class StashingTests` defined in `StashingTests.cs`
+* `Class StoreTests` defined in `StoreTests.cs`
+* `Class StoreType` defined in `StoreTests.cs`
+* `Class SupervisionTestsActorSupervisorStrategy` defined in `SupervisionTests_ActorSupervisorStrategy.cs`
+* `Class SupervisingActor` defined in `SupervisionTests_ActorSupervisorStrategy.cs`
+* `Class NonSupervisingParent` defined in `SupervisionTests_ActorSupervisorStrategy.cs`
+* `Class FailingChildActor` defined in `SupervisionTests_ActorSupervisorStrategy.cs`
+* `Class TrackingSupervisorStrategy` defined in `SupervisionTests_ActorSupervisorStrategy.cs`
+* `Class SupervisionTestsAllForOne` defined in `SupervisionTests_AllForOne.cs`
+* `Class ParentActor` defined in `SupervisionTests_AllForOne.cs`
+* `Class ChildActor` defined in `SupervisionTests_AllForOne.cs`
+* `Class SupervisionTestsAlwaysRestart` defined in `SupervisionTests_AlwaysRestart.cs`
+* `Class ParentActor` defined in `SupervisionTests_AlwaysRestart.cs`
+* `Class ChildActor` defined in `SupervisionTests_AlwaysRestart.cs`
+* `Class SupervisionTestsExponentialBackoff` defined in `SupervisionTests_ExponentialBackoff.cs`
+* `Class ParentActor` defined in `SupervisionTests_ExponentialBackoff.cs`
+* `Class BackoffChild` defined in `SupervisionTests_ExponentialBackoff.cs`
+* `Class SupervisionTestsOneForOne` defined in `SupervisionTests_OneForOne.cs`
+* `Class ParentActor` defined in `SupervisionTests_OneForOne.cs`
+* `Class ChildActor` defined in `SupervisionTests_OneForOne.cs`
+* `Class ThrowOnStartedChildActor` defined in `SupervisionTests_OneForOne.cs`
+* `Class TestProbeAsyncTests` defined in `TestProbeAsyncTests.cs`
+* `Class TimerExtensionsTests` defined in `TimerExtensionsTests.cs`
+* `Class TestSchedulerHook` defined in `TimerExtensionsTests.cs`
+* `Class UnknownSystemMessageTests` defined in `UnknownSystemMessageTests.cs`
+* `Class UnknownSystemMessage` defined in `UnknownSystemMessageTests.cs`
+* `Record GetChild` defined in `UnknownSystemMessageTests.cs`
+* `Class ParentActor` defined in `UnknownSystemMessageTests.cs`
+* `Class WatchTests` defined in `WatchTests.cs`
+
+## Related Subcontexts
+* [Dependency Injection](DependencyInjection/context.md) – See the nested context for details.
+* [Diagnostics](Diagnostics/context.md) – See the nested context for details.
+* [Extensions](Extensions/context.md) – See the nested context for details.
+* [Futures](Futures/context.md) – See the nested context for details.
+* [Headers](Headers/context.md) – See the nested context for details.
+* [Mailbox](Mailbox/context.md) – See the nested context for details.
+* [Router](Router/context.md) – See the nested context for details.
+* [Utils](Utils/context.md) – See the nested context for details.
+

--- a/tests/Proto.Analyzers.Tests/Diagnostics/context.md
+++ b/tests/Proto.Analyzers.Tests/Diagnostics/context.md
@@ -1,0 +1,35 @@
+# Diagnostics Context
+
+## Overview
+Diagnostics directory within the Proto.Actor repository.
+
+_Parent context: [Proto Analyzers Tests](../context.md)_
+
+## Key Files
+* `PoisonSelfAnalyzerTests.cs` – C# source defining Poison Self Analyzer Tests behavior.
+* `TaskMessageAnalyzerTests.cs` – C# source defining Task Message Analyzer Tests behavior.
+
+## Primary Types and Contracts
+* `Class PoisonSelfAnalyzerTests` defined in `PoisonSelfAnalyzerTests.cs`
+* `Class SomeActor` defined in `PoisonSelfAnalyzerTests.cs`
+* `Record SomeMessage` defined in `PoisonSelfAnalyzerTests.cs`
+* `Class SomeActor` defined in `PoisonSelfAnalyzerTests.cs`
+* `Record SomeMessage` defined in `PoisonSelfAnalyzerTests.cs`
+* `Class SomeActor` defined in `PoisonSelfAnalyzerTests.cs`
+* `Record SomeMessage` defined in `PoisonSelfAnalyzerTests.cs`
+* `Class SomeActor` defined in `PoisonSelfAnalyzerTests.cs`
+* `Class TaskMessageAnalyzerTests` defined in `TaskMessageAnalyzerTests.cs`
+* `Record SomeMessage` defined in `TaskMessageAnalyzerTests.cs`
+* `Class SomeActor` defined in `TaskMessageAnalyzerTests.cs`
+* `Record SomeMessage` defined in `TaskMessageAnalyzerTests.cs`
+* `Class SomeActor` defined in `TaskMessageAnalyzerTests.cs`
+* `Record SomeMessage` defined in `TaskMessageAnalyzerTests.cs`
+* `Class SomeActor` defined in `TaskMessageAnalyzerTests.cs`
+* `Record SomeMessage` defined in `TaskMessageAnalyzerTests.cs`
+* `Class SomeActor` defined in `TaskMessageAnalyzerTests.cs`
+* `Record SomeMessage` defined in `TaskMessageAnalyzerTests.cs`
+* `Class SomeActor` defined in `TaskMessageAnalyzerTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Analyzers.Tests/context.md
+++ b/tests/Proto.Analyzers.Tests/context.md
@@ -1,0 +1,22 @@
+# Proto Analyzers Tests Context
+
+## Overview
+Unit tests for the Roslyn analyzers shipped with Proto.Actor.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `AnalyzerTest.cs` – C# source defining Analyzer Test behavior.
+* `AssembliesUnderTest.cs` – C# source defining Assemblies Under Test behavior.
+* `CodeFixProviderTests.cs` – C# source defining Code Fix Provider Tests behavior.
+* `Proto.Analyzers.Tests.csproj` – Project file configuring compilation targets and dependencies.
+* `Usings.cs` – C# source defining Usings behavior.
+
+## Primary Types and Contracts
+* `Class AnalyzerTest` defined in `AnalyzerTest.cs`
+* `Class AssembliesUnderTest` defined in `AssembliesUnderTest.cs`
+* `Class CodeFixProviderTests` defined in `CodeFixProviderTests.cs`
+
+## Related Subcontexts
+* [Diagnostics](Diagnostics/context.md) – See the nested context for details.
+

--- a/tests/Proto.Cluster.CodeGen.Tests/context.md
+++ b/tests/Proto.Cluster.CodeGen.Tests/context.md
@@ -1,0 +1,36 @@
+# Proto Cluster Code Gen Tests Context
+
+## Overview
+Tests covering the code generator and templates.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `ExpectedOutput.cs` – C# source defining Expected Output behavior.
+* `ExpectedOutputPackageless.cs` – C# source defining Expected Output Packageless behavior.
+* `OutputFileNameTests.cs` – C# source defining Output File Name Tests behavior.
+* `PathPolyfillTests.cs` – C# source defining Path Polyfill Tests behavior.
+* `Proto.Cluster.CodeGen.Tests.csproj` – Project file configuring compilation targets and dependencies.
+* `ProtoGrainGenerationTests.cs` – C# source defining Proto Grain Generation Tests behavior.
+* `bar.proto` – Protocol Buffers schema.
+* `foo.proto` – Protocol Buffers schema.
+* `foo_packageless.proto` – Protocol Buffers schema.
+* `invalid.proto` – Protocol Buffers schema.
+* `invalid2.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* `Class GrainExtensions` defined in `ExpectedOutput.cs`
+* `Class TestGrainBase` defined in `ExpectedOutput.cs`
+* `Class TestGrainClient` defined in `ExpectedOutput.cs`
+* `Class TestGrainActor` defined in `ExpectedOutput.cs`
+* `Class GrainExtensions` defined in `ExpectedOutputPackageless.cs`
+* `Class TestGrainBase` defined in `ExpectedOutputPackageless.cs`
+* `Class TestGrainClient` defined in `ExpectedOutputPackageless.cs`
+* `Class TestGrainActor` defined in `ExpectedOutputPackageless.cs`
+* `Class OutputFileNameTests` defined in `OutputFileNameTests.cs`
+* `Class PathPolyfillTests` defined in `PathPolyfillTests.cs`
+* `Class ProtoGrainGenerationTests` defined in `ProtoGrainGenerationTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Cluster.Identity.Tests/context.md
+++ b/tests/Proto.Cluster.Identity.Tests/context.md
@@ -1,0 +1,24 @@
+# Proto Cluster Identity Tests Context
+
+## Overview
+Base identity provider test abstractions.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `AssemblyInfo.cs` – C# source defining Assembly Info behavior.
+* `FailureInjectionStorage.cs` – C# source defining Failure Injection Storage behavior.
+* `IdentityStorageLogging.cs` – C# source defining Identity Storage Logging behavior.
+* `IdentityStorageTests.cs` – C# source defining Identity Storage Tests behavior.
+* `Proto.Cluster.Identity.Tests.csproj` – Project file configuring compilation targets and dependencies.
+* `appsettings.json` – Configuration or metadata in JSON format.
+* `docker-compose.yml` – YAML configuration.
+
+## Primary Types and Contracts
+* `Class FailureInjectionStorage` defined in `FailureInjectionStorage.cs`
+* `Class IdentityStorageLogging` defined in `IdentityStorageLogging.cs`
+* `Class IdentityStorageTests` defined in `IdentityStorageTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Cluster.MongoIdentity.Tests/context.md
+++ b/tests/Proto.Cluster.MongoIdentity.Tests/context.md
@@ -1,0 +1,25 @@
+# Proto Cluster Mongo Identity Tests Context
+
+## Overview
+MongoDB identity lookup integration tests.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `AssemblyInfo.cs` – C# source defining Assembly Info behavior.
+* `MongoIdentityTests.cs` – C# source defining Mongo Identity Tests behavior.
+* `Proto.Cluster.MongoIdentity.Tests.csproj` – Project file configuring compilation targets and dependencies.
+* `appsettings.json` – Configuration or metadata in JSON format.
+* `docker-compose.yml` – YAML configuration.
+
+## Primary Types and Contracts
+* `Class MongoIdentityClusterFixture` defined in `MongoIdentityTests.cs`
+* `Class MongoClusterTests` defined in `MongoIdentityTests.cs`
+* `Class ChaosMongoIdentityClusterFixture` defined in `MongoIdentityTests.cs`
+* `Class ChaosMongoClusterTests` defined in `MongoIdentityTests.cs`
+* `Class MongoFixture` defined in `MongoIdentityTests.cs`
+* `Class MongoStorageTests` defined in `MongoIdentityTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Cluster.PartitionIdentity.Tests/context.md
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/context.md
@@ -1,0 +1,20 @@
+# Proto Cluster Partition Identity Tests Context
+
+## Overview
+Proto Cluster Partition Identity Tests directory within the Proto.Actor repository.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `HandoverSinkTests.cs` – C# source defining Handover Sink Tests behavior.
+* `PartitionIdentityTests.cs` – C# source defining Partition Identity Tests behavior.
+* `Proto.Cluster.PartitionIdentity.Tests.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* `Class HandoverSinkTests` defined in `HandoverSinkTests.cs`
+* `Class PartitionIdentityTests` defined in `PartitionIdentityTests.cs`
+* `Class PartitionIdentityClusterFixture` defined in `PartitionIdentityTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Cluster.PubSub.Tests/context.md
+++ b/tests/Proto.Cluster.PubSub.Tests/context.md
@@ -1,0 +1,36 @@
+# Proto Cluster Pub Sub Tests Context
+
+## Overview
+Dedicated tests for the cluster pub-sub subsystem.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `InMemorySubscribersStore.cs` – C# source defining In Memory Subscribers Store behavior.
+* `Proto.Cluster.PubSub.Tests.csproj` – Project file configuring compilation targets and dependencies.
+* `PubSubBatchingProducerTests.cs` – C# source defining Pub Sub Batching Producer Tests behavior.
+* `PubSubClientTests.cs` – C# source defining Pub Sub Client Tests behavior.
+* `PubSubClusterFixture.cs` – C# source defining Pub Sub Cluster Fixture behavior.
+* `PubSubDefaultTopicRegistrationTests.cs` – C# source defining Pub Sub Default Topic Registration Tests behavior.
+* `PubSubMemberTests.cs` – C# source defining Pub Sub Member Tests behavior.
+* `PubSubTests.cs` – C# source defining Pub Sub Tests behavior.
+
+## Primary Types and Contracts
+* `Class InMemorySubscribersStore` defined in `InMemorySubscribersStore.cs`
+* `Class PubSubBatchingProducerTests` defined in `PubSubBatchingProducerTests.cs`
+* `Class MockPublisher` defined in `PubSubBatchingProducerTests.cs`
+* `Class OptionalFailureMockPublisher` defined in `PubSubBatchingProducerTests.cs`
+* `Record TestMessage` defined in `PubSubBatchingProducerTests.cs`
+* `Class TestException` defined in `PubSubBatchingProducerTests.cs`
+* `Class PubSubClientTests` defined in `PubSubClientTests.cs`
+* `Record DataPublished` defined in `PubSubClusterFixture.cs`
+* `Record Delivery` defined in `PubSubClusterFixture.cs`
+* `Record Response` defined in `PubSubClusterFixture.cs`
+* `Class PubSubClusterFixture` defined in `PubSubClusterFixture.cs`
+* `Class PubSubDefaultTopicRegistrationTests` defined in `PubSubDefaultTopicRegistrationTests.cs`
+* `Class PubSubMemberTests` defined in `PubSubMemberTests.cs`
+* `Class PubSubTests` defined in `PubSubTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Cluster.RedisIdentity.Tests/context.md
+++ b/tests/Proto.Cluster.RedisIdentity.Tests/context.md
@@ -1,0 +1,25 @@
+# Proto Cluster Redis Identity Tests Context
+
+## Overview
+Redis identity lookup integration tests.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `AssemblyInfo.cs` – C# source defining Assembly Info behavior.
+* `Proto.Cluster.RedisIdentity.Tests.csproj` – Project file configuring compilation targets and dependencies.
+* `RedisIdentityTests.cs` – C# source defining Redis Identity Tests behavior.
+* `appsettings.json` – Configuration or metadata in JSON format.
+* `docker-compose.yml` – YAML configuration.
+
+## Primary Types and Contracts
+* `Class RedisIdentityClusterFixture` defined in `RedisIdentityTests.cs`
+* `Class RedisClusterTests` defined in `RedisIdentityTests.cs`
+* `Class ChaosMonkeyRedisIdentityClusterFixture` defined in `RedisIdentityTests.cs`
+* `Class ResilienceRedisClusterTests` defined in `RedisIdentityTests.cs`
+* `Class RedisFixture` defined in `RedisIdentityTests.cs`
+* `Class RedisStorageTests` defined in `RedisIdentityTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Cluster.Tests/context.md
+++ b/tests/Proto.Cluster.Tests/context.md
@@ -1,0 +1,136 @@
+# Proto Cluster Tests Context
+
+## Overview
+Cluster runtime tests including membership, identity, partitioning, and pub-sub behaviors.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `AssemblyInfo.cs` – C# source defining Assembly Info behavior.
+* `ClusterFixture.cs` – C# source defining Cluster Fixture behavior.
+* `ClusterTestBase.cs` – C# source defining Cluster Test Base behavior.
+* `ClusterTests.cs` – C# source defining Cluster Tests behavior.
+* `ClusterTestsWithLocalAffinity.cs` – C# source defining Cluster Tests With Local Affinity behavior.
+* `ClusterTopologyBuilderTests.cs` – C# source defining Cluster Topology Builder Tests behavior.
+* `ConcurrencyVerificationActor.cs` – C# source defining Concurrency Verification Actor behavior.
+* `ConsensusEvaluatorTests.cs` – C# source defining Consensus Evaluator Tests behavior.
+* `ConsulTests.cs` – C# source defining Consul Tests behavior.
+* `DeterministicRandomProvider.cs` – C# source defining Deterministic Random Provider behavior.
+* `EchoActor.cs` – C# source defining Echo Actor behavior.
+* `ExpectUpdatedTopologyConsensusTests.cs` – C# source defining Expect Updated Topology Consensus Tests behavior.
+* `Extensions.cs` – C# source defining Extensions behavior.
+* `ForcedSerializationTests.cs` – C# source defining Forced Serialization Tests behavior.
+* `GithubActionsReporter.cs` – C# source defining Github Actions Reporter behavior.
+* `GossipConsensusTests.cs` – C# source defining Gossip Consensus Tests behavior.
+* `GossipCoreTests.cs` – C# source defining Gossip Core Tests behavior.
+* `GossipDisseminationTests.cs` – C# source defining Gossip Dissemination Tests behavior.
+* `GossipRandomOrderingTests.cs` – C# source defining Gossip Random Ordering Tests behavior.
+* `GossipRequestValidationTests.cs` – C# source defining Gossip Request Validation Tests behavior.
+* `GossipStateManagementTests.cs` – C# source defining Gossip State Management Tests behavior.
+* `GossipStateQueryTests.cs` – C# source defining Gossip State Query Tests behavior.
+* `GossipTests.cs` – C# source defining Gossip Tests behavior.
+* `GossipTransportTests.cs` – C# source defining Gossip Transport Tests behavior.
+* `GracefulLeaveTests.cs` – C# source defining Graceful Leave Tests behavior.
+* `InMemorySubscribersStore.cs` – C# source defining In Memory Subscribers Store behavior.
+* `LegacyTimeoutTests.cs` – C# source defining Legacy Timeout Tests behavior.
+* `MemberStateDeltaBuilderTests.cs` – C# source defining Member State Delta Builder Tests behavior.
+* `OrderedDeliveryTests.cs` – C# source defining Ordered Delivery Tests behavior.
+* `PartitionConsensusTests.cs` – C# source defining Partition Consensus Tests behavior.
+* `PartitionMiddlewareTests.cs` – C# source defining Partition Middleware Tests behavior.
+* `PidCacheInvalidationTests.cs` – C# source defining Pid Cache Invalidation Tests behavior.
+* `PidCacheTests.cs` – C# source defining Pid Cache Tests behavior.
+* `Proto.Cluster.Tests.csproj` – Project file configuring compilation targets and dependencies.
+* `RedundantGossipTests.cs` – C# source defining Redundant Gossip Tests behavior.
+* `RemoteGossipTests.cs` – C# source defining Remote Gossip Tests behavior.
+* `RetryOnDeadLetterTests.cs` – C# source defining Retry On Dead Letter Tests behavior.
+* `TimeoutTests.cs` – C# source defining Timeout Tests behavior.
+* `UnreachableSubscriberTests.cs` – C# source defining Unreachable Subscriber Tests behavior.
+* `docker-compose.yml` – YAML configuration.
+* `messages.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* `Interface IClusterFixture` defined in `ClusterFixture.cs`
+* `Class TracingSettings` defined in `ClusterFixture.cs`
+* `Class ClusterFixture` defined in `ClusterFixture.cs`
+* `Class BaseInMemoryClusterFixture` defined in `ClusterFixture.cs`
+* `Class InMemoryClusterFixture` defined in `ClusterFixture.cs`
+* `Class InMemoryClusterFixtureWithPartitionActivator` defined in `ClusterFixture.cs`
+* `Class InMemoryClusterFixtureAlternativeClusterContext` defined in `ClusterFixture.cs`
+* `Class InMemoryClusterFixtureSharedFutures` defined in `ClusterFixture.cs`
+* `Class InMemoryPidCacheInvalidationClusterFixture` defined in `ClusterFixture.cs`
+* `Class SingleNodeProviderFixture` defined in `ClusterFixture.cs`
+* `Class ClusterTestBase` defined in `ClusterTestBase.cs`
+* `Class ClusterTests` defined in `ClusterTests.cs`
+* `Class InMemoryPartitionActivatorClusterTests` defined in `ClusterTests.cs`
+* `Class SingleNodeProviderClusterTests` defined in `ClusterTests.cs`
+* `Class ClusterTestsWithLocalAffinity` defined in `ClusterTestsWithLocalAffinity.cs`
+* `Class InMemoryClusterTests` defined in `ClusterTestsWithLocalAffinity.cs`
+* `Class InMemoryClusterTestsSharedFutures` defined in `ClusterTestsWithLocalAffinity.cs`
+* `Class InMemoryClusterTestsPidCacheInvalidation` defined in `ClusterTestsWithLocalAffinity.cs`
+* `Class ClusterTopologyBuilderTests` defined in `ClusterTopologyBuilderTests.cs`
+* `Class ConcurrencyVerificationActor` defined in `ConcurrencyVerificationActor.cs`
+* `Record VerificationEvent` defined in `ConcurrencyVerificationActor.cs`
+* `Record ActorStarted` defined in `ConcurrencyVerificationActor.cs`
+* `Record ActorStopped` defined in `ConcurrencyVerificationActor.cs`
+* `Record ActivationRequested` defined in `ConcurrencyVerificationActor.cs`
+* `Record ConsistencyError` defined in `ConcurrencyVerificationActor.cs`
+* `Record ClusterSnapshot` defined in `ConcurrencyVerificationActor.cs`
+* `Class ActorState` defined in `ConcurrencyVerificationActor.cs`
+* `Class ActorStateRepo` defined in `ConcurrencyVerificationActor.cs`
+* `Class ConsensusEvaluatorTests` defined in `ConsensusEvaluatorTests.cs`
+* `Class ConsulClusterFixture` defined in `ConsulTests.cs`
+* `Class DeterministicRandomProvider` defined in `DeterministicRandomProvider.cs`
+* `Class EchoActor` defined in `EchoActor.cs`
+* `Class ExpectUpdatedTopologyConsensusTests` defined in `ExpectUpdatedTopologyConsensusTests.cs`
+* `Class Extensions` defined in `Extensions.cs`
+* `Class ForcedSerializationTests` defined in `ForcedSerializationTests.cs`
+* `Class ForcedSerializationClusterFixture` defined in `ForcedSerializationTests.cs`
+* `Class GithubActionsReporter` defined in `GithubActionsReporter.cs`
+* `Record TestResult` defined in `GithubActionsReporter.cs`
+* `Class GossipConsensusTests` defined in `GossipConsensusTests.cs`
+* `Class GossipCoreTests` defined in `GossipCoreTests.cs`
+* `Class GossipDisseminationTests` defined in `GossipDisseminationTests.cs`
+* `Class GossipRandomOrderingTests` defined in `GossipRandomOrderingTests.cs`
+* `Class GossipRequestValidationTests` defined in `GossipRequestValidationTests.cs`
+* `Class GossipStateManagementTests` defined in `GossipStateManagementTests.cs`
+* `Class GossipStateQueryTests` defined in `GossipStateQueryTests.cs`
+* `Class GossipTests` defined in `GossipTests.cs`
+* `Class GossipClusterFixture` defined in `GossipTests.cs`
+* `Class GossipTransportTests` defined in `GossipTransportTests.cs`
+* `Class MockTransport` defined in `GossipTransportTests.cs`
+* `Class GracefulLeaveTests` defined in `GracefulLeaveTests.cs`
+* `Class TwoMembersClusterFixture` defined in `GracefulLeaveTests.cs`
+* `Class InMemorySubscribersStore` defined in `InMemorySubscribersStore.cs`
+* `Class LegacyTimeoutTests` defined in `LegacyTimeoutTests.cs`
+* `Class Fixture` defined in `LegacyTimeoutTests.cs`
+* `Class MemberStateDeltaBuilderTests` defined in `MemberStateDeltaBuilderTests.cs`
+* `Class OrderedDeliveryTests` defined in `OrderedDeliveryTests.cs`
+* `Class SenderActor` defined in `OrderedDeliveryTests.cs`
+* `Class VerifyOrderActor` defined in `OrderedDeliveryTests.cs`
+* `Class OrderedDeliveryFixture` defined in `OrderedDeliveryTests.cs`
+* `Class PartitionConsensusTests` defined in `PartitionConsensusTests.cs`
+* `Class PartitionClusterFixture` defined in `PartitionConsensusTests.cs`
+* `Class PartitionActivatorMiddlewareTests` defined in `PartitionMiddlewareTests.cs`
+* `Class ActivatorMiddlewareFixture` defined in `PartitionMiddlewareTests.cs`
+* `Class PartitionPlacementMiddlewareTests` defined in `PartitionMiddlewareTests.cs`
+* `Class PlacementMiddlewareFixture` defined in `PartitionMiddlewareTests.cs`
+* `Class PidCacheInvalidationTests` defined in `PidCacheInvalidationTests.cs`
+* `Class DummyIdentityLookup` defined in `PidCacheTests.cs`
+* `Class PidCacheTests` defined in `PidCacheTests.cs`
+* `Class RedundantGossipTests` defined in `RedundantGossipTests.cs`
+* `Class GossipCountingClusterFixture` defined in `RedundantGossipTests.cs`
+* `Class RemoteGossipTests` defined in `RemoteGossipTests.cs`
+* `Class TestMemberList` defined in `RemoteGossipTests.cs`
+* `Class RetryOnDeadLetterTests` defined in `RetryOnDeadLetterTests.cs`
+* `Class Fixture` defined in `RetryOnDeadLetterTests.cs`
+* `Class TimeoutTests` defined in `TimeoutTests.cs`
+* `Class Fixture` defined in `TimeoutTests.cs`
+* `Class UnreachableSubscriberTests` defined in `UnreachableSubscriberTests.cs`
+* `Record DataPublished` defined in `UnreachableSubscriberTests.cs`
+* `Record Delivery` defined in `UnreachableSubscriberTests.cs`
+* `Record Response` defined in `UnreachableSubscriberTests.cs`
+* `Class Fixture` defined in `UnreachableSubscriberTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.OpenTelemetry.Tests/context.md
+++ b/tests/Proto.OpenTelemetry.Tests/context.md
@@ -1,0 +1,28 @@
+# Proto Open Telemetry Tests Context
+
+## Overview
+Tests for the OpenTelemetry instrumentation package.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `ActivityFixture.cs` – C# source defining Activity Fixture behavior.
+* `OpenTelemetryMetricsTests.cs` – C# source defining Open Telemetry Metrics Tests behavior.
+* `OpenTelemetryTracingTests.cs` – C# source defining Open Telemetry Tracing Tests behavior.
+* `Proto.OpenTelemetry.Tests.csproj` – Project file configuring compilation targets and dependencies.
+* `messages.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* `Class ActivityFixture` defined in `ActivityFixture.cs`
+* `Class OpenTelemetryMetricsTests` defined in `OpenTelemetryMetricsTests.cs`
+* `Class EchoActor` defined in `OpenTelemetryMetricsTests.cs`
+* `Class TestExporter` defined in `OpenTelemetryMetricsTests.cs`
+* `Class OpenTelemetryTracingTests` defined in `OpenTelemetryTracingTests.cs`
+* `Enum SendAs` defined in `OpenTelemetryTracingTests.cs`
+* `Record TraceMe` defined in `OpenTelemetryTracingTests.cs`
+* `Record TraceResponse` defined in `OpenTelemetryTracingTests.cs`
+* `Class TraceTestActor` defined in `OpenTelemetryTracingTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Persistence.Tests/SnapshotStrategies/context.md
+++ b/tests/Proto.Persistence.Tests/SnapshotStrategies/context.md
@@ -1,0 +1,20 @@
+# Snapshot Strategies Context
+
+## Overview
+Snapshot Strategies directory within the Proto.Actor repository.
+
+_Parent context: [Proto Persistence Tests](../context.md)_
+
+## Key Files
+* `EventTypeStrategyTests.cs` – C# source defining Event Type Strategy Tests behavior.
+* `IntervalStrategyTests.cs` – C# source defining Interval Strategy Tests behavior.
+* `TimeStrategyTests.cs` – C# source defining Time Strategy Tests behavior.
+
+## Primary Types and Contracts
+* `Class EventTypeStrategyTests` defined in `EventTypeStrategyTests.cs`
+* `Class IntervalStrategyTests` defined in `IntervalStrategyTests.cs`
+* `Class TimeStrategyTests` defined in `TimeStrategyTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Persistence.Tests/context.md
+++ b/tests/Proto.Persistence.Tests/context.md
@@ -1,0 +1,32 @@
+# Proto Persistence Tests Context
+
+## Overview
+Persistence subsystem tests covering journals, snapshots, and strategies.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `AssemblyInfo.cs` – C# source defining Assembly Info behavior.
+* `ContainersFixture.cs` – C# source defining Containers Fixture behavior.
+* `ExamplePersistentActorTests.cs` – C# source defining Example Persistent Actor Tests behavior.
+* `InMemoryProvider.cs` – C# source defining In Memory Provider behavior.
+* `PersistenceWithSnapshotStrategiesTests.cs` – C# source defining Persistence With Snapshot Strategies Tests behavior.
+* `Proto.Persistence.Tests.csproj` – Project file configuring compilation targets and dependencies.
+
+## Primary Types and Contracts
+* `Class ContainersFixture` defined in `ContainersFixture.cs`
+* `Class ExamplePersistentActorTests` defined in `ExamplePersistentActorTests.cs`
+* `Class State` defined in `ExamplePersistentActorTests.cs`
+* `Enum TestProvider` defined in `ExamplePersistentActorTests.cs`
+* `Class GetState` defined in `ExamplePersistentActorTests.cs`
+* `Class GetIndex` defined in `ExamplePersistentActorTests.cs`
+* `Class Multiply` defined in `ExamplePersistentActorTests.cs`
+* `Class Multiplied` defined in `ExamplePersistentActorTests.cs`
+* `Class RequestSnapshot` defined in `ExamplePersistentActorTests.cs`
+* `Class ExamplePersistentActor` defined in `ExamplePersistentActorTests.cs`
+* `Class InMemoryProvider` defined in `InMemoryProvider.cs`
+* `Class PersistenceWithSnapshotStrategiesTests` defined in `PersistenceWithSnapshotStrategiesTests.cs`
+
+## Related Subcontexts
+* [Snapshot Strategies](SnapshotStrategies/context.md) – See the nested context for details.
+

--- a/tests/Proto.Remote.Tests.Messages/context.md
+++ b/tests/Proto.Remote.Tests.Messages/context.md
@@ -1,0 +1,17 @@
+# Proto Remote Tests Messages Context
+
+## Overview
+Message contracts used only by the remote tests.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `Proto.Remote.Tests.Messages.csproj` – Project file configuring compilation targets and dependencies.
+* `Protos.proto` – Protocol Buffers schema.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Remote.Tests/RemoteTests/context.md
+++ b/tests/Proto.Remote.Tests/RemoteTests/context.md
@@ -1,0 +1,37 @@
+# Remote Tests Context
+
+## Overview
+Remote Tests directory within the Proto.Actor repository.
+
+_Parent context: [Proto Remote Tests](../context.md)_
+
+## Key Files
+* `GrpcNetClientWithGrpcNetServerTests.cs` – C# source defining Grpc Net Client With Grpc Net Server Tests behavior.
+* `GrpcNetClientWithHostedGrpcNetServerTests.cs` – C# source defining Grpc Net Client With Hosted Grpc Net Server Tests behavior.
+* `GrpcNetClient_Client_With_GrpcNet_ServerTests.cs` – C# source defining Grpc Net Client Client With Grpc Net Server Tests behavior.
+* `GrpcNetClient_Client_With_HostedGrpcNet_ServerTests.cs` – C# source defining Grpc Net Client Client With Hosted Grpc Net Server Tests behavior.
+* `HostedGrpcNetClientWithGrpcNetServerTests.cs` – C# source defining Hosted Grpc Net Client With Grpc Net Server Tests behavior.
+* `HostedGrpcNetClientWithHostedGrpcNetServerTests.cs` – C# source defining Hosted Grpc Net Client With Hosted Grpc Net Server Tests behavior.
+* `HostedGrpcNetWithCustomeSerializerTests.cs` – C# source defining Hosted Grpc Net With Custome Serializer Tests behavior.
+* `WithJsonSerializeAsDefaultTests.cs` – C# source defining With Json Serialize As Default Tests behavior.
+
+## Primary Types and Contracts
+* `Class GrpcNetServerClientWithGrpcNetServerTests` defined in `GrpcNetClientWithGrpcNetServerTests.cs`
+* `Class Fixture` defined in `GrpcNetClientWithGrpcNetServerTests.cs`
+* `Class GrpcNetClientWithHostedGrpcNetServerTests` defined in `GrpcNetClientWithHostedGrpcNetServerTests.cs`
+* `Class Fixture` defined in `GrpcNetClientWithHostedGrpcNetServerTests.cs`
+* `Class GrpcNetClient_Client_With_GrpcNet_ServerTests` defined in `GrpcNetClient_Client_With_GrpcNet_ServerTests.cs`
+* `Class Fixture` defined in `GrpcNetClient_Client_With_GrpcNet_ServerTests.cs`
+* `Class GrpcNetClient_Client_With_HostedGrpcNet_ServerTests` defined in `GrpcNetClient_Client_With_HostedGrpcNet_ServerTests.cs`
+* `Class Fixture` defined in `GrpcNetClient_Client_With_HostedGrpcNet_ServerTests.cs`
+* `Class HostedGrpcNetClientWithGrpcNetServerTests` defined in `HostedGrpcNetClientWithGrpcNetServerTests.cs`
+* `Class Fixture` defined in `HostedGrpcNetClientWithGrpcNetServerTests.cs`
+* `Class HostedGrpcNetClientWithHostedGrpcNetServerTests` defined in `HostedGrpcNetClientWithHostedGrpcNetServerTests.cs`
+* `Class Fixture` defined in `HostedGrpcNetClientWithHostedGrpcNetServerTests.cs`
+* `Class HostedGrpcNetWithCustomSerializerTests` defined in `HostedGrpcNetWithCustomeSerializerTests.cs`
+* `Class CustomSerializer` defined in `HostedGrpcNetWithCustomeSerializerTests.cs`
+* `Class Fixture` defined in `HostedGrpcNetWithCustomeSerializerTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.Remote.Tests/context.md
+++ b/tests/Proto.Remote.Tests/context.md
@@ -1,0 +1,51 @@
+# Proto Remote Tests Context
+
+## Overview
+Unit and integration tests for the remote transport and endpoint handling.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `AssemblyInfo.cs` – C# source defining Assembly Info behavior.
+* `ConnectionFailTests.cs` – C# source defining Connection Fail Tests behavior.
+* `DisplayTestMethodNameAttribute.cs` – C# source defining Display Test Method Name Attribute behavior.
+* `EchoActor.cs` – C# source defining Echo Actor behavior.
+* `ForcedSerializationTests.cs` – C# source defining Forced Serialization Tests behavior.
+* `LargeMessageEnvelopeTests.cs` – C# source defining Large Message Envelope Tests behavior.
+* `Proto.Remote.Tests.csproj` – Project file configuring compilation targets and dependencies.
+* `RemoteFixture.cs` – C# source defining Remote Fixture behavior.
+* `RemoteKindsRegistrationTests.cs` – C# source defining Remote Kinds Registration Tests behavior.
+* `RemoteStreamProcessorTests.cs` – C# source defining Remote Stream Processor Tests behavior.
+* `RemoteTests.cs` – C# source defining Remote Tests behavior.
+* `SerializationTests.cs` – C# source defining Serialization Tests behavior.
+
+## Primary Types and Contracts
+* `Class DisplayTestMethodNameAttribute` defined in `DisplayTestMethodNameAttribute.cs`
+* `Class EchoActor` defined in `EchoActor.cs`
+* `Class ForcedSerializationTests` defined in `ForcedSerializationTests.cs`
+* `Record TestMessage` defined in `ForcedSerializationTests.cs`
+* `Record TestRootSerializableMessage` defined in `ForcedSerializationTests.cs`
+* `Record TestRootSerializedMessage` defined in `ForcedSerializationTests.cs`
+* `Record TestResponse` defined in `ForcedSerializationTests.cs`
+* `Record RunRequest` defined in `ForcedSerializationTests.cs`
+* `Record RunRequestAsync` defined in `ForcedSerializationTests.cs`
+* `Class LargeMessageEnvelopeTests` defined in `LargeMessageEnvelopeTests.cs`
+* `Interface IRemoteFixture` defined in `RemoteFixture.cs`
+* `Class RemoteFixture` defined in `RemoteFixture.cs`
+* `Class RemoteKindsRegistrationTests` defined in `RemoteKindsRegistrationTests.cs`
+* `Class RemoteStreamProcessorTests` defined in `RemoteStreamProcessorTests.cs`
+* `Class TestEndpoint` defined in `RemoteStreamProcessorTests.cs`
+* `Class TestWriter` defined in `RemoteStreamProcessorTests.cs`
+* `Class TestReader` defined in `RemoteStreamProcessorTests.cs`
+* `Class ThrowingAfterFirstReader` defined in `RemoteStreamProcessorTests.cs`
+* `Class RemoteTests` defined in `RemoteTests.cs`
+* `Class SerializationTests` defined in `SerializationTests.cs`
+* `Class TestType1` defined in `SerializationTests.cs`
+* `Class TestType2` defined in `SerializationTests.cs`
+* `Record JsonMessage` defined in `SerializationTests.cs`
+* `Class MockSerializer1` defined in `SerializationTests.cs`
+* `Class MockSerializer2` defined in `SerializationTests.cs`
+
+## Related Subcontexts
+* [Remote Tests](RemoteTests/context.md) – See the nested context for details.
+

--- a/tests/Proto.TestFixtures/context.md
+++ b/tests/Proto.TestFixtures/context.md
@@ -1,0 +1,31 @@
+# Proto Test Fixtures Context
+
+## Overview
+Proto Test Fixtures directory within the Proto.Actor repository.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `DoNothingActor.cs` – C# source defining Do Nothing Actor behavior.
+* `DoNothingSupervisorStrategy.cs` – C# source defining Do Nothing Supervisor Strategy behavior.
+* `Proto.TestFixtures.csproj` – Project file configuring compilation targets and dependencies.
+* `Receivers.cs` – C# source defining Receivers behavior.
+* `TestConfig.cs` – C# source defining Test Config behavior.
+* `TestDispatcher.cs` – C# source defining Test Dispatcher behavior.
+* `TestMailboxHandler.cs` – C# source defining Test Mailbox Handler behavior.
+* `TestMessageWithTaskCompletionSource.cs` – C# source defining Test Message With Task Completion Source behavior.
+* `TestProcess.cs` – C# source defining Test Process behavior.
+
+## Primary Types and Contracts
+* `Class DoNothingActor` defined in `DoNothingActor.cs`
+* `Class DoNothingSupervisorStrategy` defined in `DoNothingSupervisorStrategy.cs`
+* `Class Receivers` defined in `Receivers.cs`
+* `Class TestConfig` defined in `TestConfig.cs`
+* `Class TestDispatcher` defined in `TestDispatcher.cs`
+* `Class TestMailboxHandler` defined in `TestMailboxHandler.cs`
+* `Class TestMessageWithTaskCompletionSource` defined in `TestMessageWithTaskCompletionSource.cs`
+* `Class TestProcess` defined in `TestProcess.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/Proto.TestKit.Tests/context.md
+++ b/tests/Proto.TestKit.Tests/context.md
@@ -1,0 +1,23 @@
+# Proto Test Kit Tests Context
+
+## Overview
+Validation tests for the Proto.TestKit utilities.
+
+_Parent context: [Tests](../context.md)_
+
+## Key Files
+* `AwaitConditionAsyncTests.cs` – C# source defining Await Condition Async Tests behavior.
+* `ProbeMiddlewareTests.cs` – C# source defining Probe Middleware Tests behavior.
+* `Proto.TestKit.Tests.csproj` – Project file configuring compilation targets and dependencies.
+* `TestProbeAsyncTests.cs` – C# source defining Test Probe Async Tests behavior.
+
+## Primary Types and Contracts
+* `Class AwaitConditionAsyncTests` defined in `AwaitConditionAsyncTests.cs`
+* `Class ProbeMiddlewareTests` defined in `ProbeMiddlewareTests.cs`
+* `Class EmptyActor` defined in `ProbeMiddlewareTests.cs`
+* `Class ForwardActor` defined in `ProbeMiddlewareTests.cs`
+* `Class TestProbeAsyncTests` defined in `TestProbeAsyncTests.cs`
+
+## Related Subcontexts
+* No nested subcontexts.
+

--- a/tests/context.md
+++ b/tests/context.md
@@ -1,0 +1,33 @@
+# Tests Context
+
+## Overview
+Comprehensive automated test suites covering the actor runtime, remote, cluster, persistence, analyzers, and utilities.
+
+These suites mirror the runtime packages living under [`src`](../src/context.md) and often share helpers defined in [`tests/Proto.TestFixtures`](Proto.TestFixtures/context.md), so cross-referencing those contexts accelerates debugging test failures.
+
+_Parent context: [Repository Root](../context.md)_
+
+## Key Files
+* `Directory.Build.props` – MSBuild configuration.
+* `Directory.Build.targets` – MSBuild configuration.
+
+## Primary Types and Contracts
+* No primary C# types discovered in this directory.
+
+## Related Subcontexts
+* [Proto Actor Tests](Proto.Actor.Tests/context.md) – See the nested context for details.
+* [Proto Analyzers Tests](Proto.Analyzers.Tests/context.md) – See the nested context for details.
+* [Proto Cluster Code Gen Tests](Proto.Cluster.CodeGen.Tests/context.md) – See the nested context for details.
+* [Proto Cluster Identity Tests](Proto.Cluster.Identity.Tests/context.md) – See the nested context for details.
+* [Proto Cluster Mongo Identity Tests](Proto.Cluster.MongoIdentity.Tests/context.md) – See the nested context for details.
+* [Proto Cluster Partition Identity Tests](Proto.Cluster.PartitionIdentity.Tests/context.md) – See the nested context for details.
+* [Proto Cluster Pub Sub Tests](Proto.Cluster.PubSub.Tests/context.md) – See the nested context for details.
+* [Proto Cluster Redis Identity Tests](Proto.Cluster.RedisIdentity.Tests/context.md) – See the nested context for details.
+* [Proto Cluster Tests](Proto.Cluster.Tests/context.md) – See the nested context for details.
+* [Proto Open Telemetry Tests](Proto.OpenTelemetry.Tests/context.md) – See the nested context for details.
+* [Proto Persistence Tests](Proto.Persistence.Tests/context.md) – See the nested context for details.
+* [Proto Remote Tests](Proto.Remote.Tests/context.md) – See the nested context for details.
+* [Proto Remote Tests Messages](Proto.Remote.Tests.Messages/context.md) – See the nested context for details.
+* [Proto Test Fixtures](Proto.TestFixtures/context.md) – See the nested context for details.
+* [Proto Test Kit Tests](Proto.TestKit.Tests/context.md) – See the nested context for details.
+


### PR DESCRIPTION
## Summary
- Added `context.md` knowledge cards at the repository root and throughout major areas such as `src`, `tests`, `examples`, and `benchmarks` to speed up AI navigation.
- Populated each directory guide with key files, discovered C# types, and links to related subcontexts so readers can trace responsibilities quickly.
- Updated `AGENTS.md` with guidance about consulting and maintaining the new index and logged the work in `logs/`.

## Testing
- `dotnet --version` *(fails: command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da17dc62b88328aa08b4164de0c511