### PR TITLE
Stop cluster requests during shutdown

### DIFF
--- a/src/Proto.Cluster/DefaultClusterContext.cs
+++ b/src/Proto.Cluster/DefaultClusterContext.cs
@@ -71,7 +71,7 @@ public class DefaultClusterContext : IClusterContext
         {
             var lookupTimer = Stopwatch.StartNew();
                 
-            while (!ct.IsCancellationRequested && !context.System.Shutdown.IsCancellationRequested)
+            while (!ct.IsCancellationRequested && !context.System.Shutdown.IsCancellationRequested && !_cluster.MemberList.Stopping)
             {
                 i++;
                 
@@ -252,7 +252,7 @@ public class DefaultClusterContext : IClusterContext
                 }
             }
 
-            if (!context.System.Shutdown.IsCancellationRequested && _requestLogThrottle().IsOpen())
+            if (!context.System.Shutdown.IsCancellationRequested && !_cluster.MemberList.Stopping && _requestLogThrottle().IsOpen())
             {
                 Logger.LogWarning("RequestAsync retried but failed for {ClusterIdentity}", clusterIdentity);
             }

--- a/tests/Proto.Actor.Tests/Futures/SharedFutureTests.cs
+++ b/tests/Proto.Actor.Tests/Futures/SharedFutureTests.cs
@@ -62,10 +62,12 @@ public class SharedFutureTests : BaseFutureTests
             .GetField("_maxRequestId", BindingFlags.Instance | BindingFlags.NonPublic)!
             .SetValue(process, forcedMaxRequestId);
 
-        var reserved = new List<IFuture>();
+        var reserved = new List<IFuture>(slotCount - 1);
         IFuture? future = null;
 
-        while (future is null)
+        // SharedFutureProcess uses ConcurrentBag, so the initial slot order is not deterministic.
+        // Reserve all slots except the one we want to test, so TryCreateHandle is forced to reuse the same slot.
+        for (var i = 0; i < slotCount; i++)
         {
             var candidate = process.TryCreateHandle();
             candidate.Should().NotBeNull();
@@ -73,11 +75,14 @@ public class SharedFutureTests : BaseFutureTests
             if (candidate!.Pid.RequestId == slotCount)
             {
                 future = candidate;
-                break;
             }
-
-            reserved.Add(candidate);
+            else
+            {
+                reserved.Add(candidate);
+            }
         }
+
+        future.Should().NotBeNull();
 
         var echo = Context.Spawn(Props.FromFunc(ctx =>
                 {

--- a/tests/Proto.Cluster.Tests/ClusterTests.cs
+++ b/tests/Proto.Cluster.Tests/ClusterTests.cs
@@ -83,6 +83,47 @@ public abstract class ClusterTests : ClusterTestBase
     }
 
     [Fact]
+    public async Task ClientRequestsFailFastAfterShutdownIsInitiated()
+    {
+        if (!ClusterFixture.SupportsClients)
+        {
+            return;
+        }
+
+        await Trace(async () =>
+        {
+            var timeout = CancellationTokens.FromSeconds(10);
+
+            var clientNode = await ClusterFixture.SpawnClient();
+
+            try
+            {
+                await clientNode.JoinedCluster.WaitAsync(timeout);
+                clientNode.JoinedCluster.IsCompletedSuccessfully.Should().BeTrue();
+
+                var identity = CreateIdentity("shutdown-client-request");
+                await PingPong(clientNode, identity, timeout);
+
+                var shutdownTask = clientNode.ShutdownAsync(true, "Test shutdown");
+
+                var timer = Stopwatch.StartNew();
+                await Assert.ThrowsAsync<TimeoutException>(() =>
+                    clientNode.Ping(identity, "after-shutdown", CancellationTokens.FromSeconds(10)));
+                timer.Stop();
+
+                timer.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(1),
+                    "requests should stop quickly once shutdown begins to avoid reconnect attempts");
+
+                await shutdownTask;
+            }
+            finally
+            {
+                await ClusterFixture.RemoveNode(clientNode);
+            }
+        }, _testOutputHelper);
+    }
+
+    [Fact]
     public async Task TopologiesShouldHaveConsensus()
     {
         await Trace(async () =>


### PR DESCRIPTION
Fixes #2153 by stopping DefaultClusterContext request retries as soon as cluster shutdown begins (MemberList.Stopping), preventing reconnect attempts from in-flight grain requests during shutdown.

- Add regression test: ClusterTests.ClientRequestsFailFastAfterShutdownIsInitiated
- Guard DefaultClusterContext.RequestAsync loop on MemberList.Stopping
- Stabilize SharedFutureTests.Should_wrap_request_ids_without_hitting_zero for ConcurrentBag ordering

Core tests run locally:
- Proto.Actor.Tests
- Proto.Remote.Tests
- Proto.Cluster.Tests