### PR TITLE
Added optional ClusterIdentity parameter to IMemberStrategy.GetActivator

### DIFF
--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -143,7 +143,7 @@ internal class IdentityStorageWorker : IActor
                     //are there any members that can spawn this kind?
                     //if not, just bail out
 
-                    var activator = _memberList.GetActivator(clusterIdentity.Kind, sender.Address);
+                    var activator = _memberList.GetActivator(clusterIdentity.Kind, sender.Address, clusterIdentity);
 
                     if (activator == null)
                     {

--- a/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
+++ b/src/Proto.Cluster/Identity/IdentityStorageWorker.cs
@@ -143,7 +143,7 @@ internal class IdentityStorageWorker : IActor
                     //are there any members that can spawn this kind?
                     //if not, just bail out
 
-                    var activator = _memberList.GetActivator(clusterIdentity.Kind, sender.Address, clusterIdentity);
+                    var activator = _memberList.GetActivator(clusterIdentity, sender.Address);
 
                     if (activator == null)
                     {

--- a/src/Proto.Cluster/Membership/MemberList.cs
+++ b/src/Proto.Cluster/Membership/MemberList.cs
@@ -137,8 +137,8 @@ public record MemberList : IMemberList
     internal Task<(bool consensus, ulong topologyHash)> TopologyConsensus(CancellationToken ct) =>
         _consensusManager.TopologyConsensus(ct);
 
-    internal Member? GetActivator(string kind, string requestSourceAddress) =>
-        _memberStrategyManager.GetActivator(kind, requestSourceAddress);
+    internal Member? GetActivator(string kind, string requestSourceAddress, ClusterIdentity identity) =>
+        _memberStrategyManager.GetActivator(kind, requestSourceAddress, identity);
 
     /// <summary>
     ///     Used by clustering providers to update the member list.

--- a/src/Proto.Cluster/Membership/MemberList.cs
+++ b/src/Proto.Cluster/Membership/MemberList.cs
@@ -137,8 +137,8 @@ public record MemberList : IMemberList
     internal Task<(bool consensus, ulong topologyHash)> TopologyConsensus(CancellationToken ct) =>
         _consensusManager.TopologyConsensus(ct);
 
-    internal Member? GetActivator(string kind, string requestSourceAddress, ClusterIdentity identity) =>
-        _memberStrategyManager.GetActivator(kind, requestSourceAddress, identity);
+    internal Member? GetActivator(ClusterIdentity identity, string requestSourceAddress) =>
+        _memberStrategyManager.GetActivator(identity, requestSourceAddress);
 
     /// <summary>
     ///     Used by clustering providers to update the member list.

--- a/src/Proto.Cluster/Membership/MemberStrategy.cs
+++ b/src/Proto.Cluster/Membership/MemberStrategy.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 
@@ -37,16 +38,19 @@ public interface IMemberStrategy
     /// <summary>
     ///     Assigns a virtual actor to a member.
     /// </summary>
-    /// <param name="senderAddress">Network address of the process that initiated the activation</param>
     /// <param name="identity">Identity of the virtual actor to activate</param>
+    /// <param name="senderAddress">Network address of the process that initiated the activation</param>
     /// <returns>Member to spawn on</returns>
-    Member? GetActivator(string senderAddress, ClusterIdentity identity) => GetActivator(senderAddress);
+#pragma warning disable CS0618 // Type or member is obsolete
+    Member? GetActivator(ClusterIdentity identity, string senderAddress) => GetActivator(senderAddress);
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     ///     Assigns a virtual actor to a member.
     /// </summary>
     /// <param name="senderAddress">Network address of the process that initiated the activation</param>
     /// <returns>Member to spawn on</returns>
+    [Obsolete("Use GetActivator(ClusterIdentity identity, string senderAddress) instead")]
     Member? GetActivator(string senderAddress);
 }
 

--- a/src/Proto.Cluster/Membership/MemberStrategy.cs
+++ b/src/Proto.Cluster/Membership/MemberStrategy.cs
@@ -38,6 +38,14 @@ public interface IMemberStrategy
     ///     Assigns a virtual actor to a member.
     /// </summary>
     /// <param name="senderAddress">Network address of the process that initiated the activation</param>
+    /// <param name="identity">Identity of the virtual actor to activate</param>
+    /// <returns>Member to spawn on</returns>
+    Member? GetActivator(string senderAddress, ClusterIdentity identity) => GetActivator(senderAddress);
+
+    /// <summary>
+    ///     Assigns a virtual actor to a member.
+    /// </summary>
+    /// <param name="senderAddress">Network address of the process that initiated the activation</param>
     /// <returns>Member to spawn on</returns>
     Member? GetActivator(string senderAddress);
 }

