### PR TITLE
Add documentation for collecting code coverage with dotnet test

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,55 @@ Additional root-level documents provide deeper insights into the project:
 - [SECURITY.md](SECURITY.md) – security policy and supported versions.
 - [Terminology.md](Terminology.md) – definitions of common Proto.Actor terms.
 
+## Test coverage
+
+You can capture code coverage directly when running the test projects. The .NET SDK ships an `XPlat Code Coverage` data collector that works across platforms, so you do not need any third-party tooling for the basic workflow.
+
+### Quick coverage run
+
+Run any test project with coverage enabled by passing the `CollectCoverage` property:
+
+```bash
+dotnet test /p:CollectCoverage=true
+```
+
+This uses the built-in collector and writes coverage data under the `TestResults` directory for the invocation.
+
+### Using coverlet.collector
+
+For richer reporting support you can opt into the `coverlet.collector` package. Add it to the test project you want to analyze:
+
+```bash
+dotnet add package coverlet.collector
+```
+
+Then request coverage when running the tests:
+
+```bash
+dotnet test --collect:"XPlat Code Coverage"
+```
+
+This produces a `.coverage` file under `TestResults/...` that can be converted into other formats.
+
+### Alternative output formats
+
+You can ask the collector to emit other formats such as Cobertura, lcov, or OpenCover. For example, to produce an `lcov` report:
+
+```bash
+dotnet test --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+```
+
+### HTML reports
+
+Feed the generated `lcov` or `cobertura` files into tools like [ReportGenerator](https://github.com/danielpalme/ReportGenerator) to build browsable HTML output. Install the global tool and point it at your coverage reports:
+
+```bash
+dotnet tool install -g dotnet-reportgenerator-globaltool
+reportgenerator -reports:**/coverage.cobertura.xml -targetdir:coveragereport
+```
+
+Open the files in the `coveragereport` directory to inspect the results.
+
 ## Design principles
 
 **Minimalistic API** - The API should be small and easy to use. Avoid enterprisey containers and configurations.

--- a/context.md
+++ b/context.md
@@ -1,7 +1,7 @@
 # Repository Root Context
 
 ## Overview
-Root of the Proto.Actor for .NET repository. Hosts the runtime, clustering, remote communication, persistence providers, tooling, tests, and numerous samples.
+Root of the Proto.Actor for .NET repository. Hosts the runtime, clustering, remote communication, persistence providers, tooling, tests, and numerous samples. The `README.md` document also summarizes how to collect code coverage with the .NET SDK for contributors verifying their changes.
 
 Start here, but also read [`README.md`](README.md) for project onboarding, then dive into [`src/context.md`](src/context.md), [`tests/context.md`](tests/context.md), and [`examples/context.md`](examples/context.md) for subsystem-specific guides.
 


### PR DESCRIPTION
## Summary
- document how to collect coverage with the built-in XPlat Code Coverage collector
- describe richer workflows using coverlet.collector, alternate formats, and HTML reports
- update the root context to reference the new README guidance

## Testing
- dotnet test tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj
- dotnet test tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj
- dotnet test tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68dbe55253ac8328a4a8e27257258573