### PR TITLE
Add .NET 10 support to all core libraries

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -25,6 +25,7 @@ jobs:
       matrix:
         dotnet:
           - net8.0
+          - net10.0
         test:
           - "tests/Proto.Cluster.Tests/*.csproj"
           - "tests/Proto.Cluster.PartitionIdentity.Tests/*.csproj"
@@ -39,6 +40,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
           cache: true
           cache-dependency-path: |
             Directory.Packages.props
@@ -92,6 +94,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
           cache: true
           cache-dependency-path: |
             Directory.Packages.props
@@ -134,6 +137,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
           cache: true
           cache-dependency-path: |
             Directory.Packages.props

--- a/.github/workflows/dev-tests.yml
+++ b/.github/workflows/dev-tests.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
           cache: true
           cache-dependency-path: |
             Directory.Packages.props
@@ -76,6 +77,7 @@ jobs:
       matrix:
         dotnet:
           - net8.0
+          - net10.0
         test:
           - "tests/Proto.Cluster.Tests/*.csproj"
           - "tests/Proto.Cluster.PartitionIdentity.Tests/*.csproj"
@@ -91,6 +93,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
           cache: true
           cache-dependency-path: |
             Directory.Packages.props
@@ -145,6 +148,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
           cache: true
           cache-dependency-path: |
             Directory.Packages.props

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
           cache: true
           cache-dependency-path: |
             Directory.Packages.props
@@ -72,6 +73,7 @@ jobs:
       matrix:
         dotnet:
           - net8.0
+          - net10.0
         test:
           - "tests/Proto.Cluster.Tests/*.csproj"
           - "tests/Proto.Cluster.PartitionIdentity.Tests/*.csproj"
@@ -86,6 +88,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
           cache: true
           cache-dependency-path: |
             Directory.Packages.props
@@ -139,6 +142,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+            10.0.x
           cache: true
           cache-dependency-path: |
             Directory.Packages.props

--- a/src/Proto.Actor/Proto.Actor.csproj
+++ b/src/Proto.Actor/Proto.Actor.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <IsPackable>true</IsPackable>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Proto.Analyzers/Proto.Analyzers.csproj
+++ b/src/Proto.Analyzers/Proto.Analyzers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Proto.Cluster.AmazonECS/Proto.Cluster.AmazonECS.csproj
+++ b/src/Proto.Cluster.AmazonECS/Proto.Cluster.AmazonECS.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Proto.Cluster.AzureContainerApps/Proto.Cluster.AzureContainerApps.csproj
+++ b/src/Proto.Cluster.AzureContainerApps/Proto.Cluster.AzureContainerApps.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Azure.Identity" />

--- a/src/Proto.Cluster.AzureContainerApps/Stores/ResourceTags/ResourceTagsClusterMemberStore.cs
+++ b/src/Proto.Cluster.AzureContainerApps/Stores/ResourceTags/ResourceTagsClusterMemberStore.cs
@@ -242,11 +242,11 @@ public class ResourceTagsClusterMemberStore : IClusterMemberStore
         var resourceGroupName = _resourceGroupName;
         var subscriptionId = _subscriptionId;
         var resourceGroup = await armClient.GetResourceGroupByNameAsync(resourceGroupName, subscriptionId, cancellationToken).ConfigureAwait(false);
-        return resourceGroup.GetContainerApps().Where(x => x.Data.EnvironmentId == environmentId);
+        return resourceGroup.GetContainerApps().AsEnumerable().Where(x => x.Data.EnvironmentId == environmentId);
     }
 
     private static IEnumerable<ContainerAppRevisionResource> GetActiveRevisionsWithTraffic(ContainerAppResource containerApp) =>
-        containerApp.GetContainerAppRevisions().Where(r => r.HasData && (r.Data.IsActive ?? false) && r.Data.TrafficWeight > 0);
+        containerApp.GetContainerAppRevisions().AsEnumerable().Where(r => r.HasData && (r.Data.IsActive ?? false) && r.Data.TrafficWeight > 0);
 
     private static string Serialize(TaggedMember taggedMember) => JsonSerializer.Serialize(taggedMember);
     private static TaggedMember Deserialize(string json) => JsonSerializer.Deserialize<TaggedMember>(json)!;