--- a/src/Proto.Cluster/Membership/MemberStrategyManager.cs
+++ b/src/Proto.Cluster/Membership/MemberStrategyManager.cs
@@ -23,11 +23,11 @@ internal class MemberStrategyManager
 
     internal MemberStrategyManager(Cluster cluster) => _cluster = cluster;
 
-    internal Member? GetActivator(string kind, string requestSourceAddress)
+    internal Member? GetActivator(string kind, string requestSourceAddress, ClusterIdentity identity)
     {
         if (_memberStrategyByKind.TryGetValue(kind, out var memberStrategy))
         {
-            return memberStrategy.GetActivator(requestSourceAddress);
+            return memberStrategy.GetActivator(requestSourceAddress, identity);
         }
 
         Logger.DidNotFindActivatorForKind(kind);

--- a/src/Proto.Cluster/Membership/MemberStrategyManager.cs
+++ b/src/Proto.Cluster/Membership/MemberStrategyManager.cs
@@ -23,14 +23,14 @@ internal class MemberStrategyManager
 
     internal MemberStrategyManager(Cluster cluster) => _cluster = cluster;
 
-    internal Member? GetActivator(string kind, string requestSourceAddress, ClusterIdentity identity)
+    internal Member? GetActivator(ClusterIdentity identity, string requestSourceAddress)
     {
-        if (_memberStrategyByKind.TryGetValue(kind, out var memberStrategy))
+        if (_memberStrategyByKind.TryGetValue(identity.Kind, out var memberStrategy))
         {
-            return memberStrategy.GetActivator(requestSourceAddress, identity);
+            return memberStrategy.GetActivator(identity, requestSourceAddress);
         }
 
-        Logger.DidNotFindActivatorForKind(kind);
+        Logger.DidNotFindActivatorForKind(identity.Kind);
 
         return null;
     }

--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -580,7 +580,7 @@ internal class PartitionIdentityActor : IActor
         }
 
         //Get activator
-        var activatorAddress = _cluster.MemberList.GetActivator(msg.Kind, context.Sender!.Address, msg.ClusterIdentity)?.Address;
+        var activatorAddress = _cluster.MemberList.GetActivator(msg.ClusterIdentity, context.Sender!.Address)?.Address;
 
         if (string.IsNullOrEmpty(activatorAddress))
         {
@@ -687,7 +687,7 @@ internal class PartitionIdentityActor : IActor
                             }
 
                             var currentActivatorAddress =
-                                _cluster.MemberList.GetActivator(msg.Kind, context.Sender!.Address, msg.ClusterIdentity)?.Address;
+                                _cluster.MemberList.GetActivator(msg.ClusterIdentity, context.Sender!.Address)?.Address;
 
                             if (_myAddress != currentActivatorAddress)
                             {

--- a/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
+++ b/src/Proto.Cluster/Partition/PartitionIdentityActor.cs
@@ -580,7 +580,7 @@ internal class PartitionIdentityActor : IActor
         }
 
         //Get activator
-        var activatorAddress = _cluster.MemberList.GetActivator(msg.Kind, context.Sender!.Address)?.Address;
+        var activatorAddress = _cluster.MemberList.GetActivator(msg.Kind, context.Sender!.Address, msg.ClusterIdentity)?.Address;
 
         if (string.IsNullOrEmpty(activatorAddress))
         {
@@ -687,7 +687,7 @@ internal class PartitionIdentityActor : IActor
                             }
 
                             var currentActivatorAddress =
-                                _cluster.MemberList.GetActivator(msg.Kind, context.Sender!.Address)?.Address;
+                                _cluster.MemberList.GetActivator(msg.Kind, context.Sender!.Address, msg.ClusterIdentity)?.Address;
 
                             if (_myAddress != currentActivatorAddress)
                             {


### PR DESCRIPTION
## Description

Added the ability for IMemberStrategy to dispatch on ClusterIdentity as well as the caller address.

This allows for more custom strategies that take the identity into account, but is not used in any of the built-in strategies.

## Purpose
This pull request is a:

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

