### PR TITLE
Add ability to use IDiagnosticsTypeName on IActor for better naming control

### DIFF
--- a/src/Proto.Actor/Context/ActorContext.cs
+++ b/src/Proto.Actor/Context/ActorContext.cs
@@ -48,15 +48,15 @@ public sealed class ActorContext : IMessageInvoker, IContext, ISupervisor
         Self = self;
 
         Actor = IncarnateActor();
-        using var publishActivity = ActorSystem.ActivitySource.StartActivity($"Spawn {Actor.GetType().Name}");
-        publishActivity?.AddTag(ProtoTags.ActorType, Actor.GetType().Name);
+        using var publishActivity = ActorSystem.ActivitySource.StartActivity($"Spawn {Actor.GetActorTypeName()}");
+        publishActivity?.AddTag(ProtoTags.ActorType, Actor.GetActorTypeName());
         publishActivity?.AddTag(ProtoTags.ActorPID, self);
         publishActivity?.AddTag(ProtoTags.ActionType, "Spawn");
 
         if (System.Metrics.Enabled)
         {
             _metricTags = new KeyValuePair<string, object?>[]
-                { new("id", System.Id), new("address", System.Address), new("actortype", Actor.GetType().Name) };
+                { new("id", System.Id), new("address", System.Address), new("actortype", Actor.GetActorTypeName()) };
 
             ActorMetrics.ActorSpawnCount.Add(1, _metricTags);
         }
@@ -315,9 +315,9 @@ public sealed class ActorContext : IMessageInvoker, IContext, ISupervisor
         if (System.Config.DeveloperSupervisionLogging)
         {
             Console.WriteLine(
-                $"[Supervision] Actor {Self} : {Actor.GetType().Name} failed with message:{message} exception:{reason}");
+                $"[Supervision] Actor {Self} : {Actor.GetActorTypeName()} failed with message:{message} exception:{reason}");
 
-            Logger.EscalateFailure(reason, Self, Actor.GetType().Name, message);
+            Logger.EscalateFailure(reason, Self, Actor.GetActorTypeName(), message);
         }
 
         ActorMetrics.ActorFailureCount.Add(1, _metricTags);
@@ -438,7 +438,7 @@ public sealed class ActorContext : IMessageInvoker, IContext, ISupervisor
 
     private Task HandleProcessDiagnosticsRequest(ProcessDiagnosticsRequest processDiagnosticsRequest)
     {
-        var diagnosticsString = "ActorType:" + Actor.GetType().Name + "\n";
+        var diagnosticsString = "ActorType:" + Actor.GetActorTypeName() + "\n";
 
         if (Actor is IActorDiagnostics diagnosticsActor)
         {

--- a/src/Proto.Actor/Context/ActorLoggingContext.cs
+++ b/src/Proto.Actor/Context/ActorLoggingContext.cs
@@ -37,7 +37,7 @@ public class ActorLoggingContext : ActorContextDecorator
         _exceptionLogLevel = exceptionLogLevel;
     }
 
-    private string ActorType => Actor?.GetType().Name ?? "None";
+    private string ActorType => Actor?.GetActorTypeName() ?? "None";
 
     public override async Task Receive(MessageEnvelope envelope)
     {

--- a/src/Proto.Actor/Diagnostics/IDiagnosticsTypeName.cs
+++ b/src/Proto.Actor/Diagnostics/IDiagnosticsTypeName.cs
@@ -1,7 +1,7 @@
 namespace Proto.Diagnostics;
 
 /// <summary>
-///     This interface allows specific message types to override what typename is returned for tracing and metrics.
+///     This interface allows specific message or actor types to override what typename is returned for tracing and metrics.
 ///     e.g. MessageEnvelope can return the name of the inner message type instead of its own type name
 /// </summary>
 public interface IDiagnosticsTypeName

--- a/src/Proto.Actor/Extensions/TypeExtensions.cs
+++ b/src/Proto.Actor/Extensions/TypeExtensions.cs
@@ -13,4 +13,15 @@ public static class TypeExtensions
 
         return message?.GetType().Name ?? "null";
     }
+
+    public static string GetActorTypeName(this IActor actor)
+    {
+        // ReSharper disable once SuspiciousTypeConversion.Global
+        if (actor is IDiagnosticsTypeName d)
+        {
+            return d.GetTypeName();
+        }
+
+        return actor.GetType().Name;
+    }
 }

--- a/src/Proto.Actor/NamedActor.cs
+++ b/src/Proto.Actor/NamedActor.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using Proto.Diagnostics;
+
+namespace Proto;
+
+public class NamedActor : IActor, IDiagnosticsTypeName
+{
+    private readonly IActor _actor;
+    private readonly string _name;
+
+    public NamedActor(IActor actor, string name)
+    {
+        _actor = actor;
+        _name = name;
+    }
+
+    public Task ReceiveAsync(IContext context)
+    {
+        return _actor.ReceiveAsync(context);
+    }
+
+    public string GetTypeName()
+    {
+        return _name;
+    }
+}

--- a/src/Proto.OpenTelemetry/OpenTelemetryActorContextDecorator.cs
+++ b/src/Proto.OpenTelemetry/OpenTelemetryActorContextDecorator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Proto.Extensions;
 
 namespace Proto.OpenTelemetry;
 
@@ -50,7 +51,7 @@ internal class OpenTelemetryActorContextDecorator : ActorContextDecorator
         };
     }
 
-    private string Source => base.Actor?.GetType().Name ?? "<None>";
+    private string Source => base.Actor?.GetActorTypeName() ?? "<None>";
 
     public override void Send(PID target, object message) =>
         OpenTelemetryMethodsDecorators.Send(Source, target, message, _sendActivitySetup,
@@ -106,5 +107,5 @@ internal class OpenTelemetryActorContextDecorator : ActorContextDecorator
     }
 
     public override PID SpawnNamed(Props props, string name, Action<IContext>? callback = null) => 
-        OpenTelemetryMethodsDecorators.SpawnNamed(Source,_spawnActivitySetup, () => base.SpawnNamed(props, name, callback),name, Actor.GetType().Name);
+        OpenTelemetryMethodsDecorators.SpawnNamed(Source,_spawnActivitySetup, () => base.SpawnNamed(props, name, callback),name, Actor.GetActorTypeName());
 }


### PR DESCRIPTION
## Description

Currently, actor type names in logs or traces are constructed based on the `IActor` implementation type name. So if someone uses only `FunctionalActor`s or some other single configurable type for all actors, then these logs became effectively not so useful. This PR adds an ability to configure this behavior by using `IDiagnosticsTypeName` interface on `IActor` implementations.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