--- a/src/Proto.Cluster.CodeGen/Proto.Cluster.CodeGen.csproj
+++ b/src/Proto.Cluster.CodeGen/Proto.Cluster.CodeGen.csproj
@@ -9,7 +9,7 @@
         <VersionSuffix>build$([System.DateTime]::Now.ToString('yyyyMMdd-HHmm'))</VersionSuffix>
         <LangVersion>10</LangVersion>
         <!-- we're targeting .NET Standard 2.0 because Visual Studio uses MSBuild based on .NET Famework, which supports at most .NET Standard 2.0 -->
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/src/Proto.Cluster.Consul/Proto.Cluster.Consul.csproj
+++ b/src/Proto.Cluster.Consul/Proto.Cluster.Consul.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Consul" />

--- a/src/Proto.Cluster.Dashboard/Proto.Cluster.Dashboard.csproj
+++ b/src/Proto.Cluster.Dashboard/Proto.Cluster.Dashboard.csproj
@@ -5,7 +5,7 @@
         <LangVersion>10</LangVersion>
         <OutputType>Library</OutputType>
         <IsPackable>true</IsPackable>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         

--- a/src/Proto.Cluster.Etcd/Proto.Cluster.Etcd.csproj
+++ b/src/Proto.Cluster.Etcd/Proto.Cluster.Etcd.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable> 
     </PropertyGroup>

--- a/src/Proto.Cluster.Identity.MongoDb/Proto.Cluster.Identity.MongoDb.csproj
+++ b/src/Proto.Cluster.Identity.MongoDb/Proto.Cluster.Identity.MongoDb.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/src/Proto.Cluster.Identity.Redis/Proto.Cluster.Identity.Redis.csproj
+++ b/src/Proto.Cluster.Identity.Redis/Proto.Cluster.Identity.Redis.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Proto.Cluster.Kubernetes/Proto.Cluster.Kubernetes.csproj
+++ b/src/Proto.Cluster.Kubernetes/Proto.Cluster.Kubernetes.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Proto.Cluster.SeedNode.MongoDb/Proto.Cluster.SeedNode.MongoDb.csproj
+++ b/src/Proto.Cluster.SeedNode.MongoDb/Proto.Cluster.SeedNode.MongoDb.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Proto.Cluster.SeedNode.Redis/Proto.Cluster.SeedNode.Redis.csproj
+++ b/src/Proto.Cluster.SeedNode.Redis/Proto.Cluster.SeedNode.Redis.csproj
@@ -5,7 +5,7 @@
         <IsPackable>true</IsPackable>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Proto.Cluster.TestProvider/Proto.Cluster.TestProvider.csproj
+++ b/src/Proto.Cluster.TestProvider/Proto.Cluster.TestProvider.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <RootNamespace>Proto.Cluster.Consul</RootNamespace>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Options" />

--- a/src/Proto.Cluster/Proto.Cluster.csproj
+++ b/src/Proto.Cluster/Proto.Cluster.csproj
@@ -4,7 +4,7 @@
         <IsPackable>true</IsPackable>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Grpc.Tools" PrivateAssets="All" />

--- a/src/Proto.OpenTelemetry/Proto.OpenTelemetry.csproj
+++ b/src/Proto.OpenTelemetry/Proto.OpenTelemetry.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
     </PropertyGroup>

--- a/src/Proto.Persistence.Couchbase/Proto.Persistence.Couchbase.csproj
+++ b/src/Proto.Persistence.Couchbase/Proto.Persistence.Couchbase.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <!-- Couchbase 3.x requires extensive changes, suppress vulnerability warning until upgrade path is available -->
         <NoWarn>NU1902</NoWarn>
     </PropertyGroup>

--- a/src/Proto.Persistence.DynamoDB/Proto.Persistence.DynamoDB.csproj
+++ b/src/Proto.Persistence.DynamoDB/Proto.Persistence.DynamoDB.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="AWSSDK.DynamoDBv2" />

--- a/src/Proto.Persistence.Marten/Proto.Persistence.Marten.csproj
+++ b/src/Proto.Persistence.Marten/Proto.Persistence.Marten.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Marten" />

