### PR TITLE
Add advertised host & port to AmazonEcsProvider

### DIFF
--- a/src/Proto.Cluster.AmazonECS/AmazonEcsProvider.cs
+++ b/src/Proto.Cluster.AmazonECS/AmazonEcsProvider.cs
@@ -18,18 +18,21 @@ namespace Proto.Cluster.AmazonECS;
 public class AmazonEcsProvider : BaseClusterProvider
 {
     private static readonly ILogger _logger = Log.CreateLogger<AmazonEcsProvider>();
-    private readonly AmazonECSClient _client;
+    private readonly IAmazonECS _client;
     private readonly AmazonEcsProviderConfig _config;
     private readonly string _ecsClusterName;
     private readonly string _taskArn;
+    private readonly int? _advertisedPort;
+    private readonly string _advertisedHost;
 
-    public AmazonEcsProvider(AmazonECSClient client, string ecsClusterName, string taskArn,
-        AmazonEcsProviderConfig config)
+    public AmazonEcsProvider(IAmazonECS client, string ecsClusterName, string taskArn, AmazonEcsProviderConfig config, int? advertisedPort, string advertisedHost)
     {
         _ecsClusterName = ecsClusterName;
         _client = client;
         _config = config;
         _taskArn = taskArn;
+        _advertisedPort = advertisedPort;
+        _advertisedHost = advertisedHost;
     }
 
     protected override ILogger Logger => _logger;
@@ -44,9 +47,14 @@ public class AmazonEcsProvider : BaseClusterProvider
         var tags = new Dictionary<string, string>
         {
             [ProtoLabels.LabelCluster] = _clusterName,
-            [ProtoLabels.LabelPort] = _port.ToString(),
-            [ProtoLabels.LabelMemberId] = _cluster.System.Id
+            [ProtoLabels.LabelPort] = (_advertisedPort ?? _port).ToString(),
+            [ProtoLabels.LabelMemberId] = _cluster.System.Id,
         };
+
+        if (!string.IsNullOrEmpty(_advertisedHost))
+        {
+            tags[ProtoLabels.LabelHost] = _advertisedHost;
+        }
 
         foreach (var kind in _kinds)
         {
@@ -112,6 +120,6 @@ public class AmazonEcsProvider : BaseClusterProvider
         Logger.LogInformation("[Cluster][AmazonEcsProvider] Unregistering service {PodName} on {PodIp}", _taskArn,
             _address);
 
-        await _client.UpdateMetadata(_taskArn, new Dictionary<string, string>()).ConfigureAwait(false);
+        await _client.ClearMetadata(_taskArn).ConfigureAwait(false);
     }
 }

