### PR TITLE
Remove net5 artifacts from remaining projects

### DIFF
--- a/benchmarks/RemoteBenchmark/Node1/Node1.csproj
+++ b/benchmarks/RemoteBenchmark/Node1/Node1.csproj
@@ -15,7 +15,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net5.0'">
-    <DefineConstants>NETCORE</DefineConstants>
+  <PropertyGroup>
+    <!-- Ensure NETCORE is defined for the .NET 8 build -->
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/benchmarks/RemoteBenchmark/Node1/context.md
+++ b/benchmarks/RemoteBenchmark/Node1/context.md
@@ -6,7 +6,7 @@ Primary node for remote benchmark harness.
 _Parent context: [Remote Benchmark](../context.md)_
 
 ## Key Files
-* `Node1.csproj` – Project file configuring compilation targets and dependencies.
+* `Node1.csproj` – Project file configuring compilation targets and dependencies, now defining the `NETCORE` compilation constant for the .NET 8 build explicitly.
 * `Program.cs` – C# source defining Program behavior.
 
 ## Primary Types and Contracts

--- a/benchmarks/RemoteBenchmark/Node2/Node2.csproj
+++ b/benchmarks/RemoteBenchmark/Node2/Node2.csproj
@@ -14,7 +14,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net5.0'">
-    <DefineConstants>NETCORE</DefineConstants>
+  <PropertyGroup>
+    <!-- Ensure NETCORE is defined for the .NET 8 build -->
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/benchmarks/RemoteBenchmark/Node2/context.md
+++ b/benchmarks/RemoteBenchmark/Node2/context.md
@@ -6,7 +6,7 @@ Secondary node for remote benchmark harness.
 _Parent context: [Remote Benchmark](../context.md)_
 
 ## Key Files
-* `Node2.csproj` – Project file configuring compilation targets and dependencies.
+* `Node2.csproj` – Project file configuring compilation targets and dependencies, explicitly adding the `NETCORE` define for the .NET 8 target.
 * `Program.cs` – C# source defining Program behavior.
 
 ## Primary Types and Contracts

--- a/examples/cluster.aspnet-grains/Node1/Node1.csproj
+++ b/examples/cluster.aspnet-grains/Node1/Node1.csproj
@@ -14,9 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Reference Include="StackExchange.Redis">
-        <HintPath>..\..\..\..\..\..\.nuget\packages\stackexchange.redis\2.6.111\lib\net5.0\StackExchange.Redis.dll</HintPath>
-      </Reference>
+      <PackageReference Include="StackExchange.Redis" />
     </ItemGroup>
 
 </Project>

--- a/examples/cluster.aspnet-grains/Node1/context.md
+++ b/examples/cluster.aspnet-grains/Node1/context.md
@@ -6,7 +6,7 @@ Node1 directory within the Proto.Actor repository.
 _Parent context: [Cluster Aspnet Grains](../context.md)_
 
 ## Key Files
-* `Node1.csproj` – Project file configuring compilation targets and dependencies.
+* `Node1.csproj` – Project file configuring compilation targets and dependencies, including a .NET 8 StackExchange.Redis package reference.
 * `Program.cs` – C# source defining Program behavior.
 * `appsettings.Development.json` – Configuration or metadata in JSON format.
 * `appsettings.json` – Configuration or metadata in JSON format.

--- a/examples/cluster.aspnet-grains/Node2/Node2.csproj
+++ b/examples/cluster.aspnet-grains/Node2/Node2.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Reference Include="StackExchange.Redis" />
+      <PackageReference Include="StackExchange.Redis" />
     </ItemGroup>
 
 </Project>

--- a/examples/cluster.aspnet-grains/Node2/context.md
+++ b/examples/cluster.aspnet-grains/Node2/context.md
@@ -7,7 +7,7 @@ _Parent context: [Cluster Aspnet Grains](../context.md)_
 
 ## Key Files
 * `HelloGrain.cs` – C# source defining Hello Grain behavior.
-* `Node2.csproj` – Project file configuring compilation targets and dependencies.
+* `Node2.csproj` – Project file configuring compilation targets and dependencies, pulling StackExchange.Redis through the .NET 8 package feed.
 * `Program.cs` – C# source defining Program behavior.
 * `appsettings.Development.json` – Configuration or metadata in JSON format.
 * `appsettings.json` – Configuration or metadata in JSON format.

--- a/logs/exceptions.md
+++ b/logs/exceptions.md
@@ -58,3 +58,6 @@ Proto.TestKit.TestKitException : Waited 1 seconds but failed to receive a messag
 
 ### Proto.Cluster.Tests.GossipCoreTests.Large_cluster_should_get_topology_consensus
 `Expected x.consensus to be True, but found False.` occurred twice before extending the consensus timeout to 20 seconds.
+
+### Proto.Tests.SharedFutureTests.Should_wrap_request_ids_without_hitting_zero
+`Expected future.Pid.RequestId to be 8u, but found 1u.` observed when verifying request id wrap-around on .NET 8 after the upgrade; focused rerun and a full-suite retry passed.

--- a/tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj
+++ b/tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj
@@ -11,7 +11,8 @@
         <ProjectReference Include="..\Proto.Remote.Tests.Messages\Proto.Remote.Tests.Messages.csproj" />
         <ProjectReference Include="..\..\src\Proto.TestKit\Proto.TestKit.csproj" />
     </ItemGroup>
-    <PropertyGroup Condition="'$(TargetFramework)' != 'net5.0'">
-        <DefineConstants>NETCORE</DefineConstants>
+    <PropertyGroup>
+        <!-- Ensure NETCORE is defined for the .NET 8 build -->
+        <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
     </PropertyGroup>
 </Project>

--- a/tests/Proto.Remote.Tests/context.md
+++ b/tests/Proto.Remote.Tests/context.md
@@ -12,7 +12,7 @@ _Parent context: [Tests](../context.md)_
 * `EchoActor.cs` – C# source defining Echo Actor behavior.
 * `ForcedSerializationTests.cs` – C# source defining Forced Serialization Tests behavior.
 * `LargeMessageEnvelopeTests.cs` – C# source defining Large Message Envelope Tests behavior.
-* `Proto.Remote.Tests.csproj` – Project file configuring compilation targets and dependencies.
+* `Proto.Remote.Tests.csproj` – Project file configuring compilation targets and dependencies, including the explicit .NET 8 `NETCORE` compilation constant.
 * `RemoteFixture.cs` – C# source defining Remote Fixture behavior, including descriptor helpers for composing test transport combinations and unified startup/disposal logic.
 * `RemoteKindsRegistrationTests.cs` – C# source defining Remote Kinds Registration Tests behavior.
 * `RemoteStreamProcessorTests.cs` – C# source defining Remote Stream Processor Tests behavior.


### PR DESCRIPTION
## Summary
- replace the StackExchange.Redis assembly references in the ASP.NET Core grain sample with package references so the example relies on the .NET 8 package feed
- drop the legacy net5 conditionals from the remote benchmark nodes and remote test project while keeping the NETCORE constant for the .NET 8 build; document the changes in the related contexts
- note the transient SharedFuture test failure in logs/exceptions.md together with the successful reruns

## Testing
- `dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj`
- `dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj`
- `dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68db8c00eb908328bb2a09023514b6c8