--- a/src/Proto.Persistence.MongoDB/Proto.Persistence.MongoDB.csproj
+++ b/src/Proto.Persistence.MongoDB/Proto.Persistence.MongoDB.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="MongoDB.Driver" />

--- a/src/Proto.Persistence.RavenDB/Proto.Persistence.RavenDB.csproj
+++ b/src/Proto.Persistence.RavenDB/Proto.Persistence.RavenDB.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="RavenDB.Client" />

--- a/src/Proto.Persistence.SqlServer/Proto.Persistence.SqlServer.csproj
+++ b/src/Proto.Persistence.SqlServer/Proto.Persistence.SqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" />

--- a/src/Proto.Persistence.Sqlite/Proto.Persistence.Sqlite.csproj
+++ b/src/Proto.Persistence.Sqlite/Proto.Persistence.Sqlite.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.Sqlite" />

--- a/src/Proto.Persistence/Proto.Persistence.csproj
+++ b/src/Proto.Persistence/Proto.Persistence.csproj
@@ -3,7 +3,7 @@
         <IsPackable>true</IsPackable>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
     </ItemGroup>

--- a/src/Proto.Remote/Proto.Remote.csproj
+++ b/src/Proto.Remote/Proto.Remote.csproj
@@ -4,7 +4,7 @@
         <IsPackable>true</IsPackable>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Proto.TestKit/Proto.TestKit.csproj
+++ b/src/Proto.TestKit/Proto.TestKit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <IsPackable>true</IsPackable>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>

--- a/tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj
+++ b/tests/Proto.Actor.Tests/Proto.Actor.Tests.csproj
@@ -4,7 +4,7 @@
         <RootNamespace>Proto.Tests</RootNamespace>
         <LangVersion>10</LangVersion>
         <OutputType>Library</OutputType>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
@@ -15,7 +15,7 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
       <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net10.0'">
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     </ItemGroup>
 </Project>

--- a/tests/Proto.Analyzers.Tests/Proto.Analyzers.Tests.csproj
+++ b/tests/Proto.Analyzers.Tests/Proto.Analyzers.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/tests/Proto.Cluster.CodeGen.Tests/Proto.Cluster.CodeGen.Tests.csproj
+++ b/tests/Proto.Cluster.CodeGen.Tests/Proto.Cluster.CodeGen.Tests.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <IsPackable>false</IsPackable>
         <OutputType>Library</OutputType>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/Proto.Cluster.Identity.Tests/Proto.Cluster.Identity.Tests.csproj
+++ b/tests/Proto.Cluster.Identity.Tests/Proto.Cluster.Identity.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <DockerComposeProjectPath>..\docker-compose\docker-compose.dcproj</DockerComposeProjectPath>
         <Nullable>enable</Nullable>

--- a/tests/Proto.Cluster.MongoIdentity.Tests/Proto.Cluster.MongoIdentity.Tests.csproj
+++ b/tests/Proto.Cluster.MongoIdentity.Tests/Proto.Cluster.MongoIdentity.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <DockerComposeProjectPath>..\docker-compose\docker-compose.dcproj</DockerComposeProjectPath>
         <Nullable>enable</Nullable>

--- a/tests/Proto.Cluster.PartitionIdentity.Tests/Proto.Cluster.PartitionIdentity.Tests.csproj
+++ b/tests/Proto.Cluster.PartitionIdentity.Tests/Proto.Cluster.PartitionIdentity.Tests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <NoWarn>8981</NoWarn>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <LangVersion>10</LangVersion>

--- a/tests/Proto.Cluster.PubSub.Tests/Proto.Cluster.PubSub.Tests.csproj
+++ b/tests/Proto.Cluster.PubSub.Tests/Proto.Cluster.PubSub.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/tests/Proto.Cluster.RedisIdentity.Tests/Proto.Cluster.RedisIdentity.Tests.csproj
+++ b/tests/Proto.Cluster.RedisIdentity.Tests/Proto.Cluster.RedisIdentity.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <DockerComposeProjectPath>..\docker-compose\docker-compose.dcproj</DockerComposeProjectPath>
         <Nullable>enable</Nullable>