--- a/src/Proto.Cluster.AmazonECS/AwsHttpClient.cs
+++ b/src/Proto.Cluster.AmazonECS/AwsHttpClient.cs
@@ -6,17 +6,18 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 
 namespace Proto.Cluster.AmazonECS;
 
 [PublicAPI]
 public class AwsEcsContainerMetadataHttpClient
 {
+    private static readonly HttpClient HttpClient = new();
     private readonly ILogger _logger = Log.CreateLogger<AwsEcsContainerMetadataHttpClient>();
 
     public ContainerMetadata GetContainerMetadata()
@@ -27,12 +28,12 @@ public class AwsEcsContainerMetadataHttpClient
         {
             if (Uri.TryCreate(str, UriKind.Absolute, out var containerMetadataUri))
             {
-                var json = GetResponseString(containerMetadataUri);
+                var json = GetResponseString(HttpMethod.Get, containerMetadataUri);
 
                 _logger.LogInformation("[AwsEcsContainerMetadataHttpClient] got metadata for container {Metadata}",
                     json);
 
-                return JsonConvert.DeserializeObject<ContainerMetadata>(json);
+                return JsonSerializer.Deserialize<ContainerMetadata>(json);
             }
 
             _logger.LogError("[AwsEcsContainerMetadataHttpClient] failed to get Metadata {Url}", str);
@@ -53,10 +54,10 @@ public class AwsEcsContainerMetadataHttpClient
         {
             if (Uri.TryCreate(str, UriKind.Absolute, out var containerMetadataUri))
             {
-                var json = GetResponseString(containerMetadataUri);
+                var json = GetResponseString(HttpMethod.Get, containerMetadataUri);
                 _logger.LogInformation("[AwsEcsContainerMetadataHttpClient] got metadata for task {Metadata}", json);
 
-                return JsonConvert.DeserializeObject<TaskMetadata>(json);
+                return JsonSerializer.Deserialize<TaskMetadata>(json);
             }
 
             _logger.LogError("[AwsEcsContainerMetadataHttpClient] failed to get Metadata {Url}", str);
@@ -69,36 +70,63 @@ public class AwsEcsContainerMetadataHttpClient
         return null;
     }
 
-    //
-    // public string GetHostPrivateIPv4Address() => GetResponseString(new Uri("http://169.254.169.254/latest/meta-data/local-ipv4"));
-    //
-    // public string GetHostPublicIPv4Address() => GetResponseString(new Uri("http://169.254.169.254/latest/meta-data/public-ipv4"));
-
-    private string GetResponseString(Uri requestUri)
+    public string GetHostPrivateIPv4Address()
     {
         try
         {
-            var request = WebRequest.Create(requestUri);
+            var token = GetResponseString(HttpMethod.Put, new Uri("http://169.254.169.254/latest/api/token"), new Dictionary<string, string> { { "X-aws-ec2-metadata-token-ttl-seconds", "60" } });
+            return GetResponseString(HttpMethod.Get, new Uri("http://169.254.169.254/latest/meta-data/local-ipv4"), new Dictionary<string, string> { { "X-aws-ec2-metadata-token", token } });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[AwsEcsContainerMetadataHttpClient] failed to get Host Private IPv4 Address");
+        }
 
-            using var response = (HttpWebResponse)request.GetResponse();
+        return null;
+    }
 
-            if (response.StatusCode != HttpStatusCode.OK)
+    public string GetHostPublicIPv4Address()
+    {
+        try
+        {
+            var token = GetResponseString(HttpMethod.Put, new Uri("http://169.254.169.254/latest/api/token"), new Dictionary<string, string> { { "X-aws-ec2-metadata-token-ttl-seconds", "60" } });
+            return GetResponseString(HttpMethod.Get, new Uri("http://169.254.169.254/latest/meta-data/public-ipv4"), new Dictionary<string, string> { { "X-aws-ec2-metadata-token", token } });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[AwsEcsContainerMetadataHttpClient] failed to get Host Public IPv4 Address");
+        }
+
+        return null;
+    }
+
+    private string GetResponseString(HttpMethod method, Uri requestUri, Dictionary<String, String> headers = null)
+    {
+        try
+        {
+            var request = new HttpRequestMessage(method, requestUri);
+            if (headers != null)
             {
-                _logger.LogError("Failed to execute HTTP request. Request URI: {RequestUri}, Status code: {StatusCode}",
-                    requestUri, response.StatusCode);
+                foreach (var header in headers)
+                {
+                    request.Headers.Add(header.Key, header.Value);
+                }
+            }
+            using var response = HttpClient.SendAsync(request).GetAwaiter().GetResult();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("Failed to execute HTTP request. Method: {Method}, Request URI: {RequestUri}, Status code: {StatusCode}",
+                    method, requestUri, response.StatusCode);
 
                 return default;
             }
 
-            using var stream = response.GetResponseStream();
-            using var reader = new StreamReader(stream!);
-
-            return reader.ReadToEnd();
+            return response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
         }
-        catch (WebException ex) when (ex.Status == WebExceptionStatus.UnknownError)
+        catch (HttpRequestException ex)
         {
-            _logger.LogError(ex, "Network is unreachable");
-            // Network is unreachable
+            _logger.LogError(ex, "Failed to get AWS metadata response");
         }
         catch (Exception ex)
         {
@@ -111,127 +139,140 @@ public class AwsEcsContainerMetadataHttpClient
 
 public class Limits
 {
-    [JsonProperty("CPU")] public int CPU { get; set; }
+    [JsonPropertyName("CPU")] public int CPU { get; set; }
 }
 
 public class Network
 {
-    [JsonProperty("NetworkMode")] public string NetworkMode { get; set; }
+    [JsonPropertyName("NetworkMode")] public string NetworkMode { get; set; }
 
-    [JsonProperty("IPv4Addresses")] public List<string> IPv4Addresses { get; set; }
+    [JsonPropertyName("IPv4Addresses")] public List<string> IPv4Addresses { get; set; }
 
-    [JsonProperty("AttachmentIndex")] public int AttachmentIndex { get; set; }
+    [JsonPropertyName("AttachmentIndex")] public int AttachmentIndex { get; set; }
 
-    [JsonProperty("MACAddress")] public string MACAddress { get; set; }
+    [JsonPropertyName("MACAddress")] public string MACAddress { get; set; }
 
-    [JsonProperty("IPv4SubnetCIDRBlock")] public string IPv4SubnetCIDRBlock { get; set; }
+    [JsonPropertyName("IPv4SubnetCIDRBlock")] public string IPv4SubnetCIDRBlock { get; set; }
 
-    [JsonProperty("DomainNameServers")] public List<string> DomainNameServers { get; set; }
+    [JsonPropertyName("DomainNameServers")] public List<string> DomainNameServers { get; set; }
 
-    [JsonProperty("DomainNameSearchList")] public List<string> DomainNameSearchList { get; set; }
+    [JsonPropertyName("DomainNameSearchList")] public List<string> DomainNameSearchList { get; set; }
 
-    [JsonProperty("PrivateDNSName")] public string PrivateDNSName { get; set; }
+    [JsonPropertyName("PrivateDNSName")] public string PrivateDNSName { get; set; }
 
-    [JsonProperty("SubnetGatewayIpv4Address")]
+    [JsonPropertyName("SubnetGatewayIpv4Address")]
     public string SubnetGatewayIpv4Address { get; set; }
 }
 
 public class LogOptions
 {
-    [JsonProperty("awslogs-group")] public string AwslogsGroup { get; set; }
+    [JsonPropertyName("awslogs-group")] public string AwslogsGroup { get; set; }
 
-    [JsonProperty("awslogs-region")] public string AwslogsRegion { get; set; }
+    [JsonPropertyName("awslogs-region")] public string AwslogsRegion { get; set; }
 
-    [JsonProperty("awslogs-stream")] public string AwslogsStream { get; set; }
+    [JsonPropertyName("awslogs-stream")] public string AwslogsStream { get; set; }
 }
 
 public class ContainerMetadata
 {
-    [JsonProperty("DockerId")] public string DockerId { get; set; }
+    [JsonPropertyName("DockerId")] public string DockerId { get; set; }
 
-    [JsonProperty("Name")] public string Name { get; set; }
+    [JsonPropertyName("Name")] public string Name { get; set; }
 
-    [JsonProperty("DockerName")] public string DockerName { get; set; }
+    [JsonPropertyName("DockerName")] public string DockerName { get; set; }
 
-    [JsonProperty("Image")] public string Image { get; set; }
+    [JsonPropertyName("Image")] public string Image { get; set; }
 
-    [JsonProperty("ImageID")] public string ImageID { get; set; }
+    [JsonPropertyName("ImageID")] public string ImageID { get; set; }
 
-    [JsonProperty("DesiredStatus")] public string DesiredStatus { get; set; }
+    [JsonPropertyName("DesiredStatus")] public string DesiredStatus { get; set; }
 
-    [JsonProperty("KnownStatus")] public string KnownStatus { get; set; }
+    [JsonPropertyName("KnownStatus")] public string KnownStatus { get; set; }
 
-    [JsonProperty("Limits")] public Limits Limits { get; set; }
+    [JsonPropertyName("Limits")] public Limits Limits { get; set; }
 
-    [JsonProperty("CreatedAt")] public string CreatedAt { get; set; }
+    [JsonPropertyName("CreatedAt")] public string CreatedAt { get; set; }
 
-    [JsonProperty("StartedAt")] public string StartedAt { get; set; }
+    [JsonPropertyName("StartedAt")] public string StartedAt { get; set; }
 
-    [JsonProperty("Type")] public string Type { get; set; }
+    [JsonPropertyName("Type")] public string Type { get; set; }
 
-    [JsonProperty("Networks")] public List<Network> Networks { get; set; }
+    [JsonPropertyName("Networks")] public List<Network> Networks { get; set; }
 
-    [JsonProperty("ContainerARN")] public string ContainerARN { get; set; }
+    [JsonPropertyName("ContainerARN")] public string ContainerARN { get; set; }
 
-    [JsonProperty("LogOptions")] public LogOptions LogOptions { get; set; }
+    [JsonPropertyName("LogOptions")] public LogOptions LogOptions { get; set; }
 
-    [JsonProperty("LogDriver")] public string LogDriver { get; set; }
+    [JsonPropertyName("LogDriver")] public string LogDriver { get; set; }
+}
+
+public class PortMapping
+{
+    [JsonPropertyName("ContainerPort")] public int ContainerPort { get; set; }
+
+    [JsonPropertyName("Protocol")] public string Protocol { get; set; }
+
+    [JsonPropertyName("HostPort")] public int HostPort { get; set; }
+
+    [JsonPropertyName("HostIp")] public string HostIP { get; set; }
 }
 
 public class Container
 {
-    [JsonProperty("DockerId")] public string DockerId { get; set; }
+    [JsonPropertyName("DockerId")] public string DockerId { get; set; }
 
-    [JsonProperty("Name")] public string Name { get; set; }
+    [JsonPropertyName("Name")] public string Name { get; set; }
 
-    [JsonProperty("DockerName")] public string DockerName { get; set; }
+    [JsonPropertyName("DockerName")] public string DockerName { get; set; }
 
-    [JsonProperty("Image")] public string Image { get; set; }
+    [JsonPropertyName("Image")] public string Image { get; set; }
 
-    [JsonProperty("ImageID")] public string ImageID { get; set; }
+    [JsonPropertyName("ImageID")] public string ImageID { get; set; }
 
-    [JsonProperty("DesiredStatus")] public string DesiredStatus { get; set; }
+    [JsonPropertyName("Ports")] public List<PortMapping> Ports { get; set; }
 
-    [JsonProperty("KnownStatus")] public string KnownStatus { get; set; }
+    [JsonPropertyName("DesiredStatus")] public string DesiredStatus { get; set; }
 
-    [JsonProperty("Limits")] public Limits Limits { get; set; }
+    [JsonPropertyName("KnownStatus")] public string KnownStatus { get; set; }
 
-    [JsonProperty("CreatedAt")] public string CreatedAt { get; set; }
+    [JsonPropertyName("Limits")] public Limits Limits { get; set; }
 
-    [JsonProperty("StartedAt")] public string StartedAt { get; set; }
+    [JsonPropertyName("CreatedAt")] public string CreatedAt { get; set; }
 
-    [JsonProperty("Type")] public string Type { get; set; }
+    [JsonPropertyName("StartedAt")] public string StartedAt { get; set; }
 
-    [JsonProperty("Networks")] public List<Network> Networks { get; set; }
+    [JsonPropertyName("Type")] public string Type { get; set; }
 
-    [JsonProperty("LogDriver")] public string LogDriver { get; set; }
+    [JsonPropertyName("Networks")] public List<Network> Networks { get; set; }
 
-    [JsonProperty("LogOptions")] public LogOptions LogOptions { get; set; }
+    [JsonPropertyName("LogDriver")] public string LogDriver { get; set; }
 
-    [JsonProperty("ContainerARN")] public string ContainerARN { get; set; }
+    [JsonPropertyName("LogOptions")] public LogOptions LogOptions { get; set; }
+
+    [JsonPropertyName("ContainerARN")] public string ContainerARN { get; set; }
 }
 
 public class TaskMetadata
 {
-    [JsonProperty("Cluster")] public string Cluster { get; set; }
+    [JsonPropertyName("Cluster")] public string Cluster { get; set; }
 
-    [JsonProperty("TaskARN")] public string TaskARN { get; set; }
+    [JsonPropertyName("TaskARN")] public string TaskARN { get; set; }
 
-    [JsonProperty("Family")] public string Family { get; set; }
+    [JsonPropertyName("Family")] public string Family { get; set; }
 
-    [JsonProperty("Revision")] public string Revision { get; set; }
+    [JsonPropertyName("Revision")] public string Revision { get; set; }
 
-    [JsonProperty("DesiredStatus")] public string DesiredStatus { get; set; }
+    [JsonPropertyName("DesiredStatus")] public string DesiredStatus { get; set; }
 
-    [JsonProperty("KnownStatus")] public string KnownStatus { get; set; }
+    [JsonPropertyName("KnownStatus")] public string KnownStatus { get; set; }
 
-    [JsonProperty("PullStartedAt")] public string PullStartedAt { get; set; }
+    [JsonPropertyName("PullStartedAt")] public string PullStartedAt { get; set; }
 
-    [JsonProperty("PullStoppedAt")] public string PullStoppedAt { get; set; }
+    [JsonPropertyName("PullStoppedAt")] public string PullStoppedAt { get; set; }
 
-    [JsonProperty("AvailabilityZone")] public string AvailabilityZone { get; set; }
+    [JsonPropertyName("AvailabilityZone")] public string AvailabilityZone { get; set; }
 
-    [JsonProperty("LaunchType")] public string LaunchType { get; set; }
+    [JsonPropertyName("LaunchType")] public string LaunchType { get; set; }
 
-    [JsonProperty("Containers")] public List<Container> Containers { get; set; }
+    [JsonPropertyName("Containers")] public List<Container> Containers { get; set; }
 }

--- a/src/Proto.Cluster.AmazonECS/EcsUtils.cs
+++ b/src/Proto.Cluster.AmazonECS/EcsUtils.cs
@@ -19,38 +19,44 @@ public static class EcsUtils
 {
     private static readonly ILogger Logger = Log.CreateLogger(nameof(EcsUtils));
 
-    public static async Task<Member[]> GetMembers(this AmazonECSClient c, string ecsClusterName)
+    public static async Task<Member[]> GetMembers(this IAmazonECS c, string ecsClusterName)
     {
         var allTasks = await c.ListTasksAsync(new ListTasksRequest
-            {
-                Cluster = ecsClusterName
-            }
+        {
+            Cluster = ecsClusterName
+        }
         ).ConfigureAwait(false);
 
-        var instanceArns = allTasks.TaskArns;
+        var instanceArns = allTasks.TaskArns ?? new List<string>();
 
-        if (!instanceArns.Any())
+        if (instanceArns.Count == 0)
         {
             return Array.Empty<Member>();
         }
 
         var describedTasks = await c.DescribeTasksAsync(new DescribeTasksRequest
-            {
-                Include = { "TAGS" },
-                Cluster = ecsClusterName,
-                Tasks = instanceArns
-            }
+        {
+            Include = new List<string> { "TAGS" },
+            Cluster = ecsClusterName,
+            Tasks = instanceArns
+        }
         ).ConfigureAwait(false);
 
         var members = new List<Member>();
 
-        foreach (var task in describedTasks.Tasks)
+        foreach (var task in describedTasks.Tasks ?? new List<Task>())
         {
+            if (task.DesiredStatus != DesiredStatus.RUNNING)
+            {
+                Logger.LogDebug("Skipping Task {Arn}, not in desired state", task.TaskArn);
+                continue;
+            }
+
             var metadata = task.GetMetadata();
 
             if (!metadata.ContainsKey(ProtoLabels.LabelMemberId))
             {
-                Logger.LogWarning("Skipping Task {Arn}, no Proto Tags found", task.TaskArn);
+                Logger.LogDebug("Skipping Task {Arn}, no Proto Tags found", task.TaskArn);
 
                 continue;
             }
@@ -59,12 +65,23 @@ public static class EcsUtils
                 .Where(kvp => kvp.Key.StartsWith(ProtoLabels.LabelKind))
                 .Select(kvp => kvp.Key[(ProtoLabels.LabelKind.Length + 1)..])
                 .ToArray();
+            var port = int.Parse(metadata[ProtoLabels.LabelPort]);
+            metadata.TryGetValue(ProtoLabels.LabelHost, out string host);
+
+            var container = task.Containers.First();
+            var @interface = container.NetworkInterfaces?.FirstOrDefault();
+
+            if (@interface == null && string.IsNullOrEmpty(host))
+            {
+                Logger.LogWarning("Skipping Task {Arn}, no network information found", task.TaskArn);
+                continue;
+            }
 
             var member = new Member
             {
                 Id = metadata[ProtoLabels.LabelMemberId],
-                Port = int.Parse(metadata[ProtoLabels.LabelPort]),
-                Host = task.Containers.First().NetworkInterfaces.First().PrivateIpv4Address,
+                Port = port,
+                Host = host ?? @interface?.PrivateIpv4Address,
                 Kinds = { kinds }
             };
 
@@ -75,16 +92,16 @@ public static class EcsUtils
     }
 
     public static IDictionary<string, string> GetMetadata(this Task task) =>
-        task.Tags.ToDictionary(t => t.Key, t => t.Value);
+        (task.Tags ?? new List<Tag>()).ToDictionary(t => t.Key, t => t.Value);
 
-    public static async System.Threading.Tasks.Task UpdateMetadata(this AmazonECSClient c, string resourceArn,
+    public static async System.Threading.Tasks.Task UpdateMetadata(this IAmazonECS c, string resourceArn,
         IDictionary<string, string> metadata)
     {
         var tags = metadata.Select(kvp => new Tag
-                {
-                    Key = kvp.Key,
-                    Value = kvp.Value
-                }
+        {
+            Key = kvp.Key,
+            Value = kvp.Value
+        }
             )
             .ToList();
 
@@ -92,6 +109,15 @@ public static class EcsUtils
         {
             ResourceArn = resourceArn,
             Tags = tags
+        }).ConfigureAwait(false);
+    }
+
+    public static async System.Threading.Tasks.Task ClearMetadata(this IAmazonECS c, string resourceArn)
+    {
+        await c.UntagResourceAsync(new UntagResourceRequest
+        {
+            ResourceArn = resourceArn,
+            TagKeys = new List<string>(ProtoLabels.AllLabels)
         }).ConfigureAwait(false);
     }
 }

--- a/src/Proto.Cluster.AmazonECS/Proto.Cluster.AmazonECS.csproj
+++ b/src/Proto.Cluster.AmazonECS/Proto.Cluster.AmazonECS.csproj
@@ -7,7 +7,6 @@
 
     <ItemGroup>
         <PackageReference Include="AWSSDK.ECS" />
-        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Proto.Cluster.AmazonECS/ProtoLabels.cs
+++ b/src/Proto.Cluster.AmazonECS/ProtoLabels.cs
@@ -10,8 +10,18 @@ public static class ProtoLabels
 {
     private const string LabelPrefix = "cluster.proto.actor/";
     public const string LabelPort = LabelPrefix + "port";
+    public const string LabelHost = LabelPrefix + "host";
     public const string LabelKind = LabelPrefix + "kind";
     public const string LabelCluster = LabelPrefix + "cluster";
     public const string LabelStatusValue = LabelPrefix + "status-value";
     public const string LabelMemberId = LabelPrefix + "member-id";
+
+    public static readonly string[] AllLabels =
+        new[] {
+            LabelPort,
+            LabelHost,
+            LabelCluster,
+            LabelMemberId,
+            LabelStatusValue
+        };
 }


### PR DESCRIPTION
## Description

The Amazon ECS provider effectively only supports awsvpc network mode - it picks up IP from the task interface, and port from the cluster configuration via the task tag.

ECS (non-Fargate) can also be configured in host & bridge network modes, in which case the advertised host should be (usually) the container instance’s private IP, and in the case of bridge mode, the container-host port mapping needs to be interrogated to find the advertised (auto-assigned) host port.

The current version of the code assumes the ECS tasks are configured in awsvpc mode and will throw an exception when it encounters no interfaces.

Changes made:

* Added optional `advertisedPort` and `advertisedHost` params to the AmazonEcsProvider constructor
* Changed client parameter/member to interface type (IAmazonECS)
* Record advertised port instead of cluster port in the task tag (if configured)
* Record advertised host in a new task tag (if configured)
* Modified ECSUtils getMembers to respect advertised host if tagged, and log a warning if no interfaces or host is available
* Added soul-destroying null checks for [AWSSDK v4 ](https://docs.aws.amazon.com/sdk-for-net/v4/developer-guide/net-dg-v4.html) compatibility
* Added (restored?) GetHostPrivateIPv4Address and GetHostPublicIPv4Address to assist 
* Migrated AwsHttpClient to System.Text.Json & System.Net.Http.HttpClient


## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
   No, but I’ve been running this config in an ECS cluster in bridge mode
- [ ] I have added necessary documentation (if appropriate)
   No, Probably really needs examples added to https://proto.actor/docs/ProtoActor/cluster/aws-provider-net, I am happy to do this if the change is merged.