--- a/tests/Proto.Cluster.Tests/ClusterTests.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTests.cs
@@ -175,7 +175,7 @@ public abstract class ClusterTests : ClusterTestBase
 
             sourceMember.Gossip.SetState("some-state", new PID("abc", "def"));
             //allow state to replicate            
-            await stream.FirstAsync(x => x.MemberId == sourceMemberId && x.Key == "some-state");
+            await System.Linq.AsyncEnumerable.FirstAsync(stream, x => x.MemberId == sourceMemberId && x.Key == "some-state");
 
             //get state from target member
             //it should be noted that the response is a dict of member id for all members,
@@ -192,7 +192,7 @@ public abstract class ClusterTests : ClusterTestBase
             {
                 var channel = Channel.CreateUnbounded<object>();
                 member.System.EventStream.Subscribe(channel);
-                var stream = channel.Reader.ReadAllAsync().OfType<GossipUpdate>();
+                var stream = System.Linq.AsyncEnumerable.OfType<GossipUpdate>(channel.Reader.ReadAllAsync());
 
                 return stream;
             }

--- a/tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj
+++ b/tests/Proto.Cluster.Tests/Proto.Cluster.Tests.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <NoWarn>8981</NoWarn>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\Proto.Cluster.Consul\Proto.Cluster.Consul.csproj" />
@@ -19,7 +19,7 @@
         <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
 
-        <PackageReference Include="System.Interactive.Async" />
+        <PackageReference Include="System.Interactive.Async" Condition="'$(TargetFramework)' == 'net8.0'" />
     </ItemGroup>
     <ItemGroup>
         <Protobuf Include="*.proto" />

--- a/tests/Proto.OpenTelemetry.Tests/Proto.OpenTelemetry.Tests.csproj
+++ b/tests/Proto.OpenTelemetry.Tests/Proto.OpenTelemetry.Tests.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
         <IsPackable>false</IsPackable>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/Proto.Persistence.Tests/Proto.Persistence.Tests.csproj
+++ b/tests/Proto.Persistence.Tests/Proto.Persistence.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" />

--- a/tests/Proto.Remote.Tests.Messages/Proto.Remote.Tests.Messages.csproj
+++ b/tests/Proto.Remote.Tests.Messages/Proto.Remote.Tests.Messages.csproj
@@ -3,7 +3,7 @@
         <NoWarn>8981</NoWarn>
         <IsTestProject>false</IsTestProject>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Grpc.Tools" PrivateAssets="All" />

--- a/tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj
+++ b/tests/Proto.Remote.Tests/Proto.Remote.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Neovolve.Logging.Xunit" />

--- a/tests/Proto.TestFixtures/Proto.TestFixtures.csproj
+++ b/tests/Proto.TestFixtures/Proto.TestFixtures.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <IsTestProject>false</IsTestProject>
         <LangVersion>10</LangVersion>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Remove="AutoFixture.Xunit2" />

--- a/tests/Proto.TestKit.Tests/Proto.TestKit.Tests.csproj
+++ b/tests/Proto.TestKit.Tests/Proto.TestKit.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>9</LangVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Added .NET 10 as a target framework to all 26 core library projects
- Fixed ambiguous LINQ method calls in AzureContainerApps provider for .NET 10 compatibility
- Maintains full backward compatibility with .NET 8

## Projects Updated
- **Core**: Proto.Actor, Proto.Remote, Proto.Cluster, Proto.Persistence
- **Cluster Providers**: AmazonECS, AzureContainerApps, Consul, Dashboard, Etcd, Kubernetes, TestProvider
- **Cluster SeedNode**: MongoDb, Redis
- **Cluster Identity**: MongoDb, Redis
- **Persistence Providers**: Couchbase, DynamoDB, Marten, MongoDB, RavenDB, SqlServer, Sqlite
- **Other**: Proto.OpenTelemetry, Proto.TestKit, Proto.Analyzers, Proto.Cluster.CodeGen

## Test plan
- [x] Build succeeds for both net8.0 and net10.0 targets
- [ ] CI tests pass on all configